### PR TITLE
Add indexes to the measurements table

### DIFF
--- a/database/mysql/updates/update-2024-10-23.sql
+++ b/database/mysql/updates/update-2024-10-23.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_measurements_demographic_date ON measurements (demographicNo, dateObserved);
+CREATE INDEX idx_measurements_type_demographic ON measurements (type, demographicNo);


### PR DESCRIPTION
There is an existing REST API endpoint to obtain patient demographic data, including measurements.  Without these indices, for patients/clinics with a lot of measurements, it is extremely slow (E.g. it involves this query, which hadn't finished after 60 minutes:
```
SELECT x.* FROM measurements x LEFT JOIN measurements y ON x.dateObserved < y.dateObserved AND x.type = y.type AND x.demographicNo = y.demographicNo WHERE y.id IS NULL AND x.demographicNo = 64706 AND x.dateObserved > '2021-10-22 13:25:17' GROUP BY x.type, x.dateObserved ORDER BY x.dateObserved DESC
```
These additional indices make the query essentially instantaneous.
This REST API endpoint is used by OCEAN, which is why this crossed our radar.   The slowness of the query was causing OCEAN to timeout when contacting the API endpoint.