### PR TITLE
Persist updated image in eForm by saving src in hidden input

### DIFF
--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -66,6 +66,8 @@ function remoteSave() {
 			ShowSpin(true);
 		});
 
+		appendImageInputs();
+		
 		moveSubject();
 
 		if (typeof releaseDirtyFlag === "function") {
@@ -827,20 +829,33 @@ function remoteSave() {
 	 * A counter-measure to ensure images that are set by Javascript methods are captured
 	 * when the form is saved or rendered into a pdf.
 	 */
+	function appendImageInputs() {
+		jQuery("form[method='POST'] img").each(function () {
+			const id = jQuery(this).attr('id');
+			const src = jQuery(this).attr('src') || "";
+
+			// Skip image if it doesn't have an ID
+			if (!id || id.trim() === "") {
+				return true;
+			}
+
+			const inputId = 'openosp-img-' + id;
+
+			// Remove any existing hidden input for this image
+			jQuery("input[type='hidden'][id='" + inputId + "']").remove();
+
+			// Add a fresh hidden input
+			jQuery('<input>', {
+				id: inputId,
+				name: 'openosp-image-link',
+				value: JSON.stringify({ id: id, value: src }),
+				type: 'hidden'
+			}).appendTo("form[method='POST']");
+		});
+	}
+
 	jQuery(window).on('load', function() {
-		const imageTags = jQuery('img');
-		if(imageTags) {
-			imageTags.each(function(){
-				const id = jQuery(this).attr('id') || "";
-				const value = jQuery(this).attr('src') || "";
-				jQuery('<input>', {
-					id: Math.random().toString(36) + '-' + id,
-					name: 'openosp-image-link',
-					value: JSON.stringify({id: id, value: value}),
-					type: 'hidden'
-				}).appendTo("form[method='POST']");
-			})
-		}
+		appendImageInputs();
 	})
 
 	function handleEmailPrivilege() {


### PR DESCRIPTION
**Status Quo:**

- After opening an eForm, if an image is updated (e.g., via editing or replacing), the change is not retained after saving the form.

- This leads to outdated image data being stored, as the updated image src is not properly captured.

**Change:**

- Added logic to store the updated image src in a hidden input field before saving the eForm.