### PR TITLE
Add digital signature support to prescriptions

### DIFF
--- a/database/mysql/updates/update-2024-12-04.sql
+++ b/database/mysql/updates/update-2024-12-04.sql
@@ -1,0 +1,1 @@
+ALTER TABLE prescription ADD COLUMN digital_signature_id INT NULL DEFAULT NULL;

--- a/src/main/java/org/oscarehr/common/model/Prescription.java
+++ b/src/main/java/org/oscarehr/common/model/Prescription.java
@@ -75,6 +75,9 @@ public class Prescription extends AbstractModel<Integer> implements Serializable
 	@Temporal(TemporalType.TIMESTAMP)
 	private Date lastUpdateDate;
 
+	@Column(name = "digital_signature_id")
+	private Integer digitalSignatureId;
+
 	@PreRemove
 	protected void jpaPreventDelete() {
 		throw (new UnsupportedOperationException("Remove is not allowed for this type of item."));
@@ -180,5 +183,13 @@ public class Prescription extends AbstractModel<Integer> implements Serializable
 	public int getReprintCount() {
 		if (!isReprinted()) return 0;
 		return getDatesReprinted().split(",").length;
+	}
+
+	public Integer getDigitalSignatureId() {
+		return digitalSignatureId;
+	}
+
+	public void setDigitalSignatureId(Integer digitalSignatureId) {
+		this.digitalSignatureId = digitalSignatureId;
 	}
 }

--- a/src/main/java/org/oscarehr/managers/PrescriptionManager.java
+++ b/src/main/java/org/oscarehr/managers/PrescriptionManager.java
@@ -86,4 +86,5 @@ public interface PrescriptionManager {
 
     public boolean print(LoggedInInfo loggedInInfo, int scriptNo);
 
+    boolean setPrescriptionSignature(LoggedInInfo loggedInInfo, int scriptNo, Integer digitalSignatureId);
 }

--- a/src/main/java/org/oscarehr/managers/PrescriptionManagerImpl.java
+++ b/src/main/java/org/oscarehr/managers/PrescriptionManagerImpl.java
@@ -429,4 +429,15 @@ public class PrescriptionManagerImpl implements PrescriptionManager {
 
     }
 
+    @Override
+    public boolean setPrescriptionSignature(LoggedInInfo loggedInInfo, int scriptNo, Integer digitalSignatureId) {
+
+        Prescription prescription = prescriptionDao.find(scriptNo);
+        prescription.setDigitalSignatureId(digitalSignatureId);
+
+        prescriptionDao.merge(prescription);
+
+        return true;
+}
+
 }

--- a/src/main/java/oscar/oscarRx/data/RxPrescriptionData.java
+++ b/src/main/java/oscar/oscarRx/data/RxPrescriptionData.java
@@ -370,6 +370,7 @@ public class RxPrescriptionData {
 
 		prescription.setPrintDate(rx.getDatePrinted());
 		prescription.setDatesReprinted(rx.getDatesReprinted());
+		prescription.setDigitalSignatureId(rx.getDigitalSignatureId());
 		return prescription;
 	}
 
@@ -685,7 +686,17 @@ public class RxPrescriptionData {
 		private String protocol;
 		private String priorRxProtocol;
 		private Integer pharmacyId;
-		
+
+		private Integer digitalSignatureId;
+
+		public Integer getDigitalSignatureId() {
+			return digitalSignatureId;
+		}
+
+		public void setDigitalSignatureId(Integer digitalSignatureId) {
+			this.digitalSignatureId = digitalSignatureId;
+		}
+
 		public String getDrugReasonCode() {
 			return drugReasonCode;
 		}

--- a/src/main/java/oscar/oscarRx/pageUtil/RxWriteScriptAction.java
+++ b/src/main/java/oscar/oscarRx/pageUtil/RxWriteScriptAction.java
@@ -1205,7 +1205,8 @@ public final class RxWriteScriptAction extends DispatchAction {
 		for (int i = 0; i < bean.getStashSize(); i++) {
 			try {
 				rx = bean.getStashItem(i);
-				rx.Save(scriptId);// new drug id available after this line			
+				rx.Save(scriptId);// new drug id available after this line
+				rx.setScript_no(scriptId);
 				bean.addRandomIdDrugIdPair(rx.getRandomId(), rx.getDrugId());
 				auditStr.append(rx.getAuditString());
 				auditStr.append("\n");

--- a/src/main/webapp/WEB-INF/struts-config.xml
+++ b/src/main/webapp/WEB-INF/struts-config.xml
@@ -1072,6 +1072,9 @@
 			<forward name="success" path="/oscarRx/ViewScript2.jsp"></forward>
 		</action>
 
+		<action path="/oscarRx/saveDigitalSignature" parameter="method" scope="request" type="oscar.oscarRx.pageUtil.RxRePrescribeAction">
+		</action>
+
 		<action path="/oscarRx/WriteToEncounter" scope="request" type="oscar.oscarRx.pageUtil.RxWriteToEncounterAction">
 			<forward name="success" path="/oscarRx/ViewScript2.jsp" />
 		</action>

--- a/src/main/webapp/oscarRx/Preview2.jsp
+++ b/src/main/webapp/oscarRx/Preview2.jsp
@@ -54,6 +54,7 @@
 <%@page import="org.oscarehr.web.PrescriptionQrCodeUIBean"%>
 <%@ page import="org.oscarehr.managers.DemographicManager" %>
 <%@ page import="org.oscarehr.util.SpringUtils" %>
+<%@ page import="java.util.Objects" %>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security"%>
 <%
@@ -512,6 +513,12 @@ if(prop!=null && prop.getValue().equalsIgnoreCase("yes")){
 								imageUrl = request.getContextPath() + "/imageRenderingServlet?source=" + ImageRenderingServlet.Source.signature_preview.name() + "&" + DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY + "=" + signatureRequestId;
 								startimageUrl = request.getContextPath() + "/images/1x1.gif";
 								statusUrl = request.getContextPath() + "/PMmodule/ClientManager/check_signature_status.jsp?" + DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY + "=" + signatureRequestId;
+
+								if (bean.getStashSize() > 0 && Objects.nonNull(bean.getStashItem(0).getDigitalSignatureId())) {
+									startimageUrl=request.getContextPath()+"/imageRenderingServlet?source="+ImageRenderingServlet.Source.signature_stored.name()+"&digitalSignatureId="+bean.getStashItem(0).getDigitalSignatureId();
+								}
+
+
 								%>
 
 								<input type="hidden" name="<%= DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY %>" value="<%=signatureRequestId%>" />

--- a/src/main/webapp/oscarRx/ViewScript2.jsp
+++ b/src/main/webapp/oscarRx/ViewScript2.jsp
@@ -751,7 +751,7 @@ function toggleView(form) {
                                 }
                                 function expandPreview(text){
                                     parent.document.getElementById('lightwindow_container').style.width="1140px";
-									parent.document.getElementById('lightwindow_container').style.left="-600px";
+									// parent.document.getElementById('lightwindow_container').style.left="-600px"; // commented to resolve a UI alignment issue causing the print-rx window to shift off-screen to the left.
                                     parent.document.getElementById('lightwindow_contents').style.width="1120px";
                                     document.getElementById('preview').style.width="600px";
                                     frames['preview'].document.getElementById('pharmInfo').innerHTML=text;

--- a/src/main/webapp/oscarRx/ViewScript2.jsp
+++ b/src/main/webapp/oscarRx/ViewScript2.jsp
@@ -697,9 +697,11 @@ function toggleView(form) {
 			<tr>
 				<td width=420px>
 				<div class="DivContentPadding"><!-- src modified by vic, hsfo -->
-				<iframe id='preview' name='preview' width=420px height=890px
-					src="<%= dx<0?"Preview2.jsp?scriptId="+bean.getStashItem(0).getScript_no()+"&rePrint="+reprint+"&pharmacyId="+request.getParameter("pharmacyId"):dx==7?"HsfoPreview.jsp?dxCode=7":"about:blank" %>"
-					align=center border=0 frameborder=0></iframe></div>
+					<% if (bean.getStashSize() > 0) { %>
+						<iframe id='preview' name='preview' width=420px height=890px
+							src="<%= dx<0?"Preview2.jsp?scriptId="+bean.getStashItem(0).getScript_no()+"&rePrint="+reprint+"&pharmacyId="+request.getParameter("pharmacyId"):dx==7?"HsfoPreview.jsp?dxCode=7":"about:blank" %>"
+							align=center border=0 frameborder=0></iframe></div>
+					<% } %>
 				</td>
 
 				<td valign=top><html:form action="/oscarRx/clearPending">


### PR DESCRIPTION
Integrated digital signature functionality into the prescription workflow by adding a new database column, updating models, and incorporating signature handling in various JSP pages and Java classes. It ensures prescriptions can now store and retrieve digital signatures, enhancing the system's security and compliance capabilities.

Hide Signature pad if digital signature is already present in the prescription. This prevents users from accidentally signing the same prescription multiple times.