### PR TITLE
Bugfix - Gracefully handling a null prevention date when generating a PDF

### DIFF
--- a/src/main/java/org/oscarehr/casemgmt/service/CaseManagementPrintPdf.java
+++ b/src/main/java/org/oscarehr/casemgmt/service/CaseManagementPrintPdf.java
@@ -253,7 +253,8 @@ public class CaseManagementPrintPdf {
                  curFont = normal;
                  phrase = new Phrase(LEADING, "", curFont);
                  String refused = prevention.isRefused()?" (Refused)":"";
-                 phrase.add(formatter.format(prevention.getPreventionDate()) + " - ");
+                 String preventionDate = prevention.getPreventionDate() == null ? "Unknown" : formatter.format(prevention.getPreventionDate());
+                 phrase.add(preventionDate + " - ");
                  phrase.add(prevention.getPreventionType() + refused);
                  p.add(phrase);
                  document.add(p);


### PR DESCRIPTION
In this commit (07d164e1afeff6d56c3b6047c5356065772753ed) the prevention_date was made mandatory.  Prior to that point it was optional and so legacy DBs may contain preventions with a NULL prevention date

![image](https://github.com/user-attachments/assets/37e91210-e945-4295-954f-e4bc5815c0c5)

![image](https://github.com/user-attachments/assets/38b0f46b-718a-4fb1-b5a9-3e0b0c17e8e6)

If a PDF is generated for a chart with a prevention with a NULL prevention date, a 500 error will occur.  This change more gracefully handles that scenario by checking for NULL and using "Unknown" in that scenario instead.