### PR TITLE
Hotfix-v24.09: Enable fax on reprint if Rx is signed

### DIFF
--- a/src/main/webapp/oscarRx/ViewScript2.jsp
+++ b/src/main/webapp/oscarRx/ViewScript2.jsp
@@ -856,16 +856,21 @@ function toggleView(form) {
 							</select>
 						</td>
 					</tr>
+
+					<%
+						String isFaxDisabled = (bean.getStashSize() == 0 || Objects.isNull(bean.getStashItem(0).getDigitalSignatureId()))
+								? "disabled" : "";
+					%>
 					<tr>
 						<td style="padding-top: 0; padding-bottom: 0"><span><input type=button value="Fax"
 										 class="ControlPushButton" id="faxButton" style="width: 210px"
-										 onClick="sendFax();" disabled/></span>
+										 onClick="sendFax();" <%=isFaxDisabled%>/></span>
 						</td>
 					</tr>
 					<tr>
                             <td style="padding-top: 0"><span><input type=button value="Fax &amp; Add to encounter note"
                                     class="ControlPushButton" id="faxPasteButton" style="width: 210px"
-                                    onClick="printPaste2Parent(false, true, true);sendFax();" disabled/></span>
+                                    onClick="printPaste2Parent(false, true, true);sendFax();" <%=isFaxDisabled%>/></span>
 
                            </td>
                     </tr>


### PR DESCRIPTION
Fixes an issue where the Fax and Fax & Add to Encounter Note buttons remained disabled when reprinting a previously signed and faxed prescription.
* Added logic to check for a valid digitalSignatureId on the prescription.
* Buttons are now conditionally enabled only if the prescription is signed.
* Prevents faxing of unsigned prescriptions as per business requirements.