### PR TITLE
Convert "null" values to "0" in relationships table's deleted column

### DIFF
--- a/database/mysql/updates/update-2024-11-22.sql
+++ b/database/mysql/updates/update-2024-11-22.sql
@@ -1,0 +1,1 @@
+update relationships set deleted = 0 where deleted is null;


### PR DESCRIPTION
This migration is needed because of commit fa9fef7. Without it, attempting to open a demographic containing relationships can result in a 500 error.