### PR TITLE
Remove demographic-specific EctSessionBean keys from Session

### DIFF
--- a/src/main/java/org/oscarehr/casemgmt/service/CaseManagementPrint.java
+++ b/src/main/java/org/oscarehr/casemgmt/service/CaseManagementPrint.java
@@ -80,7 +80,7 @@ public class CaseManagementPrint {
 		request.setAttribute("demoSex", getDemoSex(demono));
 		request.setAttribute("demoAge", getDemoAge(demono));
 		request.setAttribute("demoPhn", getDemoPhn(demono));
-		request.setAttribute("mrp", getMRP(request,demono));
+		request.setAttribute("mrp", getMRP(request));
 		String dob = getDemoDOB(demono);
 		dob = convertDateFmt(dob, request);
 		request.setAttribute("demoDOB", dob);
@@ -489,9 +489,8 @@ public class CaseManagementPrint {
 		return caseManagementMgr.getDemoPhn(demoNo);
 	}
 	
-	protected String getMRP(HttpServletRequest request,String demographicNo) {
-		String strBeanName = "casemgmt_oscar_bean" + demographicNo;
-		oscar.oscarEncounter.pageUtil.EctSessionBean bean = (oscar.oscarEncounter.pageUtil.EctSessionBean) request.getSession().getAttribute(strBeanName);
+	protected String getMRP(HttpServletRequest request) {
+        oscar.oscarEncounter.pageUtil.EctSessionBean bean = (oscar.oscarEncounter.pageUtil.EctSessionBean) request.getSession().getAttribute("EctSessionBean");
 		if (bean == null) return new String("");
 		if (bean.familyDoctorNo == null) return new String("");
 		if (bean.familyDoctorNo.isEmpty()) return new String("");

--- a/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntryAction.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntryAction.java
@@ -179,8 +179,7 @@ public class CaseManagementEntryAction extends BaseCaseManagementEntryAction {
 
 			String province = OscarProperties.getInstance().getProperty("billregion", "").trim().toUpperCase();
 
-			String strBeanName = "casemgmt_oscar_bean" + demono;
-			EctSessionBean bean = (EctSessionBean) session.getAttribute(strBeanName);
+            EctSessionBean bean = (EctSessionBean) session.getAttribute("EctSessionBean");
 
 			if (bean.appointmentNo == null) {
 				bean.appointmentNo = "0";
@@ -259,8 +258,7 @@ public class CaseManagementEntryAction extends BaseCaseManagementEntryAction {
 				note.setEncounter_type("");
 			}
 
-			String strBeanName = "casemgmt_oscar_bean" + demono;
-			EctSessionBean bean = (EctSessionBean) session.getAttribute(strBeanName);
+            EctSessionBean bean = (EctSessionBean) session.getAttribute("EctSessionBean");
 			String encType = request.getParameter("encType");
 
 			if (encType == null || encType.equals("")) {
@@ -467,8 +465,7 @@ public class CaseManagementEntryAction extends BaseCaseManagementEntryAction {
 			note.setNote("");
 			note.setEncounter_type("");
 		}
-		String strBeanName = "casemgmt_oscar_bean" + demographicNo;
-		EctSessionBean bean = (EctSessionBean) request.getSession().getAttribute(strBeanName);
+        EctSessionBean bean = (EctSessionBean) request.getSession().getAttribute("EctSessionBean");
 		String encType = request.getParameter("encType");
 
 		if (encType == null || encType.equals("")) {
@@ -1346,8 +1343,7 @@ public class CaseManagementEntryAction extends BaseCaseManagementEntryAction {
 		//Ongoing 
 
 		// update appointment and add verify message to note if verified
-		String strBeanName = "casemgmt_oscar_bean" + demo;
-		EctSessionBean sessionBean = (EctSessionBean) session.getAttribute(strBeanName);
+        EctSessionBean sessionBean = (EctSessionBean) session.getAttribute("EctSessionBean");
 		String verifyStr = request.getParameter("verify");
 		boolean verify = false;
 		if (verifyStr != null && verifyStr.equalsIgnoreCase("on")) {
@@ -2766,10 +2762,9 @@ public class CaseManagementEntryAction extends BaseCaseManagementEntryAction {
 	public ActionForward cleanup(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) {
 		String demoNo = this.getDemographicNo(request);
 		String sessionFrmName = "caseManagementEntryForm" + demoNo;
-		String strBeanName = "casemgmt_oscar_bean" + demoNo;
 
-		request.getSession().setAttribute(sessionFrmName, null);
-		request.getSession().setAttribute(strBeanName, null);
+        request.getSession().setAttribute(sessionFrmName, null);
+		request.getSession().setAttribute("EctSessionBean", null);
 
 		return null;
 	}

--- a/src/main/java/org/oscarehr/ws/rest/NotesService.java
+++ b/src/main/java/org/oscarehr/ws/rest/NotesService.java
@@ -1166,8 +1166,7 @@ public class NotesService extends AbstractServiceImpl {
 		
 
 		logger.debug("Get Note for editing");
-		String strBeanName = "casemgmt_oscar_bean" + demographicNo;
-		EctSessionBean bean = (EctSessionBean) loggedInInfo.getSession().getAttribute(strBeanName);
+		EctSessionBean bean = (EctSessionBean) loggedInInfo.getSession().getAttribute("EctSessionBean");
 		String encType = getString(jsonobject,"encType");
 		
 		logger.debug("Encounter Type : "+encType);

--- a/src/main/java/oscar/oscarEncounter/pageUtil/EctIncomingEncounterAction.java
+++ b/src/main/java/oscar/oscarEncounter/pageUtil/EctIncomingEncounterAction.java
@@ -107,7 +107,7 @@ public class EctIncomingEncounterAction extends Action {
 			}
 		}
 
-		EctSessionBean bean = new EctSessionBean();
+		EctSessionBean bean;
 		String appointmentNo = null;
 
 		if (request.getSession().getAttribute("cur_appointment_no") != null) {

--- a/src/main/webapp/casemgmt/ChartNotes.jsp
+++ b/src/main/webapp/casemgmt/ChartNotes.jsp
@@ -123,9 +123,8 @@ try
     }
 
 	String demographicNo = request.getParameter("demographicNo");
-	oscar.oscarEncounter.pageUtil.EctSessionBean bean = null;
-	String strBeanName = "casemgmt_oscar_bean" + demographicNo;
-	if ((bean = (oscar.oscarEncounter.pageUtil.EctSessionBean)request.getSession().getAttribute(strBeanName)) == null)
+	oscar.oscarEncounter.pageUtil.EctSessionBean bean;
+	if ((bean = (oscar.oscarEncounter.pageUtil.EctSessionBean)request.getSession().getAttribute("EctSessionBean")) == null)
 	{
 		response.sendRedirect("error.jsp");
 		return;

--- a/src/main/webapp/casemgmt/ChartNotesAjax.jsp
+++ b/src/main/webapp/casemgmt/ChartNotesAjax.jsp
@@ -102,9 +102,8 @@ if (pId == null) {
 }
 
 String demographicNo = request.getParameter("demographicNo");
-oscar.oscarEncounter.pageUtil.EctSessionBean bean = null;
-String strBeanName = "casemgmt_oscar_bean" + demographicNo;
-if ((bean = (oscar.oscarEncounter.pageUtil.EctSessionBean)request.getSession().getAttribute(strBeanName)) == null)
+oscar.oscarEncounter.pageUtil.EctSessionBean bean;
+if ((bean = (oscar.oscarEncounter.pageUtil.EctSessionBean)request.getSession().getAttribute("EctSessionBean")) == null)
 {
 	response.sendRedirect("error.jsp");
 	return;

--- a/src/main/webapp/oscarEncounter/Index2.jsp
+++ b/src/main/webapp/oscarEncounter/Index2.jsp
@@ -130,8 +130,6 @@ You have no rights to access the data!
             EctProgram prgrmMgr = new EctProgram(session);
             session.setAttribute("case_program_id", prgrmMgr.getProgram(bean.providerNo));
             session.setAttribute("casemgmt_oscar_baseurl",request.getContextPath());
-            String strBeanName = "casemgmt_oscar_bean" + bean.getDemographicNo();
-            session.setAttribute(strBeanName, bean);
             session.setAttribute("casemgmt_bean_flag", "true");
                     String hrefurl=request.getContextPath()+"/casemgmt/forward.jsp?action=view&demographicNo="+bean.demographicNo+"&providerNo="+bean.providerNo+"&providerName="+URLEncoder.encode(bean.userName)+"&appointmentNo="+request.getParameter("appointmentNo")+"&reason=" + URLEncoder.encode(request.getParameter("reason")==null?"":request.getParameter("reason")) + "&appointmentDate="+request.getParameter("appointmentDate")+"&start_time="+request.getParameter("startTime")+ "&apptProvider=" + request.getParameter("apptProvider_no")+"&providerview="+ request.getParameter("providerview") +
                     "&msgType="+request.getParameter("msgType")+"&OscarMsgTypeLink="+request.getParameter("OscarMsgTypeLink")+"&noteId="+request.getParameter("noteId")+(request.getParameter("noteId") != null ? "&forceNote=true" :"");
@@ -156,8 +154,6 @@ You have no rights to access the data!
 <caisi:isModuleLoad moduleName="caisi">
 	<%
 session.setAttribute("casemgmt_oscar_baseurl",request.getContextPath());
-String strBeanName = "casemgmt_oscar_bean" + bean.getDemographicNo();
-session.setAttribute(strBeanName, bean);
 session.setAttribute("casemgmt_oscar_bean", bean);
 session.setAttribute("casemgmt_bean_flag", "true");
 String hrefurl=request.getContextPath()+"/casemgmt/forward.jsp?action=view&demographicNo="+bean.demographicNo+"&providerNo="+bean.providerNo+"&providerName="+bean.userName;


### PR DESCRIPTION
- Removed usage of `"casemgmt_oscar_bean" + demographicNo` _(casemgmt_oscar_bean1234)_
- Use a single session attribute `EctSessionBean` for all demographics.
- Update all relevant java and jsp files to reflect this change.

![image](https://github.com/user-attachments/assets/94d201e9-9300-41ae-8db8-a41492364ab0)
