### PR TITLE
Prevent Blank Print Page When No Drug Is Selected

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -2537,7 +2537,12 @@ function updateQty(element){
             onSuccess:function(transport){
             	
                 callReplacementWebService("ListDrugs.jsp",'drugProfile');
-                popForm2(null);
+                const hasDrugs = jQuery("[id^='drugName_']").length > 0;
+                if (hasDrugs) {
+                    popForm2(null);
+                } else {
+                    alert("Please add at least one drug first");
+                }
                 resetReRxDrugList();
             }});
         return false;


### PR DESCRIPTION
### Status Quo:

- If no drug is selected and the user clicks `Save and Print`, a blank print page opens, leading to confusion and wasted steps.

![image](https://github.com/user-attachments/assets/669e6d0c-40f8-4558-a272-a39a47953637)
![image](https://github.com/user-attachments/assets/150c61c3-5068-49ca-b960-df3e1eb99923)

### Change:

- Added a validation check before proceeding with the Save and Print action.
- If no drug is selected, an alert message is shown to the user.

![image](https://github.com/user-attachments/assets/d401d081-c453-484c-8969-a47d33a7809c)
