### PR TITLE
(NOT READY FOR REVIEW) Small Upgrade - Dynamically Removing All Versions of a Lab from Inbox

### DIFF
--- a/src/main/webapp/share/javascript/oscarMDSIndex.js
+++ b/src/main/webapp/share/javascript/oscarMDSIndex.js
@@ -1777,7 +1777,17 @@ function updateStatus(formid){//acknowledge
 				updateDocStatusInQueue(doclabid);
 				if (typeof _in_window !== 'undefined' && _in_window) {
 					if (typeof self.opener.removeReport !== 'undefined') {
-						self.opener.removeReport(doclabid);
+						/**
+						 * When a user acknowledges any lab version, it automatically files away older versions 
+						 * as well as the acknowledged version. This function removes those versions from the 
+						 * inbox results by calling the jQuery `removeReport` function on IDs up to and including
+						 * the doclabid.
+						 */
+						const multiIds = data.multiID.split(",");
+						for (const id of multiIds) {
+							self.opener.removeReport(id);
+							if (id === doclabid) break;
+						}
 					}
 					window.close();
 				} else {


### PR DESCRIPTION
As part of testing this PR (https://github.com/open-osp/Open-O/pull/23), an issue that was identified had to do with whether ALL versions of a lab would be dynamically removed from the inbox after the latest version of the lab was acknowledged.

The thinking is NO.  

This PR is designed to address that fact, by dynamically removing all of the versions.

One thing to note - this removal is not truly modifying any data, it's only adjusting what's currently visible in the inbox so that no refresh is needed.