### PR TITLE
Fix: fax account not automatically selected when faxing eform

### DIFF
--- a/src/main/webapp/fax/CoverPage.jsp
+++ b/src/main/webapp/fax/CoverPage.jsp
@@ -235,7 +235,7 @@
 							  <label for="senderFaxAccount">Fax account</label>
 							  <select class="form-control" name="senderFaxNumber"  id="senderFaxAccount">
 									<c:forEach items="${ requestScope.accounts }" var="account">
-							    		<option value="${ account.faxNumber }" ${ account.id eq requestScope.faxAccount ? 'selected' : '' } >
+							    		<option value="${ account.faxNumber }" ${ account.id eq requestScope.faxAccount or account.faxNumber eq param.letterheadFax ? 'selected' : '' } >
 							    			<c:out value="${ account.accountName }"/> <c:out value="(${ account.faxNumber })"/>
 							    		</option>
 									</c:forEach>


### PR DESCRIPTION
The fax module used to use the `letterheadFax` field of an eform to automatically select the corresponding sender from the "Fax account" dropdown. 

This feature stopped working after commit eef2b14e7410ad6751feed1383115a049d01ed2c. This PR restores that functionality.

(Tagging @D3V41 to receive updates.)