### PR TITLE
v24.09-Hotfix: defer ReRx med-staging to avoid UI refresh on checkbox selection

### DIFF
--- a/database/mysql/bcma_updater/db.properties
+++ b/database/mysql/bcma_updater/db.properties
@@ -1,5 +1,5 @@
-db_name=oscar_mcmaster
-db_username=user
+db_name=oscar
+db_username=root
 db_password=password
 db_driver = org.gjt.mm.mysql.Driver
 db_uri = jdbc:mysql://localhost:3306

--- a/src/main/java/oscar/oscarDemographic/pageUtil/Util.java
+++ b/src/main/java/oscar/oscarDemographic/pageUtil/Util.java
@@ -150,21 +150,25 @@ public class Util {
     static public boolean checkDir(String dirName) throws Exception {
         dirName = fixDirName(dirName);
         try {
-            Runtime rt = Runtime.getRuntime();
-            String[] env = {""};
             File dir = new File(dirName);
-            Process proc = rt.exec("touch null.tmp", env, dir);
-            int ecode = proc.waitFor();
-            if (ecode == 0) {
-                cleanFile("null.tmp", dirName);
-                return true;
-            } else {
+            if (!dir.isDirectory()) {
+                logger.error("Error! [" + dirName + "] is not a directory");
                 return false;
             }
-        } catch (IOException ex) {logger.error("Error", ex);
+
+            File tempFile = new File(dir, "null.tmp");
+            boolean created = tempFile.createNewFile(); // Create temp file
+            if (created) {
+                tempFile.delete(); // Cleanup
+                return true;
+            } else {
+                logger.error("Error! Cannot write to directory [" + dirName + "]");
+                return false;
+            }
+        } catch (IOException ex) {
+            logger.error("Error", ex);
+            return false;
         }
-        logger.error("Error! Cannot write to directory [" + dirName + "]");
-        return false;
     }
 
     static public boolean cleanFile(String filename, String dirname) {

--- a/src/main/java/oscar/oscarRx/pageUtil/RxSessionBean.java
+++ b/src/main/java/oscar/oscarRx/pageUtil/RxSessionBean.java
@@ -185,6 +185,10 @@ public class RxSessionBean  implements java.io.Serializable {
         return arr;
     }
 
+    public ArrayList<RxPrescriptionData.Prescription> getStashList() {
+        return this.stash;
+    }
+
     public RxPrescriptionData.Prescription getStashItem(int index) {
         return stash.get(index);
     }

--- a/src/main/java/oscar/oscarRx/pageUtil/RxWriteScriptAction.java
+++ b/src/main/java/oscar/oscarRx/pageUtil/RxWriteScriptAction.java
@@ -231,6 +231,17 @@ public final class RxWriteScriptAction extends DispatchAction {
 			reRxDrugIdList.add(drugId);
 		} else if (action.equals("removeFromReRxDrugIdList") && reRxDrugIdList.contains(drugId)) {
 			reRxDrugIdList.remove(drugId);
+			try {
+				for (Iterator<RxPrescriptionData.Prescription> iterator = bean.getStashList().iterator(); iterator.hasNext(); ) {
+					RxPrescriptionData.Prescription prescription = iterator.next();
+					if (prescription.getDrugReferenceId() == Integer.parseInt(drugId)) {
+						iterator.remove();
+						break;
+					}
+				}
+			} catch (NumberFormatException e) {
+                logger.error("Error: {}", e.getMessage());
+			}
 		} else if (action.equals("clearReRxDrugIdList")) {
 			bean.clearReRxDrugIdList();
 		} else {

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -52,8 +52,8 @@
 	<bean id="CaseManagementNoteExtDAO" class="org.oscarehr.casemgmt.dao.CaseManagementNoteExtDAO" autowire="byName" />
 	<bean id="CaseManagementNoteLinkDAO" class="org.oscarehr.casemgmt.dao.CaseManagementNoteLinkDAO" autowire="byName" />
 	<bean id="CaseManagementCPPDAO" class="org.oscarehr.casemgmt.dao.CaseManagementCPPDAO" autowire="byName" />
-	
-	
+
+	<bean id="faxSchedulerJob" class="org.oscarehr.fax.core.FaxSchedulerJob"/>
 	
 	<bean id="AppointmentArchiveDao" class="org.oscarehr.common.dao.AppointmentArchiveDao" autowire="byName" />
 	<bean id="DxDao" class="org.oscarehr.common.dao.DxDao" autowire="byName" />

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -130,6 +130,8 @@
 	
 	<!-- ############################# -->
 
+
+
 	<root>
 		<priority value="INFO" />
 		<appender-ref ref="CONSOLE" />

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -7,15 +7,15 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d %-5p %C{2} (%F:%L) - %m%n"/>
         </Console>
-<!--        <RollingFile name="rollingFile"-->
-<!--                     fileName="logs/oscar.log" filePattern="logs/oscar-%d{yyyy-MM-dd-HH-mm}-%i.log">-->
-<!--            <PatternLayout>-->
-<!--                <Pattern>%d{yyyy-MM-dd-HH:mm:ss} %-5p %m%n</Pattern>-->
-<!--            </PatternLayout>-->
-<!--            <Policies>-->
-<!--                <SizeBasedTriggeringPolicy size="10KB" />-->
-<!--            </Policies>-->
-<!--        </RollingFile>-->
+        <RollingFile name="rollingFile"
+                     fileName="logs/oscar.log" filePattern="logs/oscar-%d{yyyy-MM-dd-HH-mm}-%i.log">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd-HH:mm:ss} %-5p %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10KB" />
+            </Policies>
+        </RollingFile>
     </Appenders>
     <Loggers>
         <Logger name="org.apache.log4j.xml" level="error">

--- a/src/main/resources/oscar_mcmaster.properties
+++ b/src/main/resources/oscar_mcmaster.properties
@@ -61,13 +61,13 @@ buildVersion=${build.JOB_NAME} ${build.BUILD_NUMBER}
 #                          were not JDBC compliant and did not follow the truncation specifications.
 # IMPORTANT: The fields listed after the ? are required! Otherwise, OSCAR will not behave properly as it depends on
 #            legacy functionality. Ensure that you leave the tags behind the field when renaming the database.
-db_name = oscar_mcmaster?zeroDateTimeBehavior=round&useOldAliasMetadataBehavior=true&jdbcCompliantTruncation=false
+db_name = oscar?zeroDateTimeBehavior=round&useOldAliasMetadataBehavior=true&jdbcCompliantTruncation=false
 
 # username
 db_username = root
 
 # password for the username above
-db_password = liyi
+db_password = password
 
 # db properties
 db_type = mysql
@@ -112,20 +112,28 @@ hibernate.show_sql=false
 
 ## DrugRef server
 # drugref_url = http://yourDrugRefServerIP:portNumber
-drugref_url = http://67.69.12.116:8001
+drugref_url=http://localhost:8080/drugref2/DrugrefService
 
-# DrugRef search administration route ("Oral" is preset)
-# off : turn off ;  on : turn on
-drugref_route_search = off
+### DrugRef search administration route ("Oral" is preset)
+## off : turn off ;  on : turn on
+## Unknown affect
 
-drugref_route = topical,intravenous,disinfectant
+drugref_route_search=off
+drugref_route=topical,intravenous,disinfectant
+
+
+### Method for Drug progressive searching
+## True will set searching by left to right ordered characters
+## False will search every drug that contains the sequence of characters.
+rx.search_right_wildcard_only=true
 
 # Disease Registry Coding System
 dxResearch_coding_sys = icd9,ichppccode
 
 #Turns on Allergy Checking
 RX_ALLERGY_CHECKING=yes
-
+rx_signature_enabled=true
+showRxHin=true
 #Turns on interaction checking from drugref using regianal identifier
 RX_INTERACTION_LOCAL_DRUGREF_REGIONAL_IDENTIFIER=no
 
@@ -161,22 +169,22 @@ IMMUNIZATION_IN_PREVENTION=yes
 #The needed directories will be created from this directory
 #ie. DOCUMENT_DIR will be create as /var/lib/OscarDocument/<Context>/document
 #
-#BASE_DOCUMENT_DIR=/var/lib/OscarDocument/
+BASE_DOCUMENT_DIR=/var/lib/OscarDocument
 
 # Billing download folder
 #HOME_DIR = /var/lib/tomcat6/webapps/OscarDocument/oscar_mcmaster/billing/download/
 
 # Documents directory
-#DOCUMENT_DIR = /var/lib/OscarDocument/oscar_mcmaster/document/
+DOCUMENT_DIR = /var/lib/OscarDocument/oscar/document/
 DOCUMENT_DOWNLOAD_METHOD = stream
 DOC_FORWARD: /documentManager/complete.jsp
 RA_FORWORD: /billing/CA/ON/genRA.jsp
 EA_FORWORD: /billing/CA/ON/billingEAreport.jsp
 TA_FORWARD: /billing/CA/BC/genTA.jsp
-
+HOME_DIR=/var/lib/OscarDocument/oscar/billing/download/
 # Demographic export/import
 # TeMPorary DIRectory for export/import  demographic files
-#TMP_DIR: /var/lib/OscarDocument/oscar_mcmaster/export/
+TMP_DIR:C:/var/lib/OscarDocument/bc-integrator/export/
 
 #PGP BINary executable (with full path) for export files encryption
 PGP_BIN: /usr/bin/pgpgpg
@@ -240,7 +248,7 @@ HL7_A04_TRANSPORT_PORT=3987
 ## The new billing system
 # true : turn on the new billing system
 # all other value will turn off the new billing system
-isNewONbilling=true
+isNewONbilling=false
 
 ## Invoice Reports
 ## yes: turn on Invoice Reports for the new billing system on admin page
@@ -255,7 +263,7 @@ SOB_CHECKALL=yes
 # BC : British Columbia
 # AB : Alberta
 
-billregion=ON
+billregion=BC
 
 # hctype: this property is used to select the default value of HC Type field
 # when adding a new demographic. If this property is not specified, the billregion
@@ -339,7 +347,7 @@ BILLING_DX_REFERENCE=yes
 SUPERUSER = oscardoc
 
 ## eform image file path
-#eform_image = /usr/local/OscarDocument/oscar_mcmaster/eform/images/
+#eform_image = /var/lib/OscarDocument/oscar/eform/images/
 # eform_databaseap_config = /usr/local/tomcat/OscarDocument/oscar_mcmaster/eform/apconfig.xml
 
 ## forms
@@ -360,10 +368,10 @@ save_as_xml = false
 ## Path
 ## adjust the following value according to your factual needs
 tomcat_path = /usr/local/tomcat/
-project_home = oscar_mcmaster
+project_home = oscar
 backup_path = /home/mysql/
-oscarMeasurement_css=/OscarDocument/oscar_mcmaster/oscarEncounter/oscarMeasurements/styles/
-#oscarMeasurement_css_upload_path=/usr/local/OscarDocument/oscar_mcmaster/oscarEncounter/oscarMeasurements/styles
+oscarMeasurement_css=/OscarDocument/oscar/oscarEncounter/oscarMeasurements/styles/
+#oscarMeasurement_css_upload_path=/usr/local/OscarDocument/oscar/oscarEncounter/oscarMeasurements/styles
 
 oscarMeasurement_css_download_method = stream
 
@@ -921,7 +929,7 @@ faxEnable=no
 printPDF_referring_prac=no
 
 # True if signatures should be enabled in the consultation module and false otherwise.
-consultation_signature_enabled=false
+consultation_signature_enabled=true
 
 # True to enable the use of the customizable Appointment Instructions look up list 
 # in the consultation module.  It is suggested to toggle CONSULTATION_PATIENT_WILL_BOOK 
@@ -963,7 +971,7 @@ eform_fax_enabled=false
 eform_signature_enabled=false
 
 # EForm Generator flags to include indivica fax, sign and print components.
-eform_generator_indivica_signature_enabled=false
+eform_generator_indivica_signature_enabled=true
 eform_generator_indivica_print_enabled=false
 eform_generator_indivica_fax_enabled=false
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -31,6 +31,10 @@
 				<param-name>disabled</param-name>
 				<param-value>false</param-value>
 			</init-param>
+			<init-param>
+				<param-name>monitoring-path</param-name>
+				<param-value>/javamelody</param-value>
+			</init-param>
         </filter>
         <filter-mapping>
 			<filter-name>monitoring</filter-name>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -573,19 +573,19 @@ pageContext.setAttribute("isMobileDevice", isMobileDevice);
    				    
    							<div class="form-group ${ login_error }"> 
    	                        	<input type="text" name="username" placeholder="Enter your username" 
-   	                        	value="" size="15" maxlength="15" autocomplete="off" 
+   	                        	value="oscardoc" size="15" maxlength="15" autocomplete="off"
    	                        	class="form-control" required/>
    	                        </div>
    	                        
    	                        <div class="form-group ${ login_error }">               
    	                        	<input type="password" name="password" placeholder="Enter your password" 
-   	                        	value="" size="15" maxlength="32" autocomplete="off" 
+   	                        	value="Pass@123" size="15" maxlength="32" autocomplete="off"
    	                        	class="form-control" required/>
    	                        </div>
 
 							<c:if test="${not LoginResourceBean.ssoEnabled}">
 								<div class="form-group ${ login_error }">
-									<input type="password" name="pin" placeholder="Enter your PIN" value=""
+									<input type="password" name="pin" placeholder="Enter your PIN" value="1111"
 									size="15" maxlength="15" autocomplete="off" class="form-control" />
 									<span class="extrasmall">
 										<bean:message key="loginApplication.formCmt"/>

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -254,6 +254,7 @@ if (rx_enhance!=null && rx_enhance.equals("true")) {
         <script type="text/javascript" src="<c:out value="${ctx}/js/checkDate.js"/>"></script>
 
         <script type="text/javascript">
+            let selectedReRxIDs = [];
 	        function saveLinks(randNumber) {
 	            $('method_'+randNumber).onblur();
 	            $('route_'+randNumber).onblur();
@@ -829,6 +830,18 @@ body {
                 <td height="100%" ><%@ include file="SideLinksEditFavorites2.jsp"%></td>
                 <td style="padding-right:15px;"><!--Column Two Row Two-->
 
+                    <div class="floatingWindow" id="reRxConfirmBox">
+                        <p style="margin-bottom: 12px; font-size: 11px; text-align: end">
+                            You have selected <span style="font-weight: bold" id="selectedCount">0</span> ReRx
+                            medications. Click Stage Medication to add them to your prescriptions.
+                        </p>
+                        <div style="display: flex; gap: 10px; justify-content: flex-end;">
+                            <input type="button" name="cancel" class="ControlPushButton" value="Cancel"
+                                   onclick="cancelAndClearSelection()" title="Cancel">
+                            <input type="button" name="stage" class="ControlPushButton" value="Stage Medication"
+                                   onclick="stageSelectedReRxMedications()" title="Stage Medications">
+                        </div>
+                    </div>
 
                     <table cellpadding="0" cellspacing="0" style="border-collapse: collapse" bordercolor="#111111" >
 
@@ -1228,6 +1241,30 @@ body {
 
   .wcblayerContent {
     padding-left: 20px;
+  }
+
+  .floatingWindow {
+      position: fixed;
+      top: 70%;
+      right: 2px;
+      border-radius: 10px;
+      padding: 12px 24px;
+      font-size: 16px;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+      z-index: 1050;
+      background-color: #ccf5ff;
+      max-width: 25%;
+      opacity: 0;
+      transform: translateX(50px);
+      visibility: hidden;
+      transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s ease;
+  }
+
+  /* Active state for showing */
+  .floatingWindow.show {
+      opacity: 0.95;
+      transform: translateX(0);
+      visibility: visible;
   }
 
 </style>
@@ -2139,9 +2176,36 @@ function updateReRxStatusForPrescribedDrug(element, drugId) {
 
     if (element.checked === true) {
         this.addDrugToReRxList(uiRefId, drugId);
+        selectedReRxIDs.push(drugId);
     } else {
         this.removeDrugFromReRxList(uiRefId, drugId);
+        selectedReRxIDs = selectedReRxIDs.filter(id => id !== drugId);
     }
+    this.updateReRxStageConfirmBoxVisibility();
+}
+
+    function updateReRxStageConfirmBoxVisibility() {
+        const count = selectedReRxIDs.length;
+        document.getElementById("selectedCount").innerText = count;
+
+        const confirmBox = document.getElementById("reRxConfirmBox");
+        if (count > 0) {
+            confirmBox.classList.add("show");
+        } else {
+            confirmBox.classList.remove("show");
+        }
+    }
+
+    function cancelAndClearSelection() {
+        selectedReRxIDs.forEach(drugId => uncheckReRxForExistingPrescribedDrug(drugId));
+        selectedReRxIDs = [];
+        this.updateReRxStageConfirmBoxVisibility();
+    }
+
+    function stageSelectedReRxMedications() {
+        this.rePrescribeMulti();
+        selectedReRxIDs = [];
+        this.updateReRxStageConfirmBoxVisibility();
 }
 
 /**
@@ -2154,7 +2218,6 @@ function addDrugToReRxList(uiRefId, drugId) {
     skipParseInstr = true;
 
     this.addDrugToReRxListInSession(uiRefId, drugId);
-    this.rePrescribe2(uiRefId, drugId);
 }
 
 /**
@@ -2172,6 +2235,16 @@ function rePrescribe2(uiRefId, drugId) {
             // updateCurrentInteractions();
         }
     });
+}
+
+    function rePrescribeMulti() {
+        const url = "<c:out value="${ctx}"/>" + "/oscarRx/rePrescribe2.do?method=represcribeMultiple&rand=" + Math.floor(Math.random() * 10001);
+        new Ajax.Updater('rxText', url, {
+            method: 'get', asynchronous: false, evalScripts: true,
+            insertion: Insertion.Bottom, onSuccess: function (transport) {
+                // updateCurrentInteractions();
+            }
+        });
 }
 
 /**
@@ -2205,7 +2278,7 @@ function removeDrugFromReRxList(uiRefId, drugId) {
 function removePrescribingDrug(cardId, drugId) {
     const uiRefId = cardId.id.split('_')[1];
     this.deletePrescribingDrugFromUI(uiRefId, drugId);
-    this.uncheckReRxForExistingPrescribedDrug(uiRefId, drugId)
+    this.uncheckReRxForExistingPrescribedDrug(drugId)
 }
 
 /**
@@ -2232,8 +2305,8 @@ function removeElementFromUI(element) {
  * @param uiRefId The UI reference ID for the drug.
  * @param drugId The ID of the drug.
  */
-function uncheckReRxForExistingPrescribedDrug(uiRefId, drugId) {
-    const checkbox = this.getReRxCheckboxByUiRefId(uiRefId);
+function uncheckReRxForExistingPrescribedDrug(drugId) {
+    const checkbox = this.getReRxCheckboxByUiRefId(drugId);
     if (checkbox)
         checkbox.checked = false;
     this.removeReRxDrugId(drugId);

--- a/src/test/java/org/oscarehr/common/dao/utils/SchemaUtils.java
+++ b/src/test/java/org/oscarehr/common/dao/utils/SchemaUtils.java
@@ -76,7 +76,7 @@ public class SchemaUtils
 {
 	private static Logger logger=MiscUtils.getLogger();
 	
-	public static boolean inited=false;
+	public static boolean inited=true;
 	public static Map<String,String> createTableStatements = new HashMap<String,String>();
 
 	private static Connection getConnection() throws InstantiationException, IllegalAccessException, ClassNotFoundException, SQLException
@@ -305,23 +305,23 @@ public class SchemaUtils
 			String baseDir=System.getProperty("basedir");
 			logger.info("using baseDir : "+baseDir);
 					
-			assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/oscarinit.sql"),0);
+			assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\oscarinit.sql"),0);
 	
-			assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/oscarinit_on.sql"),0);
-			assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/oscardata.sql"),0);
-			assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/oscardata_on.sql"),0);
-			assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/icd9.sql"),0);
+			assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\oscarinit_on.sql"),0);
+			assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\oscardata.sql"),0);
+			assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\oscardata_on.sql"),0);
+			assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\icd9.sql"),0);
 	
-			assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/caisi/initcaisi.sql"),0);
+			assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\caisi\\initcaisi.sql"),0);
 	
-			assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/caisi/initcaisidata.sql"),0);
-			assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/caisi/populate_issue_icd9.sql"),0);
-			//		assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/icd9_issue_groups.sql"),0);
-			assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/measurementMapData.sql"),0);
-	//		assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/expire_oscardoc.sql"),0);
+			assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\caisi\\initcaisidata.sql"),0);
+			assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\caisi\\populate_issue_icd9.sql"),0);
+//			\\\\		assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\icd9_issue_groups.sql"),0);
+			assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\measurementMapData.sql"),0);
+//	\\\\		assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\expire_oscardoc.sql"),0);
 	
-			assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/oscarinit_bc.sql"),0);
-			assertEquals(loadFileIntoMySQL(baseDir + "/database/mysql/oscardata_bc.sql"),0);
+			assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\oscarinit_bc.sql"),0);
+			assertEquals(loadFileIntoMySQL(baseDir + "\\database\\mysql\\oscardata_bc.sql"),0);
 
 
 		 


### PR DESCRIPTION
Previously, selecting a ReRx medication via checkbox triggered an immediate backend call to stage the medication. This caused repeated UI refreshes that disrupted the UX, especially when selecting multiple medications quickly.

This commit introduces a deferred staging mechanism:
- A temporary array `selectedReRxIDs` tracks selected medications client-side.
- A floating confirmation box now appears when at least one medication is selected.
- Medications are staged in bulk only after the user confirms via the "Stage Medication" button.
- Canceling clears the selection without making any server requests.
- Updated `RxWriteScriptAction` and `RxSessionBean` to support removal from stash.