### PR TITLE
v24.09-hotfix: Prevent document deletion in refile process

### DIFF
--- a/src/main/java/org/oscarehr/documentManager/EDocUtil.java
+++ b/src/main/java/org/oscarehr/documentManager/EDocUtil.java
@@ -855,7 +855,6 @@ public final class EDocUtil {
                     throw new IOException("Cannot refile document #"+documentNo+ " "+d.getDocdesc()+". Destination File " + destFile.getAbsolutePath() + " already exists");
                 } else {
                     FileUtils.copyFile(sourceFile, destFile);
-                    EDocUtil.deleteDocument(documentNo);
                 }
             } catch (IOException e) {
                 logger.error("Error", e);
@@ -1300,4 +1299,24 @@ public final class EDocUtil {
         	return pagecount;
         }
 
+	/**
+	 * Checks if a document with the given filename has already been refiled in the specified queue.
+	 *
+	 * @see #refileDocument(String, String)
+	 * @param filename The original filename of the document.
+	 * @param queueId  The ID of the queue where the document might have been refiled.
+	 * @return {@code true} if a document with the refiled name exists in the queue's refile directory,
+	 * {@code false} otherwise.
+	 */
+	public static boolean isDocumentAlreadyRefiledInQueue(String filename, int queueId) {
+		String destFileName = filename;
+		if (destFileName.length() > 18) {
+			destFileName = destFileName.substring(14, filename.length());
+		}
+
+		String destPath = IncomingDocUtil.getIncomingDocumentFilePath(String.valueOf(queueId), "Refile");
+		File destFile = new File(destPath, "R" + destFileName);
+		return destFile.exists();
 	}
+
+}

--- a/src/main/webapp/documentManager/showDocument.jsp
+++ b/src/main/webapp/documentManager/showDocument.jsp
@@ -143,7 +143,9 @@
             String cp=request.getContextPath() ;
             String url = cp+"/documentManager/ManageDocument.do?method=viewDocPage&doc_no=" + docId+"&curPage=1";
             String url2 = cp+"/documentManager/ManageDocument.do?method=display&doc_no=" + docId;
-            String currentDate = new SimpleDateFormat("yyyy-MM-dd").format(new Date());	
+            String currentDate = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+
+            Integer docCurrentFiledQueue = null;
 %>
 
 <c:if test="${param.inWindow eq 'true'}">
@@ -303,14 +305,29 @@
                                                         <input type="button" id="mainTickler_<%=docId%>" value="Tickler" onClick="popupPatientTicklerPlus(710, 1024,'${pageContext.servletContext.contextPath}/Tickler.do?', 'Tickler','<%=docId%>')" <%=btnDisabled %>>
                                                         <% } else { %>
                                                         <input type="button" id="mainTickler_<%=docId%>" value="Tickler" onClick="popupPatientTickler(710, 1024,'${pageContext.servletContext.contextPath}/tickler/ticklerAdd.jsp?', 'Tickler','<%=docId%>')" <%=btnDisabled %>>
-                                                        <% } %>
-                                                        
+                                                        <% }
+
+                                                            String refileBtnVisibility = "";
+                                                            for (Hashtable ht : queues) {
+                                                                int id = (Integer) ht.get("id");
+
+                                                                if (EDocUtil.isDocumentAlreadyRefiledInQueue(curdoc.getDescription(), id)) {
+                                                                    docCurrentFiledQueue = id;
+                                                                    if (id == queueId) {
+                                                                        refileBtnVisibility = "disabled";
+                                                                        break;
+                                                                    }
+                                                                }
+                                                            }
+                                                        %>
+
                                                         <input type="button" id="mainEchart_<%=docId%>" value=" <bean:message key="oscarMDS.segmentDisplay.btnEChart"/> " onClick="popupPatient(710, 1024,'${pageContext.servletContext.contextPath}/oscarEncounter/IncomingEncounter.do?reason=<bean:message key="oscarMDS.segmentDisplay.labResults"/>&curDate=<%=currentDate%>>&appointmentNo=&appointmentDate=&startTime=&status=&demographicNo=', 'encounter', '<%=docId%>')" <%=btnDisabled %>>
                                                         <input type="button" id="mainMaster_<%=docId%>" value=" <bean:message key="oscarMDS.segmentDisplay.btnMaster"/>" onClick="popupPatient(710,1024,'${pageContext.servletContext.contextPath}/demographic/demographiccontrol.jsp?displaymode=edit&dboperation=search_detail&demographic_no=','master','<%=docId%>')" <%=btnDisabled %>>
                                                         <input type="button" id="mainApptHistory_<%=docId%>" value=" <bean:message key="oscarMDS.segmentDisplay.btnApptHist"/>" onClick="popupPatient(710,1024,'${pageContext.servletContext.contextPath}/demographic/demographiccontrol.jsp?orderby=appttime&displaymode=appt_history&dboperation=appt_history&limit1=0&limit2=25&demographic_no=','ApptHist','<%=docId%>')" <%=btnDisabled %>>
 
-                                                        <input type="button" id="refileDoc_<%=docId%>" value="<bean:message key="oscarEncounter.noteBrowser.msgRefile"/>" onclick="refileDoc('<%=docId%>');" >
-                                                        <select  id="queueList_<%=docId%>" name="queueList"> 
+                                                        <input type="button" id="refileDoc_<%=docId%>" value="<bean:message key="oscarEncounter.noteBrowser.msgRefile"/>" onclick="refileDoc('<%=docId%>');" <%=refileBtnVisibility%> >
+                                                        <select  id="queueList_<%=docId%>" name="queueList"
+                                                                 onchange="handleQueueListChange(this, document.getElementById('refileDoc_<%=docId%>'), '<%=docCurrentFiledQueue%>')">
                                                             <%
                                                             for (Hashtable ht : queues) {
                                                                 int id = (Integer) ht.get("id");

--- a/src/main/webapp/share/javascript/oscarMDSIndex.js
+++ b/src/main/webapp/share/javascript/oscarMDSIndex.js
@@ -1824,6 +1824,10 @@ function fileDoc(docId){
 	}
 }
 
+function handleQueueListChange(queueListSelectElement, refileBtnElement, docCurrentFiledQueue) {
+	refileBtnElement.disabled = queueListSelectElement.value === docCurrentFiledQueue;
+}
+
 function refileDoc(id) {
     var queueId=document.getElementById('queueList_'+id).options[document.getElementById('queueList_'+id).selectedIndex].value;
     var url=contextpath +"/documentManager/ManageDocument.do";


### PR DESCRIPTION
- Removed the call to `EDocUtil.deleteDocument` during the refile operation.
- Ensured that documents are not deleted when refiled, preserving their status.
- Added logic to disable "Refile" button if the document is already filed in the selected queue.