### PR TITLE
Fix: echart not closing properly after signing/saving rx note

### DIFF
--- a/src/main/webapp/casemgmt/close.jsp
+++ b/src/main/webapp/casemgmt/close.jsp
@@ -27,6 +27,10 @@
 
 
 <script type="text/javascript">
-window.opener.location.reload(true);
+// Check if the parent window (window.opener) is available
+if (window.opener) {
+    // Reload the parent window to ensure it reflects the latest changes
+    window.opener.location.reload(true);
+}
 window.close();
 </script>


### PR DESCRIPTION
Steps to reproduce original issue: 
1. Access prescriptions module
1. Find any drug and 'Save and Print' (or ReRX something)
1. Sign off and click 'Print & Add to encounter note
1. Save pdf or cancel out of it
1. Echart opens, the prescription is pasted in the note. Click Sign & Save
1. Results in blank CaseManagementEntry page window that needs to be closed manually. (The note _does_ sign and save successfully, however) 

This is fixed by adding a null check for `window.opener` before reloading the parent window.

(Tagging @D3V41 to receive updates.)