### PR TITLE
Track Password Update Date when password-hash upgrades 

### DIFF
--- a/src/main/java/org/oscarehr/managers/SecurityManager.java
+++ b/src/main/java/org/oscarehr/managers/SecurityManager.java
@@ -164,6 +164,7 @@ public class SecurityManager {
 			return false;
 
 		security.setPassword(hash);
+		security.setPasswordUpdateDate(new Date());
 		this.securityDao.merge(security);
 		return true;
 	}


### PR DESCRIPTION
Updated `SecurityManager.upgradeSavePasswordHash()` method to also update the `passwordUpdateDate` field in the `security` object when the password is changed.  This adds a timestamp to track when the password was last modified.

 ###### Suggested by @D3V41.