### PR TITLE
Update SearchDrug3.jsp to get Drugref interactions

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -296,6 +296,7 @@ if (rx_enhance!=null && rx_enhance.equals("true")) {
                        var data = "rand="+rand;
                        new Ajax.Request(url, {method: 'post',parameters:data,onSuccess:function(transport){
                     	   // updateCurrentInteractions();
+                    	   updateDrugrefInteractions();			
                         }});
             }
             function onPrint(cfgPage) {
@@ -1108,8 +1109,9 @@ body {
 <%-- End List Drugs Prescribed --%>
 
                 </td>
-                <td width="300px" valign="top" >
+                <td style="width:300px; vertical-align:top">
                     <div id="interactionsRxMyD" style="float:right;"></div>
+                    <div id="interactionsRx" style="float:right;"></div>
                 </td>
             </tr>
 
@@ -1476,6 +1478,7 @@ function changeLt(drugId){
                var data = "rand=" + Math.floor(Math.random()*10001);
                new Ajax.Request(url, {method: 'post',parameters:data,onSuccess:function(transport){
                             // updateCurrentInteractions();
+                            updateDrugrefInteractions();	
             }});
                $('rxText').innerHTML="";//make pending prescriptions disappear.
                $("searchString").focus();
@@ -1486,6 +1489,7 @@ function changeLt(drugId){
         new Ajax.Updater('rxText',url, {method:'get',parameters:data,asynchronous:true,evalScripts:true,
             insertion: Insertion.Bottom,onSuccess:function(transport){
                 // updateCurrentInteractions();
+                updateDrugrefInteractions();
         }});
 
     }
@@ -1514,6 +1518,7 @@ function changeLt(drugId){
         var url="<c:out value="${ctx}"/>" + "/oscarRx/rxStashDelete.do?parameterValue=deletePrescribe";
         new Ajax.Request(url, {method: 'get',parameters:data,onSuccess:function(transport){
                 // updateCurrentInteractions();
+                updateDrugrefInteractions();
                 if($('deleteOnCloseRxBox').value=='true'){
                     deleteRxOnCloseRxBox(randomId);
                 }
@@ -1539,6 +1544,7 @@ function changeLt(drugId){
                              $(discont).style.textDecoration='line-through';
                              $(prescrip).style.textDecoration='line-through';
 			     // updateCurrentInteractions();
+			     updateDrugrefInteractions();
                     }
                 }});
 
@@ -1598,6 +1604,7 @@ var skipParseInstr = false;
                   $(discont).style.textDecoration='line-through';
                   $(prescrip).style.textDecoration='line-through';
 		  // updateCurrentInteractions();
+		  updateDrugrefInteractions();
             }});
         }
         return false;
@@ -1695,6 +1702,7 @@ var skipParseInstr = false;
                   $('discont_'+json.id).innerHTML = json.reason;
                   $('prescrip_'+json.id).style.textDecoration='line-through';
                   // updateCurrentInteractions();
+                  updateDrugrefInteractions();
             }});
 
     }
@@ -1715,6 +1723,11 @@ var skipParseInstr = false;
                                         }});
                             }});
     }
+    function updateDrugrefInteractions(){
+        <oscar:oscarPropertiesCheck property="HOLBROOK" value="yes">
+            callReplacementWebService("InteractionDisplay.jsp",'interactionsRx');
+        </oscar:oscarPropertiesCheck>
+    }
 //represcribe long term meds
     function RePrescribeLongTerm(){
        var demoNo='<%=patient.getDemographicNo()%>';
@@ -1722,6 +1735,7 @@ var skipParseInstr = false;
         var url= "<c:out value="${ctx}"/>" + "/oscarRx/rePrescribe2.do?method=repcbAllLongTerm";
         new Ajax.Updater('rxText',url, {method:'get',parameters:data,asynchronous:true,insertion: Insertion.Bottom,onSuccess:function(transport){
                             // updateCurrentInteractions();
+                            updateDrugrefInteractions();
             }});
         return false;
     }
@@ -1890,6 +1904,7 @@ YAHOO.example.FnMultipleFields = function(){
                    new Ajax.Updater('rxText',url, {method:'get',parameters:params,evalScripts:true,
                         insertion: Insertion.Bottom,onSuccess:function(transport){
                             // updateCurrentInteractions();
+                            updateDrugrefInteractions();
                         }});
 
                     $('searchString').value = "";
@@ -2051,6 +2066,7 @@ function setSearchedDrug(drugId,name){
     var params = "demographicNo=<%=demoNo%>&drugId="+drugId+"&text="+name+"&randomId="+ran_number;
     new Ajax.Updater('rxText',url, {method:'get',parameters:params,asynchronous:true,evalScripts:true,insertion: Insertion.Bottom,onSuccess:function(transport){
                             // updateCurrentInteractions();
+                            updateDrugrefInteractions();
             }});
     $('searchString').value = "";
 }
@@ -2091,6 +2107,7 @@ function represcribe(element, toArchive){
         new Ajax.Updater('rxText',url, {method:'get',parameters:data,asynchronous:false,evalScripts:true,
             insertion: Insertion.Bottom,onSuccess:function(transport){
                 // updateCurrentInteractions();
+                updateDrugrefInteractions();
             }});
     }else if(drugId!=null){
         var dataUpdateId="reRxDrugId="+toArchive+"&action=addToReRxDrugIdList&rand="+Math.floor(Math.random()*10001);
@@ -2102,6 +2119,7 @@ function represcribe(element, toArchive){
         new Ajax.Updater('rxText',url, {method:'get',parameters:data,evalScripts:true,
             insertion: Insertion.Bottom,onSuccess:function(transport){
                 // updateCurrentInteractions();
+                updateDrugrefInteractions();
             }});
 
    }


### PR DESCRIPTION
Display interactions from Drugref controlled by a property value HOLBROOK=yes
Currently no interaction warnings are available for Open-O
This allows open source interaction warnings for those that desire them.
This is a very simple edit and will work with any Drugref
To match the full set of interactions you will need Drugref build 48 or newer