### PR TITLE
fix(oscarRx): remove random number suffix from checkbox ID

### DIFF
--- a/src/main/java/oscar/oscarRx/pageUtil/RxRePrescribeAction.java
+++ b/src/main/java/oscar/oscarRx/pageUtil/RxRePrescribeAction.java
@@ -315,7 +315,7 @@ public final class RxRePrescribeAction extends DispatchAction {
 			try {
 				rand = Long.parseLong(request.getParameter("rand"));
 			} catch (NumberFormatException e) {
-				rand = Math.round(Math.random() * 1000000);
+				rand = Math.round(Math.random() * 10001);
 			}
 			rx.setRandomId(rand);
 

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -326,7 +326,7 @@ if (heading != null){
             <td width="20px" align="center" valign="top">
                 <%if (prescriptDrug.getRemoteFacilityName() == null) {%>
                 <div style="display: flex; align-items: center;">
-                    <% String cbxId = "reRxCheckBox_" + prescriptIdInt + Math.abs(new Random().nextInt(10001)); %>
+                    <% String cbxId = "reRxCheckBox_" + prescriptIdInt; %>
                     <input id="<%=cbxId%>" type=CHECKBOX
                            onclick="updateReRxStatusForPrescribedDrug(this, <%=prescriptIdInt%>)"
                            <%if(reRxDrugList.contains(prescriptIdInt.toString())){%>checked<%}%>


### PR DESCRIPTION
- Resolved an issue where the random value used in Rx RePrescribe functionality caused parsing errors when further code is performing 'Integer.ParseInt'
- Updated the random ID generation logic:
  - Removed random number concatenation in `ListDrugs.jsp`.
  - Limited the random number range in `RxRePrescribeAction.java` to ensure values remain within the acceptable range for parsing.