### PR TITLE
Fix Incorrect Date Format in Edit Invoices Page

### DIFF
--- a/src/main/webapp/billing/CA/BC/billStatus.jsp
+++ b/src/main/webapp/billing/CA/BC/billStatus.jsp
@@ -302,7 +302,11 @@ if("true".equals(readonly)){
     </div>
     <div class="col-sm-3">
 <div class="form-group">
-    <label style="white-space: nowrap;" for="xml_appointment_date">Service End Date: <a href="javascript: function myFunction() {return false; }" onClick="fillEndDate('<%=DateUtils.sumDate("yyyy-M-d","-30")%>')" >30</a> <a href="javascript: function myFunction() {return false; }" onClick="fillEndDate('<%=DateUtils.sumDate("yyyy-M-d","-60")%>')" >60</a> <a href="javascript: function myFunction() {return false; }" onClick="fillEndDate('<%=DateUtils.sumDate("yyyy-M-d","-90")%>')" >90</a></label>
+    <label style="white-space: nowrap;" for="xml_appointment_date">Service End Date:
+        <a href="javascript: function myFunction() {return false; }" onClick="fillEndDate('<%=DateUtils.sumDate("yyyy-MM-dd","-30")%>')" >30</a>
+        <a href="javascript: function myFunction() {return false; }" onClick="fillEndDate('<%=DateUtils.sumDate("yyyy-MM-dd","-60")%>')" >60</a>
+        <a href="javascript: function myFunction() {return false; }" onClick="fillEndDate('<%=DateUtils.sumDate("yyyy-MM-dd","-90")%>')" >90</a>
+    </label>
 	<div class="input-group">
 		<input type="text" class="form-control" name="xml_appointment_date" placeholder="yyyy-mm-dd"
                id="xml_appointment_date" value="<%=xml_appointment_date%>"


### PR DESCRIPTION
This PR addresses an issue in the Edit Invoices page under `Administration / Billing / Edit Invoices`, where the auto-generated 30/60/90-days Service End Date used an incompatible date format (yyyy-M-d). This format caused errors when generating reports, as the system expected a yyyy-MM-dd format.

Changes Made:
Updated the date format string in `DateUtils.sumDate` function calls from `yyyy-M-d` to `yyyy-MM-dd` in the relevant JSP file.
Ensured that months and days are consistently represented with two digits, adding leading zeros where necessary.