### PR TITLE
Bugfix adding null check to prevent NPE in DisplayDemographicConsultationRequests.jsp

### DIFF
--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/DisplayDemographicConsultationRequests.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/DisplayDemographicConsultationRequests.jsp
@@ -203,7 +203,7 @@ function popupOscarConS(vheight,vwidth,varpage) { //open a new popup window
 							href="javascript:popupOscarRx(700,960,'../../oscarEncounter/ViewRequest.do?de=<%=demo%>&requestId=<%=id%>')">
 						<%=patient%> </a></td>
 						<td class="stat<%=status%>"><%=provide%></td>
-						<td class="stat<%=status%>"><%=cProv.getFormattedName()%></td>
+						<td class="stat<%=status%>"><%= (cProv != null) ? cProv.getFormattedName() : "" %></td>
 						<td class="stat<%=status%>">
 							<a href="javascript:popupOscarRx(700,960,'../../oscarEncounter/ViewRequest.do?de=<%=demo%>&requestId=<%=id%>')">
 								<%=StringUtils.trimToEmpty(service)%> 


### PR DESCRIPTION
If consultationRequests.providerNo = 0 for some reason (E.g. bad data in database), this page is throwing a 500 error due to a NPE.

This PR adds a NULL check to handle this bad data more gracefully by just leaving the field blank

![image](https://github.com/user-attachments/assets/62a77d06-4ec8-402b-a133-bd19cac376aa)
