### PR TITLE
v24.09-Hotfix: Fix Rourke2020 checkbox state not retrieved correctly

### DIFF
--- a/src/main/java/org/oscarehr/common/dao/forms/Rourke2020Dao.java
+++ b/src/main/java/org/oscarehr/common/dao/forms/Rourke2020Dao.java
@@ -53,7 +53,7 @@ public class Rourke2020Dao extends AbstractDao<FormRourke2020> {
     }
 
     @Override
-    public FormRourke2020 find(Object id) {
+    public FormRourke2020 find(int id) {
         // get form
         FormRourke2020 form = super.find(id);
         


### PR DESCRIPTION
This PR fixes an issue where checkbox (boolean) values in the Rourke2020 form were not being retrieved properly, making it seem like the form wasn't saved. Cherry picked from commit de807424feb23f8818c608d093decfd51e53e651




