### PR TITLE
Implement Toggle for Long-Term Drug Status and Archiving

### DIFF
--- a/src/main/java/org/oscarehr/common/model/Drug.java
+++ b/src/main/java/org/oscarehr/common/model/Drug.java
@@ -192,6 +192,8 @@ public class Drug extends AbstractModel<Integer> implements Serializable {
 	public static final String DISCONTINUED_BY_ANOTHER_PHYSICIAN = "discontinuedByAnotherPhysician";
 	public static final String COST = "cost";
 	public static final String DRUG_INTERACTION = "drugInteraction";
+	public static final String ARCHIVED_REASON_LT_ENABLED = "Updated Long-term status: ON";
+	public static final String ARCHIVED_REASON_LT_DISABLED = "Updated Long-term status: OFF";
 	public static final String OTHER = "other";
 
 	public Drug() {

--- a/src/main/java/org/oscarehr/managers/RxManager.java
+++ b/src/main/java/org/oscarehr/managers/RxManager.java
@@ -27,23 +27,12 @@
 
 package org.oscarehr.managers;
 
-import org.apache.logging.log4j.Logger;
-import org.oscarehr.common.dao.DrugDao;
-import org.oscarehr.common.dao.FavoriteDao;
-import org.oscarehr.common.exception.AccessDeniedException;
 import org.oscarehr.common.model.Drug;
 import org.oscarehr.common.model.Favorite;
 import org.oscarehr.common.model.Prescription;
 import org.oscarehr.util.LoggedInInfo;
-import org.oscarehr.util.MiscUtils;
 import org.oscarehr.ws.rest.to.model.RxStatus;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import oscar.log.LogAction;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 
@@ -63,7 +52,18 @@ public interface RxManager {
     public List<Drug> getHistory(Integer id, LoggedInInfo info, Integer demographicNo);
     public List<Favorite> getFavorites(String pid);
     public Boolean addFavorite(Favorite f);
-       
+
+    /**
+     * Archives a drug. This will remove the drug from the current list. The drug can still be found under the 'All' section.
+     *
+     * @param info          Logged-in user information.
+     * @param drugId        The ID of the drug to archive.
+     * @param demographicId The demographic ID.
+     * @param reason        The reason for archiving the drug.
+     * @return True if the drug was successfully archived, false otherwise.
+     */
+    boolean archiveDrug(LoggedInInfo info, int drugId, int demographicId, String reason);
+
     public List<Drug> getLongTermDrugs( LoggedInInfo info,  int demographicNo);
 
 

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -75,6 +75,91 @@
 	}
 %>
 
+
+
+<%--
+<link rel="stylesheet" type="text/css" href="${ctx}/library/bootstrap/5.0.2/css/bootstrap.min.css" id="bootstrap-css">
+<script type="text/javascript" src="<c:out value="${ctx}/library/bootstrap/5.0.2/js/bootstrap.min.js"/>"></script>
+--%>
+
+
+<style>
+    /* Container for the drug-maintenance-switch */
+    .drug-maintenance-switch {
+        top: -2px;
+        position: relative;
+        width: 34px;
+        height: 16px;
+    }
+
+    /* Hide the default checkbox */
+    .drug-maintenance-switch-input {
+        display: none;
+    }
+
+    /* Style the switch track */
+    .drug-maintenance-switch-label {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: #dfdfdf;
+        cursor: pointer;
+        transition: background-color 0.3s;
+        border-radius: 5%;
+    }
+
+    /* Style the toggle knob, default label to blank if unchecked */
+    .drug-maintenance-switch-label::after {
+        text-align: center;
+        content: '';
+        font-size: xx-small;
+        font-stretch: extra-expanded;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 12px;
+        height: 12px;
+        background-color: #FFFFFFAF;
+        border-radius: 50%;
+        transition: transform 0.3s, content 0.3s, width 0.3s, height 0.3s, border-radius 0.3s;
+        box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4);
+    }
+
+    /* Change Label to LT (long term) when checked */
+    .drug-maintenance-switch-input:checked + .drug-maintenance-switch-label::after {
+        content: 'LT'; /* Change label when checked */
+        transform: translateX(14px);
+        border-radius: 5%;
+        width: 16px;
+        height: 12px;
+        color: white;
+        background-color: #1e7e34AF;
+    }
+
+    /* Disabled State Styling */
+    .drug-maintenance-switch-input:disabled + .drug-maintenance-switch-label {
+        background-color: #e0e0e0;
+        cursor: not-allowed;
+    }
+
+    /* Disabled State: Handle appearance */
+    .drug-maintenance-switch-input:disabled:checked + .drug-maintenance-switch-label::after {
+        background-color: #1e7e349F;
+        transform: translateX(14px);
+        content: 'LT';
+        width: 16px;
+        height: 12px;
+        border-radius: 5%;
+    }
+
+
+</style>
+
 <%
 	LoggedInInfo loggedInInfo=LoggedInInfo.getLoggedInInfoFromSession(request);
 	com.quatro.service.security.SecurityManager securityManager = new com.quatro.service.security.SecurityManager();
@@ -217,38 +302,18 @@ if (heading != null){
             	<% } %>
             </td>
             <td valign="top">
-            	<%
-            		if(prescriptDrug.isLongTerm())
-            		{
-            		%>
-            			*
-            		<%
-            		}
-            		else
-            		{
-            			if (prescriptDrug.getRemoteFacilityId()==null)
-            			{
-            				%>
-							<%
-								if(securityManager.hasWriteAccess("_rx",roleName$,true)) {            		
-							%>
-		            			<a id="notLongTermDrug_<%=prescriptIdInt%>" title="<bean:message key='oscarRx.Prescription.changeDrugLongTerm'/>" onclick="changeLt('<%=prescriptIdInt%>');" href="javascript:void(0);">
-		            			L
-		            			</a>
-							<% } else { %>
-            					<span style="color:blue">L</span>
-            				<% } %>
 
-            				<%
-            			}
-            			else
-            			{
-		            		%>
-		            		L
-		            		<%
-            			}
-           			}
-           			%>
+                <div class="drug-maintenance-switch" style="display: flex; align-items: baseline;">
+                    <% String drugMaintenanceSwitch = "drugMaintenanceSwitch_" + prescriptIdInt + Math.abs(new Random().nextInt(10001)); %>
+                    <input id="<%=drugMaintenanceSwitch%>" type="checkbox" name="checkBox_<%=prescriptIdInt%>"
+                           class="drug-maintenance-switch-input"
+                           onclick="changeLt(this, '<%=prescriptIdInt%>');"
+                            <% if (!securityManager.hasWriteAccess("_rx", roleName$, true)) {%> disabled <%}%>
+                            <% if (prescriptDrug.isLongTerm()) {%> checked <%}%> />
+                    <label id="drugMaintenanceSwitchLbl_<%=prescriptIdInt%>" for="<%=drugMaintenanceSwitch%>" class="drug-maintenance-switch-label">
+
+                    </label>
+                </div>
             </td>
 			<%
 			//display comment as tooltip if not null - simply using the TITLE attr

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -77,12 +77,6 @@
 
 
 
-<%--
-<link rel="stylesheet" type="text/css" href="${ctx}/library/bootstrap/5.0.2/css/bootstrap.min.css" id="bootstrap-css">
-<script type="text/javascript" src="<c:out value="${ctx}/library/bootstrap/5.0.2/js/bootstrap.min.js"/>"></script>
---%>
-
-
 <style>
     /* Container for the drug-maintenance-switch */
     .drug-maintenance-switch {

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1283,25 +1283,36 @@ body {
                         }
 %>
 <script type="text/javascript">
-function changeLt(drugId){
-    if (confirm('<bean:message key="oscarRx.Prescription.changeDrugLongTermConfirm" />')==true) {
-           var data="ltDrugId="+drugId+"&rand="+Math.floor(Math.random()*10001);
-           var url="<c:out value='${ctx}'/>"+ "/oscarRx/WriteScript.do?parameterValue=changeToLongTerm";
-           new Ajax.Request(url,{method: 'post',parameters:data,onSuccess:function(transport){
-                   var json=transport.responseText.evalJSON();
-                   if(json!=null && (json.success=='true'||json.success==true) ){
-                        $("notLongTermDrug_"+drugId).innerHTML="*";
-                        $("notLongTermDrug_"+drugId).setStyle({
-                            textDecoration: 'none',
-                            color: 'red'
-                        });
-                        $("notLongTermDrug_"+drugId).setAttribute("onclick","");
-                        $("notLongTermDrug_"+drugId).setAttribute("href","");
-                    }else{
+    function changeLt(element, drugId) {
+        if (confirm('<bean:message key="oscarRx.Prescription.changeDrugLongTermConfirm" />') === true) {
+            const data = "ltDrugId=" + drugId + "&isLongTerm=" + element.checked + "&rand=" + Math.floor(Math.random() * 10001);
+            const url = "<c:out value='${ctx}'/>" + "/oscarRx/WriteScript.do?parameterValue=updateLongTermStatus";
+            new Ajax.Request(url, {
+                method: 'post',
+                parameters: data,
+                onSuccess: function (transport) {
+                    const json = transport.responseText.evalJSON();
+                    if (json != null && (json.success === 'true' || json.success === true)) {
+                        callReplacementWebService('ListDrugs.jsp','drugProfile');
+                    } else {
+                        checkboxRevertStatus(element);
                     }
-               }});
-       }
-}
+                },
+                onFailure: function () {
+                    checkboxRevertStatus(element);
+                }
+            });
+        } else {
+            checkboxRevertStatus(element);
+        }
+    }
+
+    function checkboxRevertStatus(checkbox) {
+        setTimeout(function () {
+            checkbox.checked = !checkbox.checked;
+        }, 500);
+    }
+
     function checkReRxLongTerm(){
         var url=window.location.href;
         var match=url.indexOf('ltm=true');


### PR DESCRIPTION
This pull request addresses two key issues in the current drug management system for handling Long-Term drugs:

1. **Missing Toggle for Non-Long-Term Status**:  The current implementation only allows marking a drug as Long-Term, but there is no option to revert it back to Non-Long-Term. This PR introduces a toggle switch to enable users to toggle the status between Long-Term and Non-Long-Term.

2. **Duplicate Drug Entries**:   When a drug is marked as Long-Term, a duplicate drug entry is created instead of updating the original. The original drug remains unchanged, and the new Long-Term entry is added with an asterisk `*` instead of the `LT` link. Upon refreshing the page, both the original and new Long-Term entries are displayed, leading to unnecessary clutter in the drug list. This change introduces an archiving mechanism for the original drug.


#### **Changes Made:**
#### **Frontend (UI):**
- Replaced the 'LT' link with a toggle switch in `ListDrugs.jsp` to allow users to both mark and unmark drugs as Long-Term.
- Updated the `changeLt` JavaScript function to handle the toggle functionality, sending the updated Long-Term status to the backend.

#### **Backend:**
- Modified the `RxManager` interface and its implementation to add an `archiveDrug` method that archives the original drug when a new Long-Term entry is created.
- Updated the `RxWriteScriptAction` to trigger the `archiveDrug` method after changing a drug’s Long-Term status. This ensures that the original drug is archived with a reason when its status is updated.
