### PR TITLE
Hotfix: Resolve "Stage Medication" Dialog Visibility, Layering, and ReRx Unstaged Handling Issues

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -902,10 +902,10 @@ body {
                                                 <%}%>
                                                 <br>
                                                 <security:oscarSec roleName="<%=roleName2$%>" objectName="_rx" rights="x">
-                                                <input id="saveButton" type="button"  class="ControlPushButton" onclick="updateSaveAllDrugsPrint();" value="<bean:message key="SearchDrug.msgSaveAndPrint"/>" title="<bean:message key="SearchDrug.help.SaveAndPrint"/>" />
+                                                <input id="saveButton" type="button"  class="ControlPushButton" onclick="updateSaveAllDrugsPrintCheckContinue();" value="<bean:message key="SearchDrug.msgSaveAndPrint"/>" title="<bean:message key="SearchDrug.help.SaveAndPrint"/>" />
                                                 </security:oscarSec>
 
-                                                <input id="saveOnlyButton" type="button"  class="ControlPushButton" onclick="updateSaveAllDrugs();" value="<bean:message key="SearchDrug.msgSaveOnly"/>" title="<bean:message key="SearchDrug.help.Save"/>"/>
+                                                <input id="saveOnlyButton" type="button"  class="ControlPushButton" onclick="updateSaveAllDrugsCheckContinue();" value="<bean:message key="SearchDrug.msgSaveOnly"/>" title="<bean:message key="SearchDrug.help.Save"/>"/>
 												<%
                                                     	if(OscarProperties.getInstance().getProperty("oscarrx.medrec","false").equals("true")) {
                                                 %>
@@ -2577,8 +2577,43 @@ function updateQty(element){
         return x;
     }
 
-    
-    
+
+    function updateSaveAllDrugsPrintCheckContinue() {
+        showUnstagedReRxConfirmation(updateSaveAllDrugsPrint);
+    }
+
+    function updateSaveAllDrugsCheckContinue() {
+        showUnstagedReRxConfirmation(updateSaveAllDrugs);
+    }
+
+    const CONFIRMATION_MESSAGE = {
+        SINGLE: 'is 1 unstaged ReRx drug',
+        MULTIPLE: (count) => "are " + count + " unstaged ReRx drugs"
+    };
+
+    const SAVE_WARNING = 'If you continue, the unstaged ReRx drug(s) will not be re-prescribed.';
+    const SAVE_PROMPT = 'Are you sure you want to save this prescription?';
+
+    function showUnstagedReRxConfirmation(onConfirm) {
+        if (selectedReRxIDs.length === 0) {
+            onConfirm();
+            return;
+        }
+
+        const message = buildConfirmationMessage(selectedReRxIDs.length);
+        if (confirm(message)) {
+            cancelAndClearSelection();
+            onConfirm();
+        }
+    }
+
+    function buildConfirmationMessage(count) {
+        const statusMessage = count === 1
+            ? CONFIRMATION_MESSAGE.SINGLE
+            : CONFIRMATION_MESSAGE.MULTIPLE(count);
+        return "There " + statusMessage + ".\n" + SAVE_WARNING + "\n" + SAVE_PROMPT;
+    }
+
 	<%
 		ArrayList<Object> args = new ArrayList<Object>();
 		args.add(String.valueOf(bean.getDemographicNo()));


### PR DESCRIPTION
This hotfix addresses multiple issues related to the "Stage Medication" dialog behavior and ReRx flows:

Bug Fixes:
1. Persistent Visibility of "Stage Medication" Dialog
   - Fixed a bug where the floating dialog remained visible even when there were 0 medications in the list.
   - Improved visibility logic and updated .floatingWindow CSS for correct conditional rendering.

2. Dialog Layering and Visibility Issue
   -  Increased the z-index of the "Stage Medication" dialog to prevent it from being covered by other UI elements.

3. ReRx Unstaged Medications Being Deleted
   - Added guardrails to prevent archive/deletion of re-prescribed medications when users skip staging.
   - Introduced confirmation dialogs on "Save and Print" / "Save Only" if unstaged ReRx drugs are detected. ([screenshot](https://github.com/user-attachments/assets/b4dd8482-00c9-4415-9385-11c95a678022))
   - Users are now required to acknowledge the state of unstaged ReRx items, ensuring safer recovery paths and intentional actions.

![image](https://github.com/user-attachments/assets/b4dd8482-00c9-4415-9385-11c95a678022)