### PR TITLE
Fix: Sanitize Uploaded Document Filenames to Prevent Broken Links

### DIFF
--- a/src/main/java/org/oscarehr/common/model/Document.java
+++ b/src/main/java/org/oscarehr/common/model/Document.java
@@ -57,7 +57,6 @@ import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 
 import org.apache.commons.io.FileUtils;
-import org.oscarehr.util.MiscUtils;
 
 /**
  *

--- a/src/main/java/org/oscarehr/common/model/Document.java
+++ b/src/main/java/org/oscarehr/common/model/Document.java
@@ -231,7 +231,7 @@ public class Document extends AbstractModel<Integer> implements Serializable {
     }
 
     public void setDocfilename(String docfilename) {
-        this.docfilename = MiscUtils.sanitizeFileName(docfilename);
+        this.docfilename = docfilename;
     }
 
     public String getDoccreator() {

--- a/src/main/java/org/oscarehr/common/model/Document.java
+++ b/src/main/java/org/oscarehr/common/model/Document.java
@@ -57,6 +57,7 @@ import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 
 import org.apache.commons.io.FileUtils;
+import org.oscarehr.util.MiscUtils;
 
 /**
  *
@@ -230,7 +231,7 @@ public class Document extends AbstractModel<Integer> implements Serializable {
     }
 
     public void setDocfilename(String docfilename) {
-        this.docfilename = docfilename;
+        this.docfilename = MiscUtils.sanitizeFileName(docfilename);
     }
 
     public String getDoccreator() {

--- a/src/main/java/org/oscarehr/documentManager/actions/AddEditDocumentAction.java
+++ b/src/main/java/org/oscarehr/documentManager/actions/AddEditDocumentAction.java
@@ -95,7 +95,7 @@ public class AddEditDocumentAction extends DispatchAction {
 		
 		FormFile docFile = fm.getFiledata();
 		int numberOfPages = 0;
-		String fileName = docFile.getFileName();
+		String fileName = MiscUtils.sanitizeFileName(docFile.getFileName());
 		String user = (String) request.getSession().getAttribute("user");
 		EDoc newDoc = new EDoc("", "", fileName, "", user, user, fm.getSource(), 'A', oscar.util.UtilDateUtilities.getToday("yyyy-MM-dd"), "", "", "demographic", "-1", 0);
 		newDoc.setDocPublic("0");
@@ -188,7 +188,7 @@ public class AddEditDocumentAction extends DispatchAction {
 		
 		Hashtable errors = new Hashtable();
 		FormFile docFile = fm.getDocFile();
-		String fileName = docFile.getFileName();
+		String fileName = MiscUtils.sanitizeFileName(docFile.getFileName());
 		String user = (String) request.getSession().getAttribute("user");
 		EDoc newDoc = new EDoc("", "", fileName, "", user, user, fm.getSource(), 'A', oscar.util.UtilDateUtilities.getToday("yyyy-MM-dd"), "", "", "demographic", "-1");
 		newDoc.setDocPublic("0");
@@ -426,7 +426,7 @@ public class AddEditDocumentAction extends DispatchAction {
                         
                         if(oscar.OscarProperties.getInstance().getBooleanProperty("ALLOW_UPDATE_DOCUMENT_CONTENT", "true"))
                         {
-                            fileName=docFile.getFileName();
+                            fileName=MiscUtils.sanitizeFileName(docFile.getFileName());
                         }
                         
 			String reviewerId = filled(fm.getReviewerId()) ? fm.getReviewerId() : "";

--- a/src/main/java/org/oscarehr/documentManager/actions/AddEditDocumentAction.java
+++ b/src/main/java/org/oscarehr/documentManager/actions/AddEditDocumentAction.java
@@ -289,7 +289,7 @@ public class AddEditDocumentAction extends DispatchAction {
 				throw new FileNotFoundException();
 			}
 			// original file name
-			String fileName1 = docFile.getFileName();
+			String fileName1 = MiscUtils.sanitizeFileName(docFile.getFileName());
 
 			EDoc newDoc = new EDoc(fm.getDocDesc(), fm.getDocType(), fileName1, "", fm.getDocCreator(), fm.getResponsibleId(), fm.getSource(), 'A', fm.getObservationDate(), "", "", fm.getFunction(), fm.getFunctionId());
 			newDoc.setDocPublic(fm.getDocPublic());

--- a/src/main/java/org/oscarehr/documentManager/actions/DocumentUploadAction.java
+++ b/src/main/java/org/oscarehr/documentManager/actions/DocumentUploadAction.java
@@ -110,7 +110,7 @@ public class DocumentUploadAction extends DispatchAction {
                 }
 		else {
 			int numberOfPages = 0;
-			String fileName = docFile.getFileName();
+			String fileName = MiscUtils.sanitizeFileName(docFile.getFileName());
 			String user = (String) request.getSession().getAttribute("user");
 			SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
 			EDoc newDoc = new EDoc("", "", fileName, "", user, user, fm.getSource(), 'A',

--- a/src/main/java/org/oscarehr/managers/DocumentManagerImpl.java
+++ b/src/main/java/org/oscarehr/managers/DocumentManagerImpl.java
@@ -153,6 +153,7 @@ public class DocumentManagerImpl implements  DocumentManager{
 		// Generates filename and path data and saves the document data to the file system
 		String documentPath = oscar.OscarProperties.getInstance().getProperty("DOCUMENT_DIR");
 		String fileName = dateTimeFormat.format(today) + "_" + document.getDocfilename();
+		fileName = MiscUtils.sanitizeFileName(fileName);
 		File file = new File(documentPath + File.separator + fileName);
 		FileUtils.writeByteArrayToFile(file, documentData);
 

--- a/src/main/java/org/oscarehr/util/MiscUtils.java
+++ b/src/main/java/org/oscarehr/util/MiscUtils.java
@@ -304,7 +304,7 @@ public final class MiscUtils {
 	/**
 	 * Sanitizes a file name to ensure it is safe for use and complies with naming conventions .
 	 *		<p>- Replace spaces with underscores
-	 * 		<p>- Remove invalid characters
+	 * 		<p>- Remove invalid characters, excluding valid delimiter like {@code -}.
 	 * 		<p>- Remove repeated dots
 	 *
 	 * @param fileName The original file name to be sanitized. It must not be {@code null}.
@@ -313,7 +313,7 @@ public final class MiscUtils {
 	 */
 	public static String sanitizeFileName(String fileName) {
         return fileName.replaceAll("\\s+", "_")
-                .replaceAll("[^a-zA-Z0-9._:-]", "")
+                .replaceAll("[^a-zA-Z0-9._]", "")
                 .replaceAll("\\.+", ".");
 	}
 

--- a/src/main/java/org/oscarehr/util/MiscUtils.java
+++ b/src/main/java/org/oscarehr/util/MiscUtils.java
@@ -300,4 +300,21 @@ public final class MiscUtils {
 		MiscUtils.shutdownSignaled=shutdownSignaled;
 	}
 
+
+	/**
+	 * Sanitizes a file name to ensure it is safe for use and complies with naming conventions .
+	 *		<p>- Replace spaces with underscores
+	 * 		<p>- Remove invalid characters
+	 * 		<p>- Remove repeated dots
+	 *
+	 * @param fileName The original file name to be sanitized. It must not be {@code null}.
+	 * @return A sanitized value of the input file name.
+	 * @throws NullPointerException if the input fileName is {@code null}.
+	 */
+	public static String sanitizeFileName(String fileName) {
+        return fileName.replaceAll("\\s+", "_")
+                .replaceAll("[^a-zA-Z0-9._:-]", "")
+                .replaceAll("\\.+", ".");
+	}
+
 }


### PR DESCRIPTION
### This PR fixes issues with uploaded document filenames containing unsafe characters, which caused broken links. A utility function for sanitizing filenames has been added to ensure proper handling and storage.

#### Changes

- Added filename sanitization utility for cleaning uploaded document names in MiscUtils.java. Replaces spaces with underscores `_`, removes unwanted punctuation, and retains valid delimiter `-`.
- Replaced direct file name usage with `MiscUtils.sanitizeFileName` to ensure proper handling of unsafe or invalid file names.
