### PR TITLE
Automatically closing email window after successful send

### DIFF
--- a/src/main/webapp/email/emailCompose.jsp
+++ b/src/main/webapp/email/emailCompose.jsp
@@ -486,9 +486,10 @@
 	<c:if test="${ not empty isEmailSuccessful }">
 		<c:choose>
 			<c:when test="${ emailLog.status eq 'SUCCESS' }">
-				<div class="alert alert-success" role="alert">
+				<div class="alert alert-success" role="alert" id="successMessage">
 					<p>Your email to <b><c:out value="${fn:join(emailLog.toEmail, ', ')}" /></b> was successfully sent.</p>
-				</div>								
+				</div>
+				<p class="mt-1" id="windowCloseMessage">This window will close in <b>3</b> seconds...</p>								
 			</c:when>
 			<c:otherwise>
 				<div class="alert alert-danger" role="alert">
@@ -516,6 +517,13 @@ document.addEventListener("DOMContentLoaded", function () {
 	if (document.getElementById('isEmailSuccessful').value === 'true' || document.getElementById('isEmailSuccessful').value === 'false') {
 		// Open EForm again on sent
 		openEFormAfterSend();
+
+		if (document.getElementById('isEmailSuccessful').value === 'true') {
+			// Close the window after 3 seconds
+			setTimeout(() => {
+				window.close();
+			}, 3000);
+		}
 		return;
 	}
 


### PR DESCRIPTION
**Status Quo:**

After an email is successfully sent, a window is left open that the user has to manually close.

![image](https://github.com/user-attachments/assets/915d72eb-2c8a-481a-944c-229b5fd812a3)

**Complaint**

Clicks, clicks, and more clicks!

**Change**

If the email is successfully sent, this window will automatically close after 3 seconds.  It will NOT auto-close if the email was not successfully sent.

![image](https://github.com/user-attachments/assets/263303d7-7e7c-4f94-968c-a0756142be5c)
