### PR TITLE
Upgrade labDisplayAjax for excelleris on

### DIFF
--- a/src/main/webapp/lab/CA/ALL/labDisplayAjax.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplayAjax.jsp
@@ -923,6 +923,23 @@ if (request.getAttribute("printError") != null && (Boolean) request.getAttribute
                                 boolean obrFlag = false;
                                 int obxCount = handler.getOBXCount(j);
 
+                               if (handler.getMsgType().equals("ExcellerisON") && handler.getObservationHeader(j, 0).equals(headers.get(i))) {
+                                    String orderRequestStatus = ((ExcellerisOntarioHandler) handler).getOrderStatus(j);
+                                    int obrCommentCount = handler.getOBRCommentCount(j);
+                                    if (orderRequestStatus.equals(ExcellerisOntarioHandler.OrderStatus.DELETED.getDescription())) { continue; }
+                                    
+                                    if (obxCount > 0 || !orderRequestStatus.isEmpty() || obrCommentCount > 0) {
+                                        obrFlag = true;
+                                    %>
+                                    <tr style="<%=(linenum % 2 == 1 ? "background-color:"+highlight : "")%>" >
+                                        <td style="text-align:left; vertical-align:top"><span style="font-size:16px;font-weight: bold;"><%=handler.getOBRName(j)%></span></td>
+                                        <td colspan="1"><%=orderRequestStatus%></td>
+                                    </tr>
+                                    <%
+                                    }
+                               }
+
+
                                 for (k=0; k < obxCount; k++){
                                     String obxName = handler.getOBXName(j, k);
 									boolean isAllowedDuplicate = false;

--- a/src/main/webapp/lab/CA/ALL/labDisplayAjax.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplayAjax.jsp
@@ -50,6 +50,7 @@
 <%@ taglib uri="/WEB-INF/oscarProperties-tag.tld" prefix="oscarProperties"%>
 <%@ taglib uri="/WEB-INF/indivo-tag.tld" prefix="indivo"%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%
       String roleName$ = (String)session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
 	  boolean authed=true;
@@ -613,6 +614,20 @@ if (request.getAttribute("printError") != null && (Boolean) request.getAttribute
                                                 </div>
                                             </td>
                                         </tr>
+                                        <% if ("ExcellerisON".equals(handler.getMsgType())) { %>
+                                            <tr>
+                                                <td>
+                                                    <div class="FieldData">
+                                                        <strong>Reported on:</strong>
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                    <div class="FieldData" nowrap="nowrap">
+                                                        <%= ((ExcellerisOntarioHandler) handler).getReportStatusChangeDate() %>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        <% } %>
                                         <tr>
                                             <td>
                                                 <div class="FieldData">
@@ -960,7 +975,7 @@ if (request.getAttribute("printError") != null && (Boolean) request.getAttribute
                                     
                                     if ( !handler.getOBXResultStatus(j, k).equals("DNS") && b2 && b3){ // <<--  DNS only needed for MDS messages
                                         String obrName = handler.getOBRName(j);
-                                        if(!obrFlag && !obrName.equals("") && !(obxName.contains(obrName) && obxCount < 2)){%>
+                                        if(!obrFlag && !obrName.equals("") && !(obxName.contains(obrName) && obxCount < 2) && !handler.getMsgType().equals("ExcellerisON")){%>
                                            <%--  <tr bgcolor="<%=(linenum % 2 == 1 ? highlight : "")%>" >
                                                 <td valign="top" align="left"><%=obrName%></td>
                                                 <td colspan="6">&nbsp;</td>
@@ -1077,7 +1092,13 @@ if (request.getAttribute("printError") != null && (Boolean) request.getAttribute
 													 <%
 												} else {
 											%>
-	                                            <td align="right"><%= handler.getOBXResult( j, k) %></td><%}%>
+	                                            <td align="right">
+                                                   <% if (handler.getMsgType().equals("ExcellerisON") && !((ExcellerisOntarioHandler) handler).getOBXSubId(j, k).isEmpty()) { %>
+                                                    <em><%= ((ExcellerisOntarioHandler) handler).getOBXSubIdWithObservationValue( j, k) %></em>
+                                                    <% } else { %>
+                                                    <%= handler.getOBXResult( j, k) %>
+                                                    <% } %>
+                                                </td><%}%>
 	                                            <% } %>
 	                                            <td align="center">
 	                                                    <%= handler.getOBXAbnormalFlag(j, k)%>


### PR DESCRIPTION
### **Context:**
- `labDisplay.jsp`: This file is used when labs are opened as a new window. It was recently upgraded to handle ExcellerisON labs.
![2](https://github.com/user-attachments/assets/6c5f2d2b-95f8-4c9c-b8d9-08d4ee666c62)
![3](https://github.com/user-attachments/assets/1f2e8c90-126e-4ab8-aaf4-0e6538a10a14)

- `labDisplayAjax.jsp`: This file is used by the old inbox to preview labs.
![4](https://github.com/user-attachments/assets/487ebc93-7b33-4f63-8ec7-b1b525f87dd8)

- New Inbox: The new inbox uses `labDisplay.jsp` for previewing labs, which reduces unnecessary code duplication.
![5](https://github.com/user-attachments/assets/7aabbd57-352e-4a63-87c9-9b3a095a08d6)

### **Issue:**
- PHC has identified that `labDisplayAjax.jsp` was not upgraded alongside labDisplay.jsp and requires updates to align with the recent changes.

### **Changes:**
- This PR includes the necessary upgrades to `labDisplayAjax.jsp` to ensure consistency and proper functionality with ExcellerisON labs.