### PR TITLE
Fix ClassCastException using TypedQuery

### DIFF
--- a/src/main/java/org/oscarehr/billing/CA/BC/dao/Hl7MshDao.java
+++ b/src/main/java/org/oscarehr/billing/CA/BC/dao/Hl7MshDao.java
@@ -27,8 +27,10 @@ import java.util.Date;
 import java.util.List;
 
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 
 import org.oscarehr.billing.CA.BC.model.Hl7Msh;
+import org.oscarehr.billing.CA.BC.util.PathNetLabResults;
 import org.oscarehr.common.dao.AbstractDaoImpl;
 import org.springframework.stereotype.Repository;
 
@@ -40,8 +42,8 @@ public class Hl7MshDao extends AbstractDaoImpl<Hl7Msh>{
 		super(Hl7Msh.class);
 	}
 
-    public List<Object[]> findPathnetResultsDataByPatientNameHinStatusAndProvider(String patientName, String patientHealthNumber, String status, String providerNo, String labType) {
-        String sql = "SELECT msh, pid, orc, obr, providerLabRouting, MIN(obr.resultStatus) " +
+    public List<PathNetLabResults> findPathnetResultsDataByPatientNameHinStatusAndProvider(String patientName, String patientHealthNumber, String status, String providerNo, String labType) {
+        String sql = "SELECT new org.oscarehr.billing.CA.BC.util.PathNetLabResults( msh, pid, orc, obr, providerLabRouting, MIN(obr.resultStatus) )" +
                 "FROM Hl7Msh msh, Hl7Pid pid, Hl7Orc orc, Hl7Obr obr, ProviderLabRoutingModel providerLabRouting " +
                 "WHERE providerLabRouting.labNo = pid.messageId " +
                 "AND pid.messageId = msh.messageId " +
@@ -53,8 +55,8 @@ public class Hl7MshDao extends AbstractDaoImpl<Hl7Msh>{
                 "AND pid.patientName like :patientName " +
                 "AND pid.externalId like :patientHealthNumber " +
                 "GROUP BY pid.id";
-        
-		Query query = entityManager.createQuery(sql);
+
+		TypedQuery<PathNetLabResults> query = entityManager.createQuery(sql, PathNetLabResults.class);
 		query.setParameter("status", status);
 		query.setParameter("providerNo", providerNo);
 		query.setParameter("labType", labType);
@@ -63,8 +65,8 @@ public class Hl7MshDao extends AbstractDaoImpl<Hl7Msh>{
 		return query.getResultList();
     }
 
-    public List<Object[]> findPathnetResultsByLabNo(Integer labNo) {
-        String sql = "SELECT msh, pid, orc, obr, providerLabRouting, MIN(obr.resultStatus) " +
+    public List<PathNetLabResults> findPathnetResultsByLabNo(Integer labNo) {
+        String sql = "SELECT new org.oscarehr.billing.CA.BC.util.PathNetLabResults( msh, pid, orc, obr, providerLabRouting, MIN(obr.resultStatus) )" +
                 "FROM Hl7Msh msh, Hl7Pid pid, Hl7Orc orc, Hl7Obr obr, ProviderLabRoutingModel providerLabRouting " +
                 "WHERE providerLabRouting.labNo = pid.messageId " +
                 "AND pid.messageId = msh.messageId " +
@@ -72,14 +74,14 @@ public class Hl7MshDao extends AbstractDaoImpl<Hl7Msh>{
                 "AND pid.id = obr.pidId  "+
                 "AND pid.messageId= :labNo " +
                 "GROUP BY pid.id";
-        
-		Query query = entityManager.createQuery(sql);
+
+		TypedQuery<PathNetLabResults> query = entityManager.createQuery(sql, PathNetLabResults.class);
 		query.setParameter("labNo", labNo);
 		return query.getResultList();
     }
-    
-	public List<Object[]> findPathnetResultsDeomgraphicNo(Integer demographicNo, String labType) {		
-	    String sql =  "SELECT msh, pid, orc, obr, patientLabRouting, MIN(obr.resultStatus) " +
+
+	public List<PathNetLabResults> findPathnetResultsDeomgraphicNo(Integer demographicNo, String labType) {
+	    String sql =  "SELECT new org.oscarehr.billing.CA.BC.util.PathNetLabResults( msh, pid, orc, obr, patientLabRouting, MIN(obr.resultStatus) )" +
                 "FROM Hl7Msh msh, Hl7Pid pid, Hl7Orc orc, Hl7Obr obr, PatientLabRouting patientLabRouting " +
                 "WHERE patientLabRouting.labNo = pid.id " +
                 "AND pid.id = orc.pidId " +
@@ -89,7 +91,7 @@ public class Hl7MshDao extends AbstractDaoImpl<Hl7Msh>{
                 "AND patientLabRouting.demographicNo = :demographicNo " +
                 "GROUP BY pid.id";
 
-		Query query = entityManager.createQuery(sql);
+		TypedQuery<PathNetLabResults> query = entityManager.createQuery(sql, PathNetLabResults.class);
 		query.setParameter("demographicNo", demographicNo);
 		query.setParameter("labType", labType);
 		return query.getResultList();

--- a/src/main/java/org/oscarehr/billing/CA/BC/dao/Hl7MshDao.java
+++ b/src/main/java/org/oscarehr/billing/CA/BC/dao/Hl7MshDao.java
@@ -43,6 +43,10 @@ public class Hl7MshDao extends AbstractDaoImpl<Hl7Msh>{
 	}
 
     public List<PathNetLabResults> findPathnetResultsDataByPatientNameHinStatusAndProvider(String patientName, String patientHealthNumber, String status, String providerNo, String labType) {
+		/*
+		 * Below query use a constructor expression (SELECT new org.oscarehr.billing.CA.BC.model.PathNetLabResults(Hl7Msh, Hl7Pid, Hl7Orc, Hl7Obr, ProviderLabRoutingModel, String))
+		 * and TypedQuery<PathNetLabResults> to directly create instances of PathNetLabResults from the database results
+		 * */
         String sql = "SELECT new org.oscarehr.billing.CA.BC.util.PathNetLabResults( msh, pid, orc, obr, providerLabRouting, MIN(obr.resultStatus) )" +
                 "FROM Hl7Msh msh, Hl7Pid pid, Hl7Orc orc, Hl7Obr obr, ProviderLabRoutingModel providerLabRouting " +
                 "WHERE providerLabRouting.labNo = pid.messageId " +
@@ -66,6 +70,10 @@ public class Hl7MshDao extends AbstractDaoImpl<Hl7Msh>{
     }
 
     public List<PathNetLabResults> findPathnetResultsByLabNo(Integer labNo) {
+		/*
+		 * Below query use a constructor expression (SELECT new org.oscarehr.billing.CA.BC.model.PathNetLabResults(Hl7Msh, Hl7Pid, Hl7Orc, Hl7Obr, ProviderLabRoutingModel, String))
+		 * and TypedQuery<PathNetLabResults> to directly create instances of PathNetLabResults from the database results
+		 * */
         String sql = "SELECT new org.oscarehr.billing.CA.BC.util.PathNetLabResults( msh, pid, orc, obr, providerLabRouting, MIN(obr.resultStatus) )" +
                 "FROM Hl7Msh msh, Hl7Pid pid, Hl7Orc orc, Hl7Obr obr, ProviderLabRoutingModel providerLabRouting " +
                 "WHERE providerLabRouting.labNo = pid.messageId " +
@@ -81,6 +89,10 @@ public class Hl7MshDao extends AbstractDaoImpl<Hl7Msh>{
     }
 
 	public List<PathNetLabResults> findPathnetResultsDeomgraphicNo(Integer demographicNo, String labType) {
+		/*
+		 * Below query use a constructor expression (SELECT new org.oscarehr.billing.CA.BC.model.PathNetLabResults(Hl7Msh, Hl7Pid, Hl7Orc, Hl7Obr, PatientLabRouting, String))
+		 * and TypedQuery<PathNetLabResults> to directly create instances of PathNetLabResults from the database results
+		 * */
 	    String sql =  "SELECT new org.oscarehr.billing.CA.BC.util.PathNetLabResults( msh, pid, orc, obr, patientLabRouting, MIN(obr.resultStatus) )" +
                 "FROM Hl7Msh msh, Hl7Pid pid, Hl7Orc orc, Hl7Obr obr, PatientLabRouting patientLabRouting " +
                 "WHERE patientLabRouting.labNo = pid.id " +

--- a/src/main/java/org/oscarehr/billing/CA/BC/util/PathNetLabResults.java
+++ b/src/main/java/org/oscarehr/billing/CA/BC/util/PathNetLabResults.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2005-2012. Centre for Research on Inner City Health, St. Michael's Hospital, Toronto. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for
+ * Centre for Research on Inner City Health, St. Michael's Hospital,
+ * Toronto, Ontario, Canada
+ */
+
+package org.oscarehr.billing.CA.BC.util;
+
+import org.oscarehr.billing.CA.BC.model.Hl7Msh;
+import org.oscarehr.billing.CA.BC.model.Hl7Obr;
+import org.oscarehr.billing.CA.BC.model.Hl7Orc;
+import org.oscarehr.billing.CA.BC.model.Hl7Pid;
+import org.oscarehr.common.model.PatientLabRouting;
+import org.oscarehr.common.model.ProviderLabRoutingModel;
+
+public class PathNetLabResults {
+    private Hl7Msh hl7Msh;
+    private Hl7Pid hl7Pid;
+    private Hl7Orc hl7Orc;
+    private Hl7Obr hl7Obr;
+    private ProviderLabRoutingModel providerLabRouting;
+    private PatientLabRouting patientLabRouting;
+    private Long minResultStatus;
+
+    public PathNetLabResults(Hl7Msh hl7Msh, Hl7Pid hl7Pid, Hl7Orc hl7Orc, Hl7Obr hl7Obr, ProviderLabRoutingModel providerLabRouting, String minResultStatus) {
+        this.hl7Msh = hl7Msh;
+        this.hl7Pid = hl7Pid;
+        this.hl7Orc = hl7Orc;
+        this.hl7Obr = hl7Obr;
+        this.providerLabRouting = providerLabRouting;
+        this.minResultStatus = Long.valueOf(minResultStatus);
+    }
+
+    public PathNetLabResults(Hl7Msh hl7Msh, Hl7Pid hl7Pid, Hl7Orc hl7Orc, Hl7Obr hl7Obr, PatientLabRouting patientLabRouting, String minResultStatus) {
+        this.hl7Msh = hl7Msh;
+        this.hl7Pid = hl7Pid;
+        this.hl7Orc = hl7Orc;
+        this.hl7Obr = hl7Obr;
+        this.patientLabRouting = patientLabRouting;
+        this.minResultStatus = Long.valueOf(minResultStatus);
+    }
+
+    public Hl7Msh getHl7Msh() {
+        return hl7Msh;
+    }
+
+    public void setHl7Msh(Hl7Msh hl7Msh) {
+        this.hl7Msh = hl7Msh;
+    }
+
+    public Hl7Pid getHl7Pid() {
+        return hl7Pid;
+    }
+
+    public void setHl7Pid(Hl7Pid hl7Pid) {
+        this.hl7Pid = hl7Pid;
+    }
+
+    public Hl7Orc getHl7Orc() {
+        return hl7Orc;
+    }
+
+    public void setHl7Orc(Hl7Orc hl7Orc) {
+        this.hl7Orc = hl7Orc;
+    }
+
+    public Hl7Obr getHl7Obr() {
+        return hl7Obr;
+    }
+
+    public void setHl7Obr(Hl7Obr hl7Obr) {
+        this.hl7Obr = hl7Obr;
+    }
+
+    public ProviderLabRoutingModel getProviderLabRouting() {
+        return providerLabRouting;
+    }
+
+    public void setProviderLabRouting(ProviderLabRoutingModel providerLabRouting) {
+        this.providerLabRouting = providerLabRouting;
+    }
+
+    public PatientLabRouting getPatientLabRouting() {
+        return patientLabRouting;
+    }
+
+    public void setPatientLabRouting(PatientLabRouting patientLabRouting) {
+        this.patientLabRouting = patientLabRouting;
+    }
+
+    public Long getMinResultStatus() {
+        return minResultStatus;
+    }
+
+    public void setMinResultStatus(Long minResultStatus) {
+        this.minResultStatus = minResultStatus;
+    }
+}


### PR DESCRIPTION
The code changes introduce the `PathNetLabResults` class to encapsulate data retrieved from the database related to lab results.  This improves code readability and maintainability by grouping related data elements.

* **`PathNetLabResults` class:** This new class holds instances of `Hl7Msh`, `Hl7Pid`, `Hl7Orc`, `Hl7Obr`, `ProviderLabRoutingModel`, `PatientLabRoutingModel`, and `minResultStatus`.  

* **`Hl7MshDao.java`:** The query methods `findPathnetResultsDataByPatientNameHinStatusAndProvider`, `findPathnetResultsByLabNo`, and `findPathnetResultsDeomgraphicNo` are modified.  Instead of returning a `List<Object[]>`, they now return a `List<PathNetLabResults>`. The queries use a constructor expression (`SELECT new org.oscarehr.billing.CA.BC.model.PathNetLabResults(...)`) and `TypedQuery<PathNetLabResults>` to directly create instances of `PathNetLabResults` from the database results.

* **`PathnetResultsData.java`:**  The `getPathNetResultsData` method now handles a `List<PathNetLabResults>` instead of a `List<Object[]>`. The code within the loop is updated to access data using the getter methods of the `PathNetLabResults` objects, which is cleaner than array indexing. Also, added a null check for `o.getProviderLabRouting()` before accessing the status, preventing a potential `NPE`.
