### PR TITLE
Consult request has attached documents of the other demographic

### DIFF
--- a/src/main/java/org/oscarehr/documentManager/actions/DocumentPreviewAction.java
+++ b/src/main/java/org/oscarehr/documentManager/actions/DocumentPreviewAction.java
@@ -43,12 +43,6 @@ public class DocumentPreviewAction extends DispatchAction {
 	private final DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
 	private final FormsManager formsManager = SpringUtils.getBean(FormsManager.class);
 
-	private List<EDoc> allDocuments = new ArrayList<>();
-	private List<EFormData> allEForms = new ArrayList<>();
-	private ArrayList<HashMap<String,? extends Object>> allHRMDocuments = new ArrayList<>();
-	private List<AttachmentLabResultData> allLabsSortedByVersions = new ArrayList<>();
-	private List<EctFormData.PatientForm> allForms = new ArrayList<>();
-
 	public void renderEDocPDF(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) {
 		LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 		String eDocId = request.getParameter("eDocId");
@@ -131,13 +125,18 @@ public class DocumentPreviewAction extends DispatchAction {
 		
 		String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
 
-		allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
-		allEForms = EFormUtil.listPatientEformsCurrent(new Integer(demographicNo), true);
-		allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicNo,false);
-		allLabsSortedByVersions = documentAttachmentManager.getAllLabsSortedByVersions(loggedInInfo, demographicNo);
-		allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, Integer.parseInt(demographicNo), false, true);
+		List<EDoc> allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
+		List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(new Integer(demographicNo), true);
+		ArrayList<HashMap<String,? extends Object>> allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicNo,false);
+		List<AttachmentLabResultData> allLabsSortedByVersions = documentAttachmentManager.getAllLabsSortedByVersions(loggedInInfo, demographicNo);
+		List<EctFormData.PatientForm> allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, Integer.parseInt(demographicNo), false, true);
 
-		return forwardDocuments(mapping, request);
+		request.setAttribute("allDocuments", allDocuments);
+		request.setAttribute("allLabsSortedByVersions", allLabsSortedByVersions);
+		request.setAttribute("allForms", allForms);
+		request.setAttribute("allEForms", allEForms);
+		request.setAttribute("allHRMDocuments", allHRMDocuments);
+		return mapping.findForward("fetchDocuments");
 	}
 
 	public ActionForward fetchEFormDocuments(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) {
@@ -146,13 +145,18 @@ public class DocumentPreviewAction extends DispatchAction {
 		String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
 		String fdid = StringUtils.isNullOrEmpty(request.getParameter("fdid")) ? "0" : request.getParameter("fdid");
 
-		allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
-		allEForms = documentAttachmentManager.getAllEFormsExpectFdid(loggedInInfo, Integer.parseInt(demographicNo), Integer.parseInt(fdid));
-		allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicNo,false);
-		allLabsSortedByVersions = documentAttachmentManager.getAllLabsSortedByVersions(loggedInInfo, demographicNo);
-		allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, Integer.parseInt(demographicNo), false, true);
+		List<EDoc> allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
+		List<EFormData> allEForms = documentAttachmentManager.getAllEFormsExpectFdid(loggedInInfo, Integer.parseInt(demographicNo), Integer.parseInt(fdid));
+		ArrayList<HashMap<String,? extends Object>> allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicNo,false);
+		List<AttachmentLabResultData> allLabsSortedByVersions = documentAttachmentManager.getAllLabsSortedByVersions(loggedInInfo, demographicNo);
+		List<EctFormData.PatientForm> allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, Integer.parseInt(demographicNo), false, true);
 
-		return forwardDocuments(mapping, request);
+		request.setAttribute("allDocuments", allDocuments);
+		request.setAttribute("allLabsSortedByVersions", allLabsSortedByVersions);
+		request.setAttribute("allForms", allForms);
+		request.setAttribute("allEForms", allEForms);
+		request.setAttribute("allHRMDocuments", allHRMDocuments);
+		return mapping.findForward("fetchDocuments");
 	}
 
 	private void generateResponse(HttpServletResponse response, Path pdfPath) throws PDFGenerationException {
@@ -176,14 +180,5 @@ public class DocumentPreviewAction extends DispatchAction {
 		} catch (IOException e) {
 			logger.error("An error occurred while writing JSON response to the output stream", e);
 		}
-	}
-
-	private ActionForward forwardDocuments(ActionMapping mapping, HttpServletRequest request) {
-		request.setAttribute("allDocuments", allDocuments);
-		request.setAttribute("allLabsSortedByVersions", allLabsSortedByVersions);
-		request.setAttribute("allForms", allForms);
-		request.setAttribute("allEForms", allEForms);
-		request.setAttribute("allHRMDocuments", allHRMDocuments);
-		return mapping.findForward("fetchDocuments");
 	}
 }


### PR DESCRIPTION
### Status Quo

- Users were able to see documents (Doc, HL7, and HRM) belonging to other demographics while attempting to attach them to a consult request or eForm.

- This led to users mistakenly attaching documents to the wrong demographic.

### Change

- Resolved the issue by moving the list variables from class-level scope to method-level scope, ensuring the data is isolated per request.

- The issue occurred because the variables were defined at the class level in the Action file. Since the Action class is shared across requests in a Struts-based Java JSP project, concurrent user actions could interfere with each other. For example, if Provider A made a request and, before it completed, Provider B made a similar request and their response returned first, the shared class-level variables would be overwritten, causing Provider A to see documents from the demographic requested by Provider B.

- This concurrency issue caused documents to appear under the wrong demographic, resulting in mistaken attachments.

- By moving the variables to the method level, each request now maintains its own data, preventing such cross-user data leaks.