### PR TITLE
Fix: Correct prescription active dates handling

### DIFF
--- a/src/main/java/oscar/oscarRx/util/RxUtil.java
+++ b/src/main/java/oscar/oscarRx/util/RxUtil.java
@@ -796,8 +796,8 @@ public class RxUtil {
 					durationSpec = instructionToCheck.substring(m1.start(), m.start());
 					duration = durationSpec.trim();
 					p("duration here1", duration);
+					break;
 				}
-				break;
 			}
 		}
 


### PR DESCRIPTION
The original code used a `break` statement outside the `if` block, meaning the loop would always terminate after the first potential `durationUnitSpec` match found, regardless of whether a `duration` was found.  The modified code moves the `break` statement *inside* the `if` block. This ensures the loop only terminates when a duration has been successfully matched and extracted.  If no duration is found within the loop's iterations, the method will continue processing subsequent instruction text. This change likely fixes a bug where only the first potential duration match was considered, potentially ignoring valid durations specified later in the input string.


> Sample input instruction which raised the issue: 
> **_Once a day for 3 months_**  Qty:90 Repeats:1