### PR TITLE
Fix ConvertToEdoc:getRealPath() - Incorrect Real Path Check Causing Asset Removal

### DIFF
--- a/src/main/java/org/oscarehr/documentManager/ConvertToEdoc.java
+++ b/src/main/java/org/oscarehr/documentManager/ConvertToEdoc.java
@@ -53,6 +53,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * A utility that converts HTML into a PDF and returns an Oscar eDoc object.
@@ -581,9 +582,28 @@ public final class ConvertToEdoc {
 		
 		logger.debug( "Context path set to " + contextPath );
 		
-		if( ConvertToEdoc.contextPath != null && ConvertToEdoc.realPath != null ) {
+		if(ConvertToEdoc.realPath != null) {
 			logger.debug( "Relative file path " + uri );
-			contextRealPath = Paths.get(ConvertToEdoc.realPath, ConvertToEdoc.realPath).toAbsolutePath().toString();
+			try {
+				Path basePath = Paths.get(ConvertToEdoc.realPath);
+				String fileNameToFind = Paths.get(uri).getFileName().toString();
+	
+				try (Stream<Path> paths = Files.walk(basePath)) {
+					Path found = paths
+						.filter(Files::isRegularFile)
+						.filter(path -> path.getFileName().toString().equals(fileNameToFind))
+						.findFirst()
+						.orElse(null);
+	
+					if (found != null) { 
+						contextRealPath = found.toAbsolutePath().toString(); 
+					} else {
+						contextRealPath = uri;
+					}
+				}
+			} catch (Exception e) {
+				logger.error("Error while searching file in directory: " + ConvertToEdoc.realPath, e);
+			}
 		}
 
 		logger.debug( "Absolute file path " + contextRealPath );

--- a/src/main/java/org/oscarehr/documentManager/ConvertToEdoc.java
+++ b/src/main/java/org/oscarehr/documentManager/ConvertToEdoc.java
@@ -347,6 +347,11 @@ public final class ConvertToEdoc {
 		}
 	}
 
+	public static Document getDocument(final String documenString, String realPath) {
+		ConvertToEdoc.realPath = realPath;
+		return getDocument(documenString);
+	}
+
 	/**
 	 * Clean and parse the HTML document string into a manageable DOM
 	 * with JSoup tools

--- a/src/main/java/oscar/eform/actions/AddEFormAction.java
+++ b/src/main/java/oscar/eform/actions/AddEFormAction.java
@@ -55,6 +55,8 @@ import oscar.util.StringUtils;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+
+import java.io.File;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -201,6 +203,9 @@ public class AddEFormAction extends Action {
 		}
 
 		EForm curForm = new EForm(fid, demographic_no, providerNo);
+		curForm.setContextPath(request.getContextPath());
+		curForm.setRealPath(request.getServletContext().getRealPath(File.separator));
+		curForm.setImagePath();
 
 		//add eform_link value from session attribute
 		ArrayList<String> openerNames = curForm.getOpenerNames();
@@ -218,7 +223,6 @@ public class AddEFormAction extends Action {
 		curForm.setValues(paramNames, paramValues);
 		if (!openerNames.isEmpty()) curForm.setOpenerValues(openerNames, openerValues);
 		if (eform_link!=null) curForm.setEformLink(eform_link);
-		curForm.setImagePath();
 		curForm.setAction();
 		curForm.setNowDateTime();
 		if (!errors.isEmpty()) {

--- a/src/main/java/oscar/eform/data/EFormBase.java
+++ b/src/main/java/oscar/eform/data/EFormBase.java
@@ -56,6 +56,7 @@ public class EFormBase {
     protected boolean patientIndependent=false;
     protected String roleType;
     private Document document;
+    private String realPath;
 
     protected ArrayList<String> updateFields = new ArrayList<String>();
 
@@ -213,12 +214,20 @@ public class EFormBase {
             /*
              * use the ConvertToEdoc utilities for consistent use of the JSoup parser.
              */
-            this.document = ConvertToEdoc.getDocument(this.formHtml);
+            this.document = ConvertToEdoc.getDocument(this.formHtml, this.realPath);
         }
         if(this.document == null) {
             MiscUtils.getLogger().error("There was a problem while parsing this eForm into a JSoup DOM. Exception needed?");
         }
         return document;
     }
+   
+    public String getRealPath() {
+        return realPath;
+    }
+    
+    public void setRealPath(String realPath) {
+        this.realPath = realPath;
+    }    
 
 }


### PR DESCRIPTION
### Status Quo
- The `getRealPath()` method does not correctly validate the `uri` parameter and is returning incorrect results.

![image](https://github.com/user-attachments/assets/68918b81-716d-4a47-82e3-a70da16715b5)


### Changes
- Fixed the `getRealPath()` method based on the values of `ConvertToEdoc.realPath` and `ConvertToEdoc.contextPath`.
- Current values:
    - `ConvertToEdoc.realPath`: `/home/vagrant/tomcat/apache-tomcat-9.0.41/webapps/oscar/`
    - `ConvertToEdoc.contextPath` : `/oscar`

- Based on these values, it appears that `getRealPath()` is intended to resolve the real path of the given `uri` within the `oscar` project directory. The implementation has been updated accordingly.