### PR TITLE
Hotfix-v24.09: Resolve "Stage Medication" Dialog Visibility, Layering, and ReRx Unstaged Handling Issues

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -901,10 +901,10 @@ body {
                                                 <%}%>
                                                 <br>
                                                 <security:oscarSec roleName="<%=roleName2$%>" objectName="_rx" rights="x">
-                                                <input id="saveButton" type="button"  class="ControlPushButton" onclick="updateSaveAllDrugsPrint();" value="<bean:message key="SearchDrug.msgSaveAndPrint"/>" title="<bean:message key="SearchDrug.help.SaveAndPrint"/>" />
+                                                <input id="saveButton" type="button"  class="ControlPushButton" onclick="updateSaveAllDrugsPrintCheckContinue();" value="<bean:message key="SearchDrug.msgSaveAndPrint"/>" title="<bean:message key="SearchDrug.help.SaveAndPrint"/>" />
                                                 </security:oscarSec>
 
-                                                <input id="saveOnlyButton" type="button"  class="ControlPushButton" onclick="updateSaveAllDrugs();" value="<bean:message key="SearchDrug.msgSaveOnly"/>" title="<bean:message key="SearchDrug.help.Save"/>"/>
+                                                <input id="saveOnlyButton" type="button"  class="ControlPushButton" onclick="updateSaveAllDrugsCheckContinue();" value="<bean:message key="SearchDrug.msgSaveOnly"/>" title="<bean:message key="SearchDrug.help.Save"/>"/>
 												<%
                                                     	if(OscarProperties.getInstance().getProperty("oscarrx.medrec","false").equals("true")) {
                                                 %>
@@ -2576,8 +2576,43 @@ function updateQty(element){
         return x;
     }
 
-    
-    
+
+    function updateSaveAllDrugsPrintCheckContinue() {
+        showUnstagedReRxConfirmation(updateSaveAllDrugsPrint);
+    }
+
+    function updateSaveAllDrugsCheckContinue() {
+        showUnstagedReRxConfirmation(updateSaveAllDrugs);
+    }
+
+    const CONFIRMATION_MESSAGE = {
+        SINGLE: 'is 1 unstaged ReRx drug',
+        MULTIPLE: (count) => "are " + count + " unstaged ReRx drugs"
+    };
+
+    const SAVE_WARNING = 'If you continue, the unstaged ReRx drug(s) will not be re-prescribed.';
+    const SAVE_PROMPT = 'Are you sure you want to save this prescription?';
+
+    function showUnstagedReRxConfirmation(onConfirm) {
+        if (selectedReRxIDs.length === 0) {
+            onConfirm();
+            return;
+        }
+
+        const message = buildConfirmationMessage(selectedReRxIDs.length);
+        if (confirm(message)) {
+            cancelAndClearSelection();
+            onConfirm();
+        }
+    }
+
+    function buildConfirmationMessage(count) {
+        const statusMessage = count === 1
+            ? CONFIRMATION_MESSAGE.SINGLE
+            : CONFIRMATION_MESSAGE.MULTIPLE(count);
+        return "There " + statusMessage + ".\n" + SAVE_WARNING + "\n" + SAVE_PROMPT;
+    }
+
 	<%
 		ArrayList<Object> args = new ArrayList<Object>();
 		args.add(String.valueOf(bean.getDemographicNo()));

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -725,7 +725,7 @@ function checkFav(){
         padding: 12px 24px;
         font-size: 16px;
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
-        z-index: 1050;
+        z-index: 5000;
         background-color: #ccf5ff;
         max-width: 25%;
         opacity: 0;

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -717,6 +717,30 @@ function checkFav(){
 
 <style type="text/css">
 
+    .floatingWindow {
+        position: fixed;
+        top: 70%;
+        right: 2px;
+        border-radius: 10px;
+        padding: 12px 24px;
+        font-size: 16px;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+        z-index: 1050;
+        background-color: #ccf5ff;
+        max-width: 25%;
+        opacity: 0;
+        transform: translateX(50px);
+        visibility: hidden;
+        transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s ease;
+    }
+
+    /* Active state for showing */
+    .floatingWindow.show {
+        opacity: 0.95;
+        transform: translateX(0);
+        visibility: visible;
+    }
+
     .ControlPushButton{
         font-size:x-small !important;
         padding:3px !important;
@@ -1241,30 +1265,6 @@ body {
 
   .wcblayerContent {
     padding-left: 20px;
-  }
-
-  .floatingWindow {
-      position: fixed;
-      top: 70%;
-      right: 2px;
-      border-radius: 10px;
-      padding: 12px 24px;
-      font-size: 16px;
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
-      z-index: 1050;
-      background-color: #ccf5ff;
-      max-width: 25%;
-      opacity: 0;
-      transform: translateX(50px);
-      visibility: hidden;
-      transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s ease;
-  }
-
-  /* Active state for showing */
-  .floatingWindow.show {
-      opacity: 0.95;
-      transform: translateX(0);
-      visibility: visible;
   }
 
 </style>


### PR DESCRIPTION
This hotfix addresses multiple issues related to the "Stage Medication" dialog behavior and ReRx flows:

Bug Fixes:
1. Persistent Visibility of "Stage Medication" Dialog
   - Fixed a bug where the floating dialog remained visible even when there were 0 medications in the list.
   - Improved visibility logic and updated .floatingWindow CSS for correct conditional rendering.

2. Dialog Layering and Visibility Issue
   -  Increased the z-index of the "Stage Medication" dialog to prevent it from being covered by other UI elements.

3. ReRx Unstaged Medications Being Deleted
   - Added guardrails to prevent archive/deletion of re-prescribed medications when users skip staging.
   - Introduced confirmation dialogs on "Save and Print" / "Save Only" if unstaged ReRx drugs are detected. ([screenshot](https://github.com/user-attachments/assets/b4dd8482-00c9-4415-9385-11c95a678022))
   - Users are now required to acknowledge the state of unstaged ReRx items, ensuring safer recovery paths and intentional actions.

![image](https://github.com/user-attachments/assets/b4dd8482-00c9-4415-9385-11c95a678022)
