### PR TITLE
Fix: Resolve ReRx Drug Disappearance and Improve Checkbox Handling

### DIFF
--- a/src/main/java/oscar/oscarRx/pageUtil/RxRePrescribeAction.java
+++ b/src/main/java/oscar/oscarRx/pageUtil/RxRePrescribeAction.java
@@ -281,7 +281,12 @@ public final class RxRePrescribeAction extends DispatchAction {
 			RxPrescriptionData.Prescription oldRx = rxData.getPrescription(drugId);
 			// create copy of Prescription
 			RxPrescriptionData.Prescription rx = rxData.newPrescription(beanRX.getProviderNo(), beanRX.getDemographicNo(), oldRx); // set writtendate, rxdate ,enddate=null.
-			Long rand = Math.round(Math.random() * 1000000);
+			long rand;
+			try {
+				rand = Long.parseLong(request.getParameter("rand"));
+			} catch (NumberFormatException e) {
+				rand = Math.round(Math.random() * 1000000);
+			}
 			rx.setRandomId(rand);
 
 			request.setAttribute("BoxNoFillFirstLoad", "true");

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -271,10 +271,8 @@ if (heading != null){
                            onclick="updateReRxStatusForPrescribedDrug(this, <%=prescriptIdInt%>)"
                            <%if(reRxDrugList.contains(prescriptIdInt.toString())){%>checked<%}%>
                            name="checkBox_<%=prescriptIdInt%>">
-                    <label for="<%=cbxId%>">ReRx</label>
+                    <label id="reRx_<%=prescriptIdInt%>" for="<%=cbxId%>">ReRx</label>
                 </div>
-<%--                <a name="rePrescribe" style="vertical-align:top" id="reRx_<%=prescriptIdInt%>" <%=styleColor%>--%>
-<%--                   href="javascript:void(0)" onclick="rePrescribeNew(this, <%=prescriptIdInt%>)">ReRx</a>--%>
                 <%} else {%>
                 <form action="<%=request.getContextPath()%>/oscarRx/searchDrug.do" method="post">
                     <input type="hidden" name="demographicNo" value="<%=patient.getDemographicNo()%>" />

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -265,8 +265,16 @@ if (heading != null){
            	%>
             <td width="20px" align="center" valign="top">
                 <%if (prescriptDrug.getRemoteFacilityName() == null) {%>
-                <input id="reRxCheckBox_<%=prescriptIdInt%>" type=CHECKBOX onclick="updateReRxDrugId(this.id)" <%if(reRxDrugList.contains(prescriptIdInt.toString())){%>checked<%}%> name="checkBox_<%=prescriptIdInt%>">
-                <a name="rePrescribe" style="vertical-align:top" id="reRx_<%=prescriptIdInt%>" <%=styleColor%> href="javascript:void(0)" onclick="represcribe(this, <%=prescriptIdInt%>)">ReRx</a>
+                <div style="display: flex; align-items: center;">
+                    <% String cbxId = "reRxCheckBox_" + prescriptIdInt + Math.abs(new Random().nextInt(10001)); %>
+                    <input id="<%=cbxId%>" type=CHECKBOX
+                           onclick="updateReRxStatusForPrescribedDrug(this, <%=prescriptIdInt%>)"
+                           <%if(reRxDrugList.contains(prescriptIdInt.toString())){%>checked<%}%>
+                           name="checkBox_<%=prescriptIdInt%>">
+                    <label for="<%=cbxId%>">ReRx</label>
+                </div>
+<%--                <a name="rePrescribe" style="vertical-align:top" id="reRx_<%=prescriptIdInt%>" <%=styleColor%>--%>
+<%--                   href="javascript:void(0)" onclick="rePrescribeNew(this, <%=prescriptIdInt%>)">ReRx</a>--%>
                 <%} else {%>
                 <form action="<%=request.getContextPath()%>/oscarRx/searchDrug.do" method="post">
                     <input type="hidden" name="demographicNo" value="<%=patient.getDemographicNo()%>" />

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -2107,6 +2107,12 @@ function represcribe(element, toArchive){
    }
 }
 
+/**
+ * Updates the re-prescribing status of a prescribed drug in the UI and session.
+ *
+ * @param element The checkbox element that triggered the update.
+ * @param drugId The ID of the drug being updated.
+ */
 function updateReRxStatusForPrescribedDrug(element, drugId) {
     const uiRefId = element.id.split('_')[1];
     if (drugId == null || uiRefId == null) {
@@ -2120,6 +2126,12 @@ function updateReRxStatusForPrescribedDrug(element, drugId) {
     }
 }
 
+/**
+ * Sets off instruction parsing and adds a drug to the re-prescribe list in the UI and session.
+ *
+ * @param uiRefId The unique ID used in the UI to reference this drug.
+ * @param drugId The ID of the drug to add.
+ */
 function addDrugToReRxList(uiRefId, drugId) {
     skipParseInstr = true;
 
@@ -2127,6 +2139,12 @@ function addDrugToReRxList(uiRefId, drugId) {
     this.rePrescribe2(uiRefId, drugId);
 }
 
+/**
+ * Add ReRx drug to UI by making an AJAX request to update the 'rxText' element.
+ *
+ * @param uiRefId The unique ID used in the UI to reference this drug.
+ * @param drugId The ID of the drug to re-prescribe.
+ */
 function rePrescribe2(uiRefId, drugId) {
     const data = "drugId=" + drugId;
     const url = "<c:out value="${ctx}"/>" + "/oscarRx/rePrescribe2.do?method=represcribe2&rand=" + uiRefId;
@@ -2138,33 +2156,64 @@ function rePrescribe2(uiRefId, drugId) {
     });
 }
 
+/**
+ * Adds a drug to the re-prescribe list in the session.
+ *
+ * @param uiRefId The unique ID used in the UI to reference this drug.
+ * @param drugId The ID of the drug to add.
+ */
 function addDrugToReRxListInSession(uiRefId, drugId) {
     const dataUpdateId = "reRxDrugId=" + drugId + "&action=addToReRxDrugIdList&rand=" + uiRefId;
     const urlUpdateId = "<c:out value="${ctx}"/>" + "/oscarRx/WriteScript.do?parameterValue=updateReRxDrug";
     new Ajax.Request(urlUpdateId, {method: 'get', parameters: dataUpdateId});
 }
 
+/**
+ * Removes a drug from the re-prescribe list and updates the UI.
+ *
+ * @param uiRefId The unique ID used in the UI to reference this drug.
+ * @param drugId The ID of the drug to remove.
+ */
 function removeDrugFromReRxList(uiRefId, drugId) {
     this.removeElementFromUI(this.getPrescribingDrugCardByUiRefId(uiRefId));
     this.removeReRxDrugId(drugId);
 }
 
+/**
+ * Removes a prescribing drug entry from both the UI and the backend.
+ * @param cardId The id of the card from which to delete
+ * @param drugId The id of the drug to remove
+ */
 function removePrescribingDrug(cardId, drugId) {
     const uiRefId = cardId.id.split('_')[1];
     this.deletePrescribingDrugFromUI(uiRefId, drugId);
     this.uncheckReRxForExistingPrescribedDrug(uiRefId, drugId)
 }
 
+/**
+ * Deletes a prescribing drug from UI and calls deletePrescribe.
+ * @param uiRefId The unique id for referencing the UI element.
+ * @param drugId The id of the drug to delete.
+ */
 function deletePrescribingDrugFromUI(uiRefId, drugId) {
     this.removeElementFromUI(this.getPrescribingDrugCardByUiRefId(uiRefId));
     this.deletePrescribe(drugId);
 }
 
+/**
+ * Removes a DOM element from the UI.
+ * @param {HTMLElement} element The element to remove.
+ */
 function removeElementFromUI(element) {
     if (element)
         element.remove();
 }
 
+/**
+ * Unchecks the "re-prescribe" checkbox for an existing prescribed drug and removes its ID from the re-prescribe list.
+ * @param uiRefId The UI reference ID for the drug.
+ * @param drugId The ID of the drug.
+ */
 function uncheckReRxForExistingPrescribedDrug(uiRefId, drugId) {
     const checkbox = this.getReRxCheckboxByUiRefId(uiRefId);
     if (checkbox)
@@ -2172,10 +2221,20 @@ function uncheckReRxForExistingPrescribedDrug(uiRefId, drugId) {
     this.removeReRxDrugId(drugId);
 }
 
+/**
+ * Gets the prescribing/staged drug container element by its UI reference ID.
+ * @param uiRefId The UI reference ID.
+ * @returns {HTMLElement|null} The drug container element, or null if not found.
+ */
 function getPrescribingDrugCardByUiRefId(uiRefId) {
     return $('set_' + uiRefId);
 }
 
+/**
+ * Gets the re-prescribe checkbox element by its UI reference ID.
+ * @param uiRefId The UI reference ID.
+ * @returns {HTMLElement|null} The checkbox element, or null if not found.
+ */
 function getReRxCheckboxByUiRefId(uiRefId) {
     return $('reRxCheckBox_' + uiRefId);
 }

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -2070,13 +2070,13 @@ function updateReRxDrugId(elementId){
 }
 
 
-function removeReRxDrugId(drugId){
-	 if(drugId!=null){
-	   var data="reRxDrugId="+drugId+"&action=removeFromReRxDrugIdList&rand="+Math.floor(Math.random()*10001);
-	   var url= "<c:out value="${ctx}"/>" + "/oscarRx/WriteScript.do?parameterValue=updateReRxDrug";
-	   new Ajax.Request(url, {method: 'get',parameters:data});
-	}
-	}
+function removeReRxDrugId(drugId) {
+    if (drugId != null) {
+        const data = "reRxDrugId=" + drugId + "&action=removeFromReRxDrugIdList&rand=" + Math.floor(Math.random() * 10001);
+        const url = "<c:out value="${ctx}"/>" + "/oscarRx/WriteScript.do?parameterValue=updateReRxDrug";
+        new Ajax.Request(url, {method: 'get', parameters: data});
+    }
+}
 
 //represcribe a drug
 function represcribe(element, toArchive){
@@ -2105,6 +2105,79 @@ function represcribe(element, toArchive){
             }});
 
    }
+}
+
+function updateReRxStatusForPrescribedDrug(element, drugId) {
+    const uiRefId = element.id.split('_')[1];
+    if (drugId == null || uiRefId == null) {
+        return;
+    }
+
+    if (element.checked === true) {
+        this.addDrugToReRxList(uiRefId, drugId);
+    } else {
+        this.removeDrugFromReRxList(uiRefId, drugId);
+    }
+}
+
+function addDrugToReRxList(uiRefId, drugId) {
+    skipParseInstr = true;
+
+    this.addDrugToReRxListInSession(uiRefId, drugId);
+    this.rePrescribe2(uiRefId, drugId);
+}
+
+function rePrescribe2(uiRefId, drugId) {
+    const data = "drugId=" + drugId;
+    const url = "<c:out value="${ctx}"/>" + "/oscarRx/rePrescribe2.do?method=represcribe2&rand=" + uiRefId;
+    new Ajax.Updater('rxText', url, {
+        method: 'get', parameters: data, evalScripts: true,
+        insertion: Insertion.Bottom, onSuccess: function (transport) {
+            // updateCurrentInteractions();
+        }
+    });
+}
+
+function addDrugToReRxListInSession(uiRefId, drugId) {
+    const dataUpdateId = "reRxDrugId=" + drugId + "&action=addToReRxDrugIdList&rand=" + uiRefId;
+    const urlUpdateId = "<c:out value="${ctx}"/>" + "/oscarRx/WriteScript.do?parameterValue=updateReRxDrug";
+    new Ajax.Request(urlUpdateId, {method: 'get', parameters: dataUpdateId});
+}
+
+function removeDrugFromReRxList(uiRefId, drugId) {
+    this.removeElementFromUI(this.getPrescribingDrugCardByUiRefId(uiRefId));
+    this.removeReRxDrugId(drugId);
+}
+
+function removePrescribingDrug(cardId, drugId) {
+    const uiRefId = cardId.id.split('_')[1];
+    this.deletePrescribingDrugFromUI(uiRefId, drugId);
+    this.uncheckReRxForExistingPrescribedDrug(uiRefId, drugId)
+}
+
+function deletePrescribingDrugFromUI(uiRefId, drugId) {
+    this.removeElementFromUI(this.getPrescribingDrugCardByUiRefId(uiRefId));
+    this.deletePrescribe(drugId);
+}
+
+function removeElementFromUI(element) {
+    if (element)
+        element.remove();
+}
+
+function uncheckReRxForExistingPrescribedDrug(uiRefId, drugId) {
+    const checkbox = this.getReRxCheckboxByUiRefId(uiRefId);
+    if (checkbox)
+        checkbox.checked = false;
+    this.removeReRxDrugId(drugId);
+}
+
+function getPrescribingDrugCardByUiRefId(uiRefId) {
+    return $('set_' + uiRefId);
+}
+
+function getReRxCheckboxByUiRefId(uiRefId) {
+    return $('reRxCheckBox_' + uiRefId);
 }
 
 function updateQty(element){

--- a/src/main/webapp/oscarRx/prescribe.jsp
+++ b/src/main/webapp/oscarRx/prescribe.jsp
@@ -174,11 +174,11 @@ if(listRxDrugs!=null){
                 drugName=drugName.replace("\"","\\\"");
                 byte[] drugNameBytes = drugName.getBytes("ISO-8859-1");
                 drugName= new String(drugNameBytes, "UTF-8");
-                
+                String fieldSetId = "set_" + rand;
 %>
 
-<fieldset style="margin-top:2px;width:640px;" id="set_<%=rand%>">
-    <a tabindex="-1" href="javascript:void(0);"  style="float:right;margin-left:5px;margin-top:0px;padding-top:0px;" onclick="$('set_<%=rand%>').remove();deletePrescribe('<%=rand%>');removeReRxDrugId('<%=DrugReferenceId%>')"><img src='<c:out value="${ctx}/images/close.png"/>' border="0"></a>
+<fieldset style="margin-top:2px;width:640px;" id="<%=fieldSetId%>">
+    <a tabindex="-1" href="javascript:void(0);"  style="float:right;margin-left:5px;margin-top:0px;padding-top:0px;" onclick="removePrescribingDrug(<%=fieldSetId%>, <%=DrugReferenceId%>);"><img src='<c:out value="${ctx}/images/close.png"/>' border="0"></a>
     <a tabindex="-1" href="javascript:void(0);"  style="float:right;;margin-left:5px;margin-top:0px;padding-top:0px;" title="Add to Favorites" onclick="addFav('<%=rand%>','<%=drugName%>')">F</a>
     <a tabindex="-1" href="javascript:void(0);" style="float:right;margin-top:0px;padding-top:0px;" onclick="$('rx_more_<%=rand%>').toggle();">  <span id="moreLessWord_<%=rand%>" onclick="updateMoreLess(id)" >more</span> </a>
 
@@ -635,7 +635,7 @@ if(listRxDrugs!=null){
                         //do nothing
                     }
                     else{
-                        $('set_<%=rand%>').remove();
+                        $('<%=fieldSetId%>').remove();
                         //call java class to delete it from stash pool.
                         var randId='<%=rand%>';
                         deletePrescribe(randId);


### PR DESCRIPTION
**Fix:** drugs selected for re-prescribing would disappear from the medication list if the prescription preview window was closed before confirming. Also, improves the overall handling of ReRx checkboxes for a more streamlined user experience.

The disappearance issue stemmed from a lack of association between the ReRx checkbox and the corresponding drug in the prescription preview. Fixing it by introducing Reference UI IDs that uniquely map each ReRx checkbox to its associated drug.


**Further improvements include:**

- Enhanced Checkbox Handling: The ReRx workflow is simplified by merging the ReRx link action directly into the onChecked event of the checkbox. This removes the separate ReRx link, eliminating potential user confusion and streamlining the interaction.
- These changes result in a better ReRx actions, preventing accidental drug removal and providing a clearer, more efficient workflow for re-prescribing medications. 