### PR TITLE
Implement Single Login Restriction for Users

### DIFF
--- a/src/main/java/org/oscarehr/common/exception/UserSessionNotFoundException.java
+++ b/src/main/java/org/oscarehr/common/exception/UserSessionNotFoundException.java
@@ -1,0 +1,12 @@
+package org.oscarehr.common.exception;
+
+/**
+ * This exception is thrown when a user session is not found in the registry.
+ */
+public class UserSessionNotFoundException extends IllegalArgumentException {
+
+    public UserSessionNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/org/oscarehr/managers/UserSessionManager.java
+++ b/src/main/java/org/oscarehr/managers/UserSessionManager.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2005-2012. Centre for Research on Inner City Health, St. Michael's Hospital, Toronto. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for
+ * Centre for Research on Inner City Health, St. Michael's Hospital,
+ * Toronto, Ontario, Canada
+ */
+
+
+package org.oscarehr.managers;
+
+import org.oscarehr.common.exception.UserSessionNotFoundException;
+
+import javax.servlet.http.HttpSession;
+
+/**
+ * Manages user sessions.  Provides methods to register, unregister, and retrieve user sessions based on a user security code.
+ * This interface is implemented by a service class that handles the actual session management logic.
+ *
+ */
+public interface UserSessionManager {
+
+    /**
+     * Registers a user session.
+     * @param userSecurityCode The user's security code.
+     * @param session The HTTP session object.
+     */
+    void registerUserSession(Integer userSecurityCode, HttpSession session);
+
+    /**
+     * Unregisters a user session.
+     * @param userSecurityCode The user's security code.
+     * @return The unregistered HTTP session object.
+     * @throws UserSessionNotFoundException If the user session is not found.
+     */
+    HttpSession unregisterUserSession(Integer userSecurityCode) throws UserSessionNotFoundException;
+
+    /**
+     * Retrieves a registered user session.
+     * @param userSecurityCode The user's security code.
+     * @return The registered HTTP session object, or null if not found.
+     */
+    HttpSession getRegisteredSession(Integer userSecurityCode);
+}

--- a/src/main/java/org/oscarehr/managers/UserSessionManagerImpl.java
+++ b/src/main/java/org/oscarehr/managers/UserSessionManagerImpl.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2005-2012. Centre for Research on Inner City Health, St. Michael's Hospital, Toronto. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for
+ * Centre for Research on Inner City Health, St. Michael's Hospital,
+ * Toronto, Ontario, Canada
+ */
+
+package org.oscarehr.managers;
+
+import org.apache.logging.log4j.Logger;
+import org.oscarehr.common.exception.UserSessionNotFoundException;
+import org.oscarehr.util.MiscUtils;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Implementation of the {@link UserSessionManager} interface.
+ * This class manages user sessions using a HashMap to store the association between user security codes and HttpSessions.
+ */
+@Service
+public class UserSessionManagerImpl implements UserSessionManager {
+
+    public static final String KEY_USER_SECURITY_CODE = "UserSecurityCode";
+    private static final Logger logger = MiscUtils.getLogger();
+    private static final Map<Integer, HttpSession> userSessionMap = new HashMap<>();
+
+    /**
+     * Registers a user session with the given user security code and HttpSession.
+     * If a session is already registered for the given user security code, it is invalidated before registering the
+     * new provided session.
+     * @param userSecurityCode The user security code.
+     * @param session The HttpSession.
+     */
+    @Override
+    public void registerUserSession(Integer userSecurityCode, HttpSession session) {
+        if (this.isUserSessionRegistered(userSecurityCode))
+            // Explicitly invalidate the previous session if it exists
+            try {
+                HttpSession previousSession = userSessionMap.get(userSecurityCode);
+                logger.debug("Existing User Session found, invalidating: {}", previousSession.getId());
+
+                previousSession.invalidate();
+
+                logger.debug("Previous user session successfully invalidated");
+            } catch (IllegalStateException e) {
+                MiscUtils.getLogger().debug(e.getMessage());
+            }
+
+        // Register the new session, overwrite previous registry
+        userSessionMap.put(userSecurityCode, session);
+        session.setAttribute(KEY_USER_SECURITY_CODE, userSecurityCode);
+        logger.debug("User Session successfully registered: {}", session.getId());
+    }
+
+    /**
+     * Unregisters the user session associated with the given user security code.
+     * @param userSecurityCode The user security code.
+     * @return The HttpSession that was unregistered.
+     * @throws UserSessionNotFoundException If no session is found for the given user security code.
+     */
+    @Override
+    public HttpSession unregisterUserSession(Integer userSecurityCode) throws UserSessionNotFoundException {
+        if (this.isUserSessionRegistered(userSecurityCode)) {
+            HttpSession session = userSessionMap.remove(userSecurityCode);
+            session.removeAttribute(KEY_USER_SECURITY_CODE);
+            logger.debug("User Session successfully unregistered: {}", session.getId());
+            return session;
+        } else {
+            throw new UserSessionNotFoundException("User session not registered");
+        }
+    }
+
+    /**
+     * Retrieves the registered HttpSession for the given user security code.
+     * @param userSecurityCode The user security code.
+     * @return The HttpSession.
+     * @throws UserSessionNotFoundException If no session is found for the given user security code.
+     */
+    @Override
+    public HttpSession getRegisteredSession(Integer userSecurityCode) {
+        if (this.isUserSessionRegistered(userSecurityCode)) {
+            return userSessionMap.get(userSecurityCode);
+        } else {
+            throw new UserSessionNotFoundException("User session not registered");
+        }
+    }
+
+    /**
+     * Checks if a session is registered for the given user security code.
+     *
+     * @param userSecurityCode The user security code.
+     * @return True if the session is registered, false otherwise.
+     */
+    private boolean isUserSessionRegistered(Integer userSecurityCode) {
+        return Objects.nonNull(userSessionMap.get(userSecurityCode));
+    }
+}

--- a/src/main/java/org/oscarehr/web/OscarSessionListener.java
+++ b/src/main/java/org/oscarehr/web/OscarSessionListener.java
@@ -23,15 +23,17 @@
  */
 package org.oscarehr.web;
 
-import javax.servlet.http.HttpSessionEvent;
-import javax.servlet.http.HttpSessionListener;
-
 import org.oscarehr.common.dao.CasemgmtNoteLockDao;
+import org.oscarehr.common.exception.UserSessionNotFoundException;
 import org.oscarehr.common.model.CasemgmtNoteLock;
+import org.oscarehr.managers.UserSessionManager;
+import org.oscarehr.managers.UserSessionManagerImpl;
 import org.oscarehr.util.MiscUtils;
 import org.oscarehr.util.SpringUtils;
 
-import java.util.Enumeration;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
 
 public class OscarSessionListener implements HttpSessionListener {
 
@@ -52,6 +54,17 @@ public class OscarSessionListener implements HttpSessionListener {
 			MiscUtils.getLogger().info("removing note locks for this session - " + lock);
 			
 			casemgmtNoteLockDao.remove(lock.getId());
+		}
+
+		HttpSession session = se.getSession();
+		Integer userSecurityCode = (Integer) session.getAttribute(UserSessionManagerImpl.KEY_USER_SECURITY_CODE);
+		if (userSecurityCode != null) {
+			try {
+				UserSessionManager userSessionManager = SpringUtils.getBean(UserSessionManager.class);
+				userSessionManager.unregisterUserSession(userSecurityCode);
+			} catch (UserSessionNotFoundException e) {
+				MiscUtils.getLogger().warn("Failed to unregister session on destroy: {}", e.getMessage());
+			}
 		}
 	}
 

--- a/src/main/java/oscar/login/LoginAction.java
+++ b/src/main/java/oscar/login/LoginAction.java
@@ -41,6 +41,7 @@ import org.oscarehr.common.model.*;
 import org.oscarehr.decisionSupport.service.DSService;
 import org.oscarehr.managers.AppManager;
 import org.oscarehr.managers.SecurityManager;
+import org.oscarehr.managers.UserSessionManager;
 import org.oscarehr.util.*;
 import org.owasp.encoder.Encode;
 import org.springframework.context.ApplicationContext;
@@ -57,13 +58,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 import java.util.regex.Pattern;
 
 public final class LoginAction extends DispatchAction {
+
+	public static Map<Integer, HttpSession> userSessionMap = new HashMap<>();
 
 	/**
 	 * This variable is only intended to be used by this class and the jsp which
@@ -84,6 +84,7 @@ public final class LoginAction extends DispatchAction {
 	private UserPropertyDAO propDao = SpringUtils.getBean(UserPropertyDAO.class);
 
 	private final SecurityManager securityManager = SpringUtils.getBean(SecurityManager.class);
+	private final UserSessionManager userSessionManager = SpringUtils.getBean(UserSessionManager.class);
 
 	// remove after testing is done
 	// private SsoAuthenticationManager ssoAuthenticationManager =
@@ -359,6 +360,10 @@ public final class LoginAction extends DispatchAction {
 			}
 			session = request.getSession(); // Create a new session for this user
 			session.setMaxInactiveInterval(7200); // 2 hours
+
+			if (security != null) {
+				this.userSessionManager.registerUserSession(security.getSecurityNo(), session);
+			}
 
 			// If the ondIdKey parameter is not null and is not an empty string
 			if (oneIdKey != null && !oneIdKey.equals("")) {


### PR DESCRIPTION
This code implements a user session management system to prevent multiple simultaneous logins with the same user credentials. Following are the changes and how they work together: 

- `UserSessionManager` interface: contract for managing user sessions. It includes methods for registering, unregistering, and retrieving sessions based on a user's security code.
- `UserSessionManagerImpl` class: Implements the `UserSessionManager` interface.  It uses a `Map` to store the sessions, keyed by the user's security code as an unique identifier.
- `LoginAction.java`: Upon successful login, the `registerUserSession` method of the `UserSessionManager` is called. This method stores the current `HttpSession` in the `userSessionMap`, associating it with the user's security code. If a session already exists for that user, the existing session is invalidated before the new session is registered, effectively logging out the other session.
- `OscarSessionListener.java`: This listener is triggered when a session is destroyed (e.g., user logout, session timeout). It calls the `unregisterUserSession` method of the new `UserSessionManager` to remove the session from the `userSessionMap`.
- `UserSessionNotFoundException`: Thrown when trying to unregister a session that doesn't exist in the `userSessionMap`.