### PR TITLE
Fix re-linking issue for previously removed MD in document

### DIFF
--- a/src/main/java/org/oscarehr/common/dao/ProviderInboxRoutingDao.java
+++ b/src/main/java/org/oscarehr/common/dao/ProviderInboxRoutingDao.java
@@ -53,6 +53,8 @@ public interface ProviderInboxRoutingDao extends AbstractDao<ProviderInboxItem> 
 
 	public int howManyDocumentsLinkedWithAProvider(String providerNo);
 
+	public List<ProviderInboxItem> findDocumentsLinkedWithProvider(String docType, Integer docId, String providerNo);
+
 	public void addToProviderInbox(String providerNo, Integer labNo, String labType);
 
 }


### PR DESCRIPTION
### Status Quo

- For documents, if a linked provider is removed and then re-linked, the provider does not appear in the linked provider list in the document.

![image](https://github.com/user-attachments/assets/55a825ac-fa9b-4987-890d-1925e839637b)


### Change

- In the backend, when a linked provider is removed from a document, the provider’s status is updated to `X`.

![image](https://github.com/user-attachments/assets/6286ca6d-da2c-46a0-b3dc-db4e2d306c7c)

- Later, if the same provider is flagged again, Oscar checks the table to see if the provider is already linked, but it does not check the status.

- Since the status remains `X`, the provider is not shown in the linked provider list when trying to link again.

- This issue is fixed by adding logic to update the status appropriately when re-linking a previously removed provider.