### PR TITLE
(READY FOR REVIEW) Bugfix - Handle 'showLatest' parameter correctly

### DIFF
--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -94,6 +94,8 @@ String remoteLabKey = request.getParameter("remoteLabKey");
 String demographicID = request.getParameter("demographicId");
 String showAllstr = request.getParameter("all");
 
+String showLatest = request.getParameter("showLatest");
+
 List<String> allLicenseNames = new ArrayList<String>();
 String lastLicenseNo = null, currentLicenseNo = null;
 
@@ -195,6 +197,11 @@ if (remoteFacilityIdString==null) // local lab
 	else {
 		multiLabId = Hl7textResultsData.getMatchingLabs(segmentID);
 		segmentIDs = multiLabId.split(",");
+
+		int totalMatchingLabs = segmentIDs.length;
+		if (showLatest != null && "true".equals(showLatest) && totalMatchingLabs > 1) {
+			segmentID = segmentIDs[totalMatchingLabs - 1];
+		}
 		
 		List<String> segmentIdList = new ArrayList<String>();
 		handler = Factory.getHandler(segmentID);


### PR DESCRIPTION
**Summary**
When opening a lab, the latest version of the lab is not necessarily displayed when the ‘showLatest=true’ parameter is present in the URL.

![image](https://github.com/user-attachments/assets/cce16bbf-0e97-4239-bbe9-83d5cacadde0)

**Analysis**
The current implementation does not account for the ‘showLatest’ parameter in the URL that already exists, causing the system to display the version(segmentID) specified in the URL instead.  The real world impact is that users are surprised that they don't default to the latest version when they open a lab from their inbox and they see this as a "bug".

![image](https://github.com/user-attachments/assets/76290664-ff52-4d71-a900-c5ed7260dd41)

**Solution**
- Added logic in ‘labDisplay.jsp’ to handle the ‘showLatest’ parameter.
- The method ‘getMatchingLabs’, which is already used in the page, retrieves all lab versions in order. The first lab in the array is the oldest, and the last lab is the latest.
![image](https://github.com/user-attachments/assets/5af1b6ab-70f9-4035-a816-8bf60ecfb23e)
- Updated the logic to check for the ‘showLatest’ parameter in the URL.
         - If ‘showLatest’ is present, the latest lab version (last item in the array returned by getMatchingLabs) is displayed.
         - If ‘showLatest’ is absent, the lab specified(segmentID) in the URL is displayed as before.
    
![image](https://github.com/user-attachments/assets/828554b3-3da3-4a26-ae74-3e7e0c7437cb)

**Code Changes**
In ‘labDisplay.jsp’:
- Modified the logic to determine the lab version to display based on the presence of the ‘showLatest’ parameter.
- Ensured the existing functionality remains unaffected for URLs without the ‘showLatest’ parameter.
