### PR TITLE
Fix Ontario Prevention Report not loading

### DIFF
--- a/src/main/webapp/oscarPrevention/PreventionReporting.jsp
+++ b/src/main/webapp/oscarPrevention/PreventionReporting.jsp
@@ -561,9 +561,9 @@ table.ele thead {
 
                           <%if (type == null ){ %>
                           <td><%=demo.getAgeAsOf(asDate)%></td>
-                          <td><%=Encode.forHtml(h.get("sex"))%></td>
-                          <td><%=Encode.forHtml(h.get("lastName"))%></td>
-                          <td><%=Encode.forHtml(h.get("firstName"))%></td>
+                          <td><%=Encode.forHtml(h.get("sex").toString())%></td>
+                          <td><%=Encode.forHtml(h.get("lastName").toString())%></td>
+                          <td><%=Encode.forHtml(h.get("firstName").toString())%></td>
                           <td><%=Encode.forHtml(demo.getHin())+Encode.forHtml(demo.getVer())%></td>
                           <td><%=Encode.forHtml(demo.getPhone())%> </td>
                           <td><%=Encode.forHtml(demo.getEmail()) %></td>
@@ -578,9 +578,9 @@ table.ele thead {
                           <% }else {
                               org.oscarehr.common.model.Demographic demoSDM = demoData.getSubstituteDecisionMaker(LoggedInInfo.getLoggedInInfoFromSession(request), dis.demographicNo.toString());%>
                           <td><%=demo.getAgeAsOf(asDate)%></td>
-                          <td><%=Encode.forHtml(h.get("sex"))%></td>
-                          <td><%=Encode.forHtml(h.get("lastName"))%></td>
-                          <td><%=Encode.forHtml(h.get("firstName"))%></td>
+                          <td><%=Encode.forHtml(h.get("sex").toString())%></td>
+                          <td><%=Encode.forHtml(h.get("lastName").toString())%></td>
+                          <td><%=Encode.forHtml(h.get("firstName").toString())%></td>
                           <td><%=Encode.forHtml(demo.getHin())+Encode.forHtml(demo.getVer())%></td>
                           <td><%=demoSDM==null?"":Encode.forHtml(demoSDM.getLastName())%><%=demoSDM==null?"":","%> <%= demoSDM==null?"":Encode.forHtml(demoSDM.getFirstName()) %>&nbsp;</td>
                           <td><%=demoSDM==null?"":Encode.forHtml(demoSDM.getPhone())%> &nbsp;</td>


### PR DESCRIPTION
This reverts commit 06b96bb0dd99d7b9d8075410a26abc3dca9fdb36. 

`Encode.forHtml` throws an error when called on an Object. 