### PR TITLE
Tweak - Automatically resizing note window

### DIFF
--- a/src/main/webapp/casemgmt/ChartNotesAjax.jsp
+++ b/src/main/webapp/casemgmt/ChartNotesAjax.jsp
@@ -1016,7 +1016,12 @@ CasemgmtNoteLock casemgmtNoteLock = (CasemgmtNoteLock)session.getAttribute("case
         document.forms["caseManagementEntryForm"].note_edit.value = "existing";
     <%}%>
     setupNotes();
-    Element.observe(caseNote, "keyup", monitorCaseNote);
+	jQuery('#' + caseNote).on('keyup', monitorCaseNote);
+	jQuery('#' + caseNote).on('paste', function(e) {
+		// Let the paste happen first, then resize
+		setTimeout(adjustCaseNote, 0);
+	});
+	
     Element.observe(caseNote, 'click', getActiveText);
     <%Integer num;
 			Iterator<Integer> iterator = lockedNotes.iterator();

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -1403,7 +1403,8 @@ function changeToView(id) {
         Element.remove("notePasswd");
     }
 
-    Element.stopObserving(id, 'keyup', monitorCaseNote);
+    jQuery('#' + id).off('keyup', monitorCaseNote);
+    jQuery('#' + caseNote).off('paste');
     Element.stopObserving(id, 'click', getActiveText);
 
     Element.remove(id);
@@ -2013,7 +2014,11 @@ function editNote(e) {
         Element.stopObserving(txt, 'click', fullView);
     }
 
-    Element.observe(caseNote, 'keyup', monitorCaseNote);
+    jQuery('#' + caseNote).on('keyup', monitorCaseNote);
+    jQuery('#' + caseNote).on('paste', function(e) {
+		// Let the paste happen first, then resize
+		setTimeout(adjustCaseNote, 0);
+	});
     Element.observe(caseNote, 'click', getActiveText);
 
     if( passwordEnabled ) {
@@ -2932,7 +2937,11 @@ function newNote(e) {
         if( reason.length > 0 )
             setCaretPosition($(caseNote),$(caseNote).value.length);
 
-        Element.observe(caseNote, 'keyup', monitorCaseNote);
+        jQuery('#' + caseNote).on('keyup', monitorCaseNote);
+        jQuery('#' + caseNote).on('paste', function(e) {
+            // Let the paste happen first, then resize
+            setTimeout(adjustCaseNote, 0);
+        });
         Element.observe(caseNote, 'click', getActiveText);
 
         origCaseNote = $F(caseNote);
@@ -3094,7 +3103,7 @@ function monitorCaseNote(e) {
 
     var MAXCHARS = 78;
     var MINCHARS = -10;
-    var newChars = $(caseNote).value.length - numChars;
+    var newChars = jQuery('#' + caseNote).val().length - numChars;
     var newline = false;
 
     if( e.keyCode == 13)
@@ -3624,7 +3633,8 @@ function autoCompleteShowMenuCPP(element, update) {
                     Element.remove("notePasswd");
                 }
 
-                Element.stopObserving(caseNote, 'keyup', monitorCaseNote);
+                jQuery('#' + caseNote).off('keyup', monitorCaseNote);
+                jQuery('#' + caseNote).off('paste');
                 Element.stopObserving(caseNote, 'click', getActiveText);
 
                 Element.remove(caseNote);


### PR DESCRIPTION
**Status Quo:**

If you use the mouse (not keyboard) to paste a long template into a note, it does NOT automatically resize.  It only automatically resizes if you use a keyboard:

![image](https://github.com/user-attachments/assets/eab29747-4515-4377-95b5-08c5b389eec9)

**Change:**

We trigger the auto resize automatically 

![image](https://github.com/user-attachments/assets/8e1a4cd2-3406-4417-a6b8-ca44b127ded3)
