### PR TITLE
[Ready for review] Add option to record an internal note to the echart when sending an email

### DIFF
--- a/database/mysql/updates/update-2025-01-29.sql
+++ b/database/mysql/updates/update-2025-01-29.sql
@@ -1,0 +1,1 @@
+ALTER TABLE emailLog ADD COLUMN internalComment BLOB DEFAULT '' AFTER chartDisplayOption;

--- a/src/main/java/org/oscarehr/common/model/EmailLog.java
+++ b/src/main/java/org/oscarehr/common/model/EmailLog.java
@@ -75,6 +75,10 @@ public class EmailLog extends AbstractModel<Integer> implements Comparable<Email
     @Enumerated(EnumType.STRING)
     private ChartDisplayOption chartDisplayOption;
 
+    @Lob
+    @Column(columnDefinition = "BLOB")
+    private byte[] internalComment;
+
     @Enumerated(EnumType.STRING)
     private TransactionType transactionType;
 
@@ -221,6 +225,14 @@ public class EmailLog extends AbstractModel<Integer> implements Comparable<Email
 
     public void setChartDisplayOption(ChartDisplayOption chartDisplayOption) {
         this.chartDisplayOption = chartDisplayOption;
+    }
+
+    public String getInternalComment() {
+        return new String(Base64.decodeBase64(internalComment), StandardCharsets.UTF_8);
+    }
+
+    public void setInternalComment(String internalComment) {
+        this.internalComment = Base64.encodeBase64(internalComment.getBytes(StandardCharsets.UTF_8));
     }
 
     public TransactionType getTransactionType() {

--- a/src/main/java/org/oscarehr/email/action/EmailSendAction.java
+++ b/src/main/java/org/oscarehr/email/action/EmailSendAction.java
@@ -80,6 +80,7 @@ public class EmailSendAction extends DispatchAction {
         String isEncrypted = request.getParameter("isEmailEncrypted");
         String isAttachmentEncrypted = request.getParameter("isEmailAttachmentEncrypted");
         String chartDisplayOption = request.getParameter("patientChartOption");
+        String internalComment = request.getParameter("internalComment");
         String transactionType = request.getParameter("transactionType");
         String demographicNo = request.getParameter("demographicId");
         String additionalParams = request.getParameter("additionalURLParams");
@@ -99,6 +100,7 @@ public class EmailSendAction extends DispatchAction {
         emailData.setIsEncrypted(isEncrypted);
         emailData.setIsAttachmentEncrypted(isAttachmentEncrypted);
         emailData.setChartDisplayOption(chartDisplayOption);
+        emailData.setInternalComment(internalComment);
         emailData.setTransactionType(transactionType);
         emailData.setDemographicNo(demographicNo);
         emailData.setProviderNo(providerNo);

--- a/src/main/java/org/oscarehr/email/admin/ManageEmails.java
+++ b/src/main/java/org/oscarehr/email/admin/ManageEmails.java
@@ -129,6 +129,7 @@ public class ManageEmails extends JSONAction {
 		request.setAttribute("isEmailEncrypted", emailLog.getIsEncrypted());
 		request.setAttribute("isEmailAttachmentEncrypted", emailLog.getIsAttachmentEncrypted());
 		request.setAttribute("emailPatientChartOption", emailLog.getChartDisplayOption().getValue());
+		request.setAttribute("internalComment", emailLog.getInternalComment());
 		request.setAttribute("emailAdditionalParams", emailLog.getAdditionalParams());
         request.getSession().setAttribute("emailAttachmentList", emailAttachmentList);
 

--- a/src/main/java/org/oscarehr/email/core/EmailData.java
+++ b/src/main/java/org/oscarehr/email/core/EmailData.java
@@ -20,6 +20,7 @@ public class EmailData {
     private boolean isEncrypted;
     private boolean isAttachmentEncrypted;
     private ChartDisplayOption chartDisplayOption;
+    private String internalComment;
     private TransactionType transactionType;
     private Integer demographicNo;
     private String providerNo;
@@ -121,6 +122,14 @@ public class EmailData {
     public void setChartDisplayOption(String chartDisplayOption) {
         if (chartDisplayOption == null) { chartDisplayOption = "addFullNote"; }
         this.chartDisplayOption = "doNotAddAsNote".equalsIgnoreCase(chartDisplayOption) ? ChartDisplayOption.WITHOUT_NOTE : ChartDisplayOption.WITH_FULL_NOTE;
+    }
+
+    public String getInternalComment() {
+        return internalComment;
+    }
+
+    public void setInternalComment(String internalComment) {
+        this.internalComment = internalComment != null ? internalComment : "";
     }
 
     public TransactionType getTransactionType() {

--- a/src/main/java/org/oscarehr/email/util/EmailNoteUtil.java
+++ b/src/main/java/org/oscarehr/email/util/EmailNoteUtil.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.oscarehr.common.model.EFormData;
 import org.oscarehr.common.model.EmailAttachment;
 import org.oscarehr.common.model.EmailLog;
+import org.oscarehr.common.model.EmailLog.ChartDisplayOption;
 import org.oscarehr.documentManager.EDoc;
 import org.oscarehr.documentManager.EDocUtil;
 import org.oscarehr.hospitalReportManager.HRMUtil;
@@ -52,6 +53,7 @@ public class EmailNoteUtil {
         addAttachments(emailLog, noteBuilder);
         addEncryptedBody(emailLog, noteBuilder);
         addTechnicalInformation(emailLog, noteBuilder);
+        addInternalComment(emailLog, noteBuilder);
         return noteBuilder.toString();
     }
 
@@ -191,6 +193,13 @@ public class EmailNoteUtil {
         noteBuilder.append("To: ").append(getRecipientEmail()).append("\n");        
         noteBuilder.append("Sent: ").append(getEmailTime()).append(" on ").append(getEmailDate()).append("\n");
         noteBuilder.append("Unique Email Log ID: ").append(emailLog.getId());
+    }
+
+    private void addInternalComment(EmailLog emailLog, StringBuilder noteBuilder) {
+        if (emailLog.getChartDisplayOption().equals(ChartDisplayOption.WITHOUT_NOTE)) { return; }
+
+        noteBuilder.append("\n\n").append("***Internal Comment***").append("\n\n");
+        noteBuilder.append(emailLog.getInternalComment());
     }
 
     private String getRecipientEmail() {

--- a/src/main/java/org/oscarehr/managers/EmailManager.java
+++ b/src/main/java/org/oscarehr/managers/EmailManager.java
@@ -108,6 +108,7 @@ public class EmailManager {
         emailLog.setIsEncrypted(emailData.getIsEncrypted());
         emailLog.setIsAttachmentEncrypted(emailData.getIsAttachmentEncrypted());
         emailLog.setChartDisplayOption(emailData.getChartDisplayOption());
+        emailLog.setInternalComment(emailData.getInternalComment());
         emailLog.setTransactionType(emailData.getTransactionType());
         emailLog.setErrorMessage("Email was not sent successfully for unknown reasons.");
         emailLog.setAdditionalParams(emailData.getAdditionalParams());
@@ -225,6 +226,10 @@ public class EmailManager {
             emailData.setIsAttachmentEncrypted(false);
             emailData.setPassword("");
             emailData.setPasswordClue("");
+        }
+
+        if (emailData.getChartDisplayOption().equals(ChartDisplayOption.WITHOUT_NOTE)) {
+            emailData.setInternalComment("");
         }
     }
 

--- a/src/main/webapp/email/emailCompose.jsp
+++ b/src/main/webapp/email/emailCompose.jsp
@@ -401,7 +401,7 @@
 									<label>Chart options</label>
 									<div class="form-check">
 										<div class="form-check-label">
-											<input class="form-check-input" type="radio" name="patientChartOption" id="doNotAddAsNoteOption" value="doNotAddAsNote">
+											<input class="form-check-input" type="radio" name="patientChartOption" id="doNotAddAsNoteOption" value="doNotAddAsNote" onClick="toggleInternalTextArea()">
 											<label class="form-check-label" for="doNotAddAsNoteOption">
 												Do not add to patient chart
 											</label>
@@ -409,10 +409,13 @@
 									</div>
 									<div class="form-check">
 										<div class="form-check-label">
-											<input class="form-check-input" type="radio" name="patientChartOption" id="addFullNoteOption" value="addFullNote" checked>
+											<input class="form-check-input" type="radio" name="patientChartOption" id="addFullNoteOption" value="addFullNote" checked onClick="toggleInternalTextArea()">
 											<label class="form-check-label" for="addFullNoteOption">
 												Chart as new note in patient's chart
 											</label>
+										</div>
+										<div id="internalCommentContainer" class="d-none">
+											<textarea class="form-control" id="internalComment" name="internalComment" placeholder="Internal comment to include" rows="3"><c:out value="${ not empty param.internalComment ? param.internalComment : internalComment }" /></textarea>
 										</div>
 									</div>
 								</div>
@@ -533,6 +536,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
 	// Show additional field option if API type sender is selected
 	showAdditionalParamOption();
+
+	// Toggle internal note text area
+	toggleInternalTextArea();
 });
 
 document.addEventListener("keydown", function(event) {
@@ -740,6 +746,17 @@ function showErrorAndClose() {
 	const errorMessage = document.getElementById('emailErrorMessage').value.replace(/\\n/g, '\n');
 	alert(errorMessage);
 	window.close();
+}
+
+function toggleInternalTextArea() {
+	const addFullNoteOption = document.getElementById('addFullNoteOption');
+	const internalCommentContainer = document.getElementById('internalCommentContainer');
+
+	if (addFullNoteOption.checked) {
+		internalCommentContainer.classList.remove('d-none'); // Show the textarea
+	} else {
+		internalCommentContainer.classList.add('d-none'); // Hide the textarea
+	}
 }
 
 </script>


### PR DESCRIPTION
Providers have expressed that they would like the ability to record some internal notes that would not be shared with the patient when sending emails. 

This PR enhances the email module by a textarea that is only visible when "Chart as new note in patient's chart" is selected. The text is NOT sent to the patient, and is recorded with the email content in the patient's echart.

![image](https://github.com/user-attachments/assets/1900e97e-6a5b-40cd-bee6-93efbce9c951)

![image](https://github.com/user-attachments/assets/f35aeaaf-c59e-4c18-9a09-de04da598106)


(Tagging @D3V41 to receive updates.)