### PR TITLE
Handle missing _email security object in eForms and eChart notes

### DIFF
--- a/src/main/java/org/oscarehr/managers/EmailComposeManager.java
+++ b/src/main/java/org/oscarehr/managers/EmailComposeManager.java
@@ -7,6 +7,7 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -22,6 +23,7 @@ import org.oscarehr.common.model.Demographic;
 import org.oscarehr.common.model.EmailAttachment;
 import org.oscarehr.common.model.EmailConfig;
 import org.oscarehr.common.model.EmailLog;
+import org.oscarehr.common.model.SecObjectName;
 import org.oscarehr.common.model.UserProperty;
 import org.oscarehr.common.model.enumerator.DocumentType;
 import org.oscarehr.documentManager.DocumentAttachmentManager;
@@ -229,6 +231,11 @@ public class EmailComposeManager {
     public String createEmailPDFPassword(LoggedInInfo loggedInInfo, Integer demographicId) {
         Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographicId);
         return demographic.getYearOfBirth() + demographic.getMonthOfBirth() + demographic.getDateOfBirth() + demographic.getHin();
+    }
+
+    public boolean hasEmailPrivilege(LoggedInInfo loggedInInfo, String privilege) {
+        boolean hasEmailPrivilege = securityInfoManager.hasPrivilege(loggedInInfo, "_email", privilege, null);
+        return hasEmailPrivilege;
     }
 
     private boolean isValidEmail(String email) {

--- a/src/main/webapp/casemgmt/ChartNotesAjax.jsp
+++ b/src/main/webapp/casemgmt/ChartNotesAjax.jsp
@@ -65,6 +65,8 @@
 <%@page import="org.oscarehr.common.model.CasemgmtNoteLock"%>
 <%@page import="org.oscarehr.common.model.EmailLog"%>
 <%@page import="org.oscarehr.managers.EmailManager"%>
+<%@page import="org.oscarehr.managers.EmailComposeManager"%>
+<%@page import="org.oscarehr.managers.SecurityInfoManager"%>
 
 <%
     String roleName2$ = (String)session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -88,6 +90,7 @@ Facility facility = loggedInInfo.getCurrentFacility();
 ProfessionalSpecialistDao professionalSpecialistDao=(ProfessionalSpecialistDao)SpringUtils.getBean(ProfessionalSpecialistDao.class);
 
 EmailManager emailManager = SpringUtils.getBean(EmailManager.class);
+EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManager.class);
 
 String pId = (String)session.getAttribute("case_program_id");
 Program program = null;
@@ -317,6 +320,7 @@ CasemgmtNoteLock casemgmtNoteLock = (CasemgmtNoteLock)session.getAttribute("case
 				} else if (note.isInvoice()) {
 					globalNoteId = "INV" + note.getNoteId();
 				} else if (note.isEmailNote()) {
+					if (!emailComposeManager.hasEmailPrivilege(loggedInInfo, SecurityInfoManager.READ)) { continue; }
 					EmailLog emailLog = emailManager.getEmailLogByCaseManagementNoteId(loggedInInfo, Long.valueOf(noteId));
 					if (emailLog == null) { continue; }
 					dispDocNo = String.valueOf(emailLog.getId());

--- a/src/main/webapp/eform/efmformadd_data.jsp
+++ b/src/main/webapp/eform/efmformadd_data.jsp
@@ -26,6 +26,7 @@
 
 <%@ page import="oscar.eform.data.*"%>
 <%@ page import="org.oscarehr.managers.EmailComposeManager"%>
+<%@ page import="org.oscarehr.managers.SecurityInfoManager"%>
 <%@ page import="org.oscarehr.util.SpringUtils"%>
 <%@ page import="org.oscarehr.util.LoggedInInfo"%>
 <%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html"%>
@@ -61,6 +62,11 @@
 <%!
     public void addHiddenEmailProperties(LoggedInInfo loggedInInfo, EForm thisEForm, String demographicNo) {
         EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManager.class);
+        if (!emailComposeManager.hasEmailPrivilege(loggedInInfo, SecurityInfoManager.WRITE)) { 
+            thisEForm.addHiddenInputElement("hasEmailPrivilege", Boolean.FALSE.toString());
+            return; 
+        }
+
         Boolean hasValidRecipient = emailComposeManager.hasValidRecipient(loggedInInfo, Integer.parseInt(demographicNo));
         String[] emailConsent = emailComposeManager.getEmailConsentStatus(loggedInInfo, Integer.parseInt(demographicNo));
 

--- a/src/main/webapp/eform/efmshowform_data.jsp
+++ b/src/main/webapp/eform/efmshowform_data.jsp
@@ -31,6 +31,7 @@
 <%@ page import="org.oscarehr.common.model.enumerator.DocumentType"%>
 <%@ page import="org.oscarehr.documentManager.DocumentAttachmentManager"%>
 <%@ page import="org.oscarehr.managers.EmailComposeManager"%>
+<%@ page import="org.oscarehr.managers.SecurityInfoManager"%>
 <%@ page import="org.oscarehr.util.SpringUtils"%>
 <%@ page import="oscar.util.StringUtils" %>
 <%@ page import="java.util.List"%>
@@ -52,6 +53,11 @@
 
     public void addHiddenEmailProperties(LoggedInInfo loggedInInfo, EForm eForm, String demographicNo) {
         EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManager.class);
+        if (!emailComposeManager.hasEmailPrivilege(loggedInInfo, SecurityInfoManager.WRITE)) { 
+            eForm.addHiddenInputElement("hasEmailPrivilege", Boolean.FALSE.toString());
+            return; 
+        }
+        
         Boolean hasValidRecipient = emailComposeManager.hasValidRecipient(loggedInInfo, Integer.parseInt(demographicNo));
         String[] emailConsent = emailComposeManager.getEmailConsentStatus(loggedInInfo, Integer.parseInt(demographicNo));
 

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -711,6 +711,9 @@ function remoteSave() {
 
 					// After adding floating toolbar update number of attachments
 					jQuery('#remoteTotalAttachments').empty().append(jQuery('.delegateAttachment').length);
+
+					// Check email privilege and if not, hide the Email button.
+					handleEmailPrivilege();
 				}
 
 				if (this.status === 404)
@@ -839,3 +842,16 @@ function remoteSave() {
 			})
 		}
 	})
+
+	function handleEmailPrivilege() {
+		// Get the value of the element with ID 'hasEmailPrivilege'
+		const hasEmailPrivilege = document.getElementById('hasEmailPrivilege');
+		
+		if (hasEmailPrivilege) {
+			const value = hasEmailPrivilege.value.toLowerCase();
+			if (value === 'false') {
+				// If 'hasEmailPrivilege' is false, hide the 'remoteEmailButton'
+				document.getElementById('remoteEmailButton').style.display = 'none';
+			}
+		}
+	}


### PR DESCRIPTION
This PR fixes the issue where eforms could not be accessed if a user was missing the `_email` security object.

**To replicate the original issue:**
Completely remove the _email security object from all roles and users.  Then try to open an eForm from anywhere.

**Observed result:**
500 error 

**Expected result:**
eForms should open  - and without displaying the Email button in the floating toolbar.

(Tagging @D3V41 to receive updates)