### PR TITLE
(NOT READY FOR REVIEW) Automatically closing rx fax window after succesfully generating the fax

### DIFF
--- a/src/main/java/oscar/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/oscar/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -165,7 +165,7 @@ public class FrmCustomedPDFServlet extends HttpServlet {
 
 					if (validFaxNumber) {
 						LogAction.addLog(provider_no, LogConst.SENT, LogConst.CON_FAX, "PRESCRIPTION " + pdfFile);
-						writer.println("<div id='fax-success' style='color:green;'><h3>Fax successfully generated</h3><p>" + pharmaName + " (" + faxNo + ")</p></div>");
+						writer.println("<div id='fax-success' style='color:green;'><h3>Fax successfully generated</h3><p>" + pharmaName + " (" + faxNo + ")</p><br><p>This window will close in <b>3</b> seconds...</p></div><script>setTimeout(() => window.top.close(), 3000);</script>");
 					}
 				}
 			} else {


### PR DESCRIPTION
**Status Quo:**

After faxing a prescription, the window is left open and needs to be manually closed.

![image](https://github.com/user-attachments/assets/c5f98830-cc90-4f5d-af39-31cf3b6bee76)

**Complaint**

Clicks, clicks, and more clicks!

**Change**

Automatically close this window after 3 seconds if the fax was successfully generated.

![image](https://github.com/user-attachments/assets/c62f6a95-38b1-4491-9c01-529926217962)
