### PR TITLE
Fix UI Breakage in Drug Table for Long Medication Names

### DIFF
--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -152,6 +152,11 @@
         border-radius: 5%;
     }
 
+    .list-drugs td:nth-child(5) {
+        word-break: break-word;
+        white-space: normal;
+    }
+
 
 </style>
 
@@ -179,7 +184,7 @@ if (heading != null){
 <h4 style="margin-bottom:1px;margin-top:3px;"><%=Encode.forHtmlContent(heading)%></h4>
 <%}%>
 <div class="drugProfileText" style="">
-    <table width="100%" cellpadding="3" border="0" class="sortable" id="Drug_table<%=Encode.forHtmlContent(heading)%>">
+    <table width="100%" cellpadding="3" border="0" class="list-drugs sortable" id="Drug_table<%=Encode.forHtmlContent(heading)%>">
         <tr>
         	<th align="left"><b>Entered Date</b></th>
             <th align="left"><b><bean:message key="SearchDrug.msgRxDate"/></b></th>


### PR DESCRIPTION
### Status Quo

- In the drug table, long unbroken words (e.g., medication names) in the 5th column caused UI layout issues, such as:
   - Overflowing cells
   - Horizontal scrolling
![image](https://github.com/user-attachments/assets/d1653fc4-71d9-422f-9364-8596bc2b4505)

### Change
- Added the CSS rule to handle long content gracefully.
- This ensures that long words wrap within the cell, preventing layout distortion.