### PR TITLE
Revert the change to the REST API access token lifetime.

### DIFF
--- a/src/main/java/oscar/login/OscarOAuthDataProvider.java
+++ b/src/main/java/oscar/login/OscarOAuthDataProvider.java
@@ -173,7 +173,7 @@ public AccessToken createAccessToken(AccessTokenRegistration reg) throws OAuthSe
     sat.setClientId(sc.getId());
     sat.setDateCreated(new Date());
     sat.setIssued(issuedAt);
-    sat.setLifetime(3600); // Assuming lifetime is 3600 seconds or should be set as per your application logic
+    sat.setLifetime(sc.getLifetime());
     sat.setTokenId(accessTokenString);
     sat.setTokenSecret(tokenSecretString);
     sat.setProviderNo(srt.getProviderNo());


### PR DESCRIPTION
This reverts a change that was causing newly created tokens to expire after an hour. We ran into this when we were trying to set up our Ocean integration and it would "randomly" stop working. 