### PR TITLE
Prevent demographic match when Health Card Number is empty during lab upload

### DIFF
--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -1351,11 +1351,6 @@ INSERT INTO provider VALUES ('999998','oscardoc','doctor','doctor',null,'','',''
 --
 -- Dumping data for table 'quickList'
 --
-INSERT INTO quickList VALUES(1,"default", "999997", "000","ichppc");
-INSERT INTO quickList VALUES(2,"default", "999997", "204","ichppc");
-INSERT INTO quickList VALUES(3,"default", "999997", "288","ichppc");
-INSERT INTO quickList VALUES(4,"default", "999997", "053","ichppc");
-INSERT INTO quickList VALUES(5,"default", "999997", "235","ichppc");
 INSERT INTO quickList VALUES(6,"List1", "999998", "235","ichppc");
 INSERT INTO quickList VALUES(7,"List1", "999998", "376","ichppc");
 INSERT INTO quickList VALUES(8,"List1", "999998", "246","ichppc");
@@ -1498,7 +1493,6 @@ insert into `secRole` (role_name, description) values('HRMAdmin','HRM Administat
 
 insert into `secUserRole` (`provider_no`,`role_name`,`orgcd`,`activeyn`,lastUpdateDate) values('999998', 'doctor', 'R0000001',1,now());
 insert into `secUserRole` (`provider_no`,`role_name`,`orgcd`,`activeyn`,lastUpdateDate) values('999998', 'admin', 'R0000001',1,now());
-insert into `secUserRole` (`provider_no`,`role_name`,`orgcd`,`activeyn`,lastUpdateDate) values('999997', 'receptionist', 'R0000001',1,now());
 
 insert into `secPrivilege` values(1, 'x', 'All rights.');
 insert into `secPrivilege` values(2, 'r', 'Read');

--- a/src/main/java/org/oscarehr/common/web/FlowSheetCustomAction.java
+++ b/src/main/java/org/oscarehr/common/web/FlowSheetCustomAction.java
@@ -472,7 +472,9 @@ public class FlowSheetCustomAction extends DispatchAction {
         fsuc.setCreatedDate(new Date());
         flowSheetUserCreatedDao.persist(fsuc);
 
-        return mapping.findForward("newflowsheet");
+        request.setAttribute("flowsheet", fsuc.getName());
+        request.setAttribute("displayName", fsuc.getDisplayName());
+        return mapping.findForward("success");
     }
 
 

--- a/src/main/java/org/oscarehr/common/web/FlowSheetCustomAction.java
+++ b/src/main/java/org/oscarehr/common/web/FlowSheetCustomAction.java
@@ -25,15 +25,6 @@
 
 package org.oscarehr.common.web;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.Hashtable;
-import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
@@ -50,7 +41,6 @@ import org.oscarehr.managers.SecurityInfoManager;
 import org.oscarehr.util.LoggedInInfo;
 import org.oscarehr.util.MiscUtils;
 import org.oscarehr.util.SpringUtils;
-
 import oscar.oscarEncounter.oscarMeasurements.FlowSheetItem;
 import oscar.oscarEncounter.oscarMeasurements.MeasurementFlowSheet;
 import oscar.oscarEncounter.oscarMeasurements.MeasurementTemplateFlowSheetConfig;
@@ -58,6 +48,10 @@ import oscar.oscarEncounter.oscarMeasurements.util.Recommendation;
 import oscar.oscarEncounter.oscarMeasurements.util.RecommendationCondition;
 import oscar.oscarEncounter.oscarMeasurements.util.TargetColour;
 import oscar.oscarEncounter.oscarMeasurements.util.TargetCondition;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.*;
 
 public class FlowSheetCustomAction extends DispatchAction {
     private static final Logger logger = MiscUtils.getLogger();
@@ -277,32 +271,6 @@ public class FlowSheetCustomAction extends DispatchAction {
             item.setTargetColour(targets);
             item.setRecommendations(recommendations);
 
-
-
-
-
-            //DEALING WITH TARGET DATA//////////
-
-          /*
-            <select name="type<%=targetCount%>c1">
-               <option value="-1">Not Set</option>
-                <option value="getDataAsDouble"       >Number Value</option>
-                <option value="isMale"              > Is Male </option>
-                <option value="isFemale"            > Is Female </option>
-                <option value="getNumberFromSplit"  > Number Split </option>
-                <option value="isDataEqualTo"       >  String </option>
-           </select>
-
-           Param: <input type="text" name="param<%=targetCount%>c1" value="" />
-           Value: <input type="text" name="value<%=targetCount%>c1" value="" />
-
-             */
-
-
-            ////////////
-
-
-
             Element va = templateConfig.getItemFromObject(item);
 
             XMLOutputter outp = new XMLOutputter();
@@ -446,16 +414,6 @@ public class FlowSheetCustomAction extends DispatchAction {
         m.setWarningColour(warningColour);
         m.setRecommendationColour(recommendationColour);
 
-        //Im not sure if adding an initializing measurement is required yet
-        /*
-        Map<String,String> h = new HashMap<String,String>();
-        h.put("measurement_type","WT");
-        h.put("display_name","WT");
-        h.put("value_name","WT");
-
-        FlowSheetItem fsi = new FlowSheetItem( h);
-        m.addListItem(fsi);
-*/
         MeasurementTemplateFlowSheetConfig templateConfig = MeasurementTemplateFlowSheetConfig.getInstance();
         templateConfig.addIndicatorsInCustomFlowsheet(m);
         String name =  templateConfig.addFlowsheet( m );

--- a/src/main/java/oscar/oscarLab/ca/all/upload/MessageUploader.java
+++ b/src/main/java/oscar/oscarLab/ca/all/upload/MessageUploader.java
@@ -676,7 +676,7 @@ public final class MessageUploader {
 				
 	
 				// HIN is ALWAYS required for lab matching. Please do not revert this code. Previous iterations have caused fatal patient miss-matches.				
-				if( hinMod != null ) {
+				if( hinMod != null && !hinMod.trim().isEmpty()) {
 					if (OscarProperties.getInstance().getBooleanProperty("LAB_NOMATCH_NAMES", "yes")) {
 						sql = "select demographic_no, provider_no from demographic where hin='" + hinMod + "' and " + " year_of_birth like '" + dobYear + "' and " + " month_of_birth like '" + dobMonth + "' and " + " date_of_birth like '" + dobDay + "' and " + " sex like '" + sex + "%' ";
 					} else {

--- a/src/main/webapp/admin/manageFlowsheets.jsp
+++ b/src/main/webapp/admin/manageFlowsheets.jsp
@@ -49,6 +49,7 @@
 <%@ page import="org.oscarehr.common.model.Flowsheet" %>
 <%@ page import="org.oscarehr.common.dao.FlowsheetDao" %>
 <%@ page import="org.oscarehr.util.SpringUtils" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%
 	String method = request.getParameter("method");
@@ -74,17 +75,24 @@
 
 <link href="<%=request.getContextPath()%>/css/bootstrap.css" rel="stylesheet" type="text/css">
 <link href="<%=request.getContextPath()%>/css/bootstrap-responsive.css"	rel="stylesheet" type="text/css">
-
+	<link rel="stylesheet" href="<%=request.getContextPath() %>/library/jquery/jquery-ui.structure-1.12.1.min.css">
+	<link rel="stylesheet" href="<%=request.getContextPath() %>/library/jquery/jquery-ui.theme-1.12.1.min.css">
 <script src="<%=request.getContextPath() %>/library/jquery/jquery-3.6.4.min.js"></script>
+	<script src="<%=request.getContextPath()%>/js/bootstrap.js"></script>
 
-<link rel="stylesheet" href="<%=request.getContextPath() %>/library/jquery/jquery-ui.structure-1.12.1.min.css">
-<link rel="stylesheet" href="<%=request.getContextPath() %>/library/jquery/jquery-ui.theme-1.12.1.min.css">
 <script src="<%=request.getContextPath() %>/library/jquery/jquery-ui-1.12.1.min.js"></script>
 
-<script src="<%=request.getContextPath()%>/js/bootstrap.js"></script>
+
 <script	src="<%=request.getContextPath()%>/share/javascript/Oscar.js"></script>
 
-
+	<style>
+		table {
+			table-layout: fixed;
+		}
+		table td {
+			word-wrap: break-word;
+		}
+	</style>
 
 <script>
 jQuery.noConflict();
@@ -98,10 +106,12 @@ jQuery(function() {
 
 <body>
 
+<div class="container-fluid">
+<div class="navbar" id="demoHeader"><div class="navbar-inner">
+	<a class="brand" href="javascript:void(0)">Flowsheets</a>
+</div></div>
 
-			<h3>Flowsheets</h3>
-			<br>
-			<table class="table table-striped table-hover">
+			<table class="table table-striped table-condensed table-hover">
                 <thead>
 				<tr>
 					<td><b>Name</b></td>
@@ -136,14 +146,14 @@ jQuery(function() {
 					%>
 
 						<tr>
-							<td><%=flowSheet.getDisplayName()%></td>
+							<td><%=Encode.forHtmlContent(flowSheet.getDisplayName())%></td>
 							<td><%=flowSheet.isUniversal() %></td>
-							<td><%=flowSheet.getDxTriggersString() %></td>
-							<td><%=flowSheet.getProgramTriggersString() %></td>
-							<td><%=type %></td>
+							<td><%=Encode.forHtmlContent(flowSheet.getDxTriggersString()) %></td>
+							<td><%=Encode.forHtmlContent(flowSheet.getProgramTriggersString()) %></td>
+							<td><%=Encode.forHtmlContent(type) %></td>
 							<td><%=enabled%></td>
 							<td>
-								<a href="<%=request.getContextPath()%>/oscarEncounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp?flowsheet=<%=flowSheet.getName()%>">Edit</a>&nbsp;
+								<a href="<%=request.getContextPath()%>/oscarEncounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp?flowsheet=<%=flowSheet.getName()%>&displayName=<%=flowSheet.getDisplayName()%>">Edit</a>&nbsp;
 								<%if(enabled) { %>
 									<a href="manageFlowsheets.jsp?method=disable&name=<%=flowSheet.getName()%>">Disable</a>
 								<% } else { %>
@@ -158,14 +168,17 @@ jQuery(function() {
             </tbody>
 			</table>
 
-			<br><br><br>
-
+		<div class="panel panel-default">
+			<div class="panel-heading">
+				<h4>Upload Custom Flowsheet</h4>
+			</div>
+		<div class="panel-body">
 			<form enctype="multipart/form-data" method="POST" action="<%=request.getContextPath()%>/admin/manageFlowsheetsUpload.jsp">
 				<input type="file" name="flowsheet_file">
-				<span title="<bean:message key="global.uploadWarningBody"/>" style="vertical-align:middle;font-family:arial;font-size:20px;font-weight:bold;color:#ABABAB;cursor:pointer"><img alt="alert" src="<%=request.getContextPath()%>/images/icon_alertsml.gif"/></span>
-
-				&nbsp;
+				<span title="<bean:message key="global.uploadWarningBody"/>" style="vertical-align:middle;cursor:pointer"><img alt="alert" src="<%=request.getContextPath()%>/images/icon_alertsml.gif"/></span>
 				<input type="submit" value="Upload" class="btn btn-primary">
 			</form>
-
+		</div>
+		</div>
+</div>
 </html:html>

--- a/src/main/webapp/admin/manageFlowsheets.jsp
+++ b/src/main/webapp/admin/manageFlowsheets.jsp
@@ -143,7 +143,7 @@ jQuery(function() {
 							<td><%=type %></td>
 							<td><%=enabled%></td>
 							<td>
-								<a href="/oscar/oscarEncounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp?flowsheet=<%=flowSheet.getName()%>">Edit</a>&nbsp;
+								<a href="<%=request.getContextPath()%>/oscarEncounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp?flowsheet=<%=flowSheet.getName()%>">Edit</a>&nbsp;
 								<%if(enabled) { %>
 									<a href="manageFlowsheets.jsp?method=disable&name=<%=flowSheet.getName()%>">Disable</a>
 								<% } else { %>

--- a/src/main/webapp/admin/providerRole.jsp
+++ b/src/main/webapp/admin/providerRole.jsp
@@ -345,7 +345,9 @@ if(newCaseManagement) {
 
 				if(programProvider == null || programProvider.isEmpty()) {
                     ProviderData provider = providerDao.findByProviderNo(user);
-                    msg += String.format("</br><span style='color:red;'>WARNING: Provider %s requires a primary role assignment.</span>", provider.getFirstName() + " " + provider.getLastName());
+                    if (provider != null) {
+                        msg += String.format("</br><span style='color:red;'>WARNING: Provider %s requires a primary role assignment.</span>", provider.getFirstName() + " " + provider.getLastName());
+                    }
                 }
             }
         }

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/TemplateFlowSheetPage.jspf
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/TemplateFlowSheetPage.jspf
@@ -45,6 +45,7 @@
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security"%>
 <%@page import="oscar.OscarProperties"%>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%
 	if(session.getValue("user") == null) response.sendRedirect("${ pageContext.request.contextPath }/logout.jsp");
@@ -1003,7 +1004,7 @@ if(temp.equals("diab2") || temp.equals("chf")) {
         <% for (int i = 0; i < comments.size(); i++){
             String str = (String) comments.get(i);
         %>
-        <li><%=str%></li>
+        <li><%=Encode.forHtmlContent(str)%></li>
         <% }%>
     </ol>
 </div>

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp
@@ -126,12 +126,6 @@ if(!authed2) {
 
 <link href="<%=request.getContextPath() %>/css/bootstrap.css" rel="stylesheet">
 
-
-<!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
-<!--[if lt IE 9]>
-  <script src="<%=request.getContextPath() %>/js/html5.js"></script>
-<![endif]-->
-
 <!-- Fav and touch icons -->
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="ico/apple-touch-icon-144-precomposed.png">
 <link rel="apple-touch-icon-precomposed" sizes="114x114" href="ico/apple-touch-icon-114-precomposed.png">
@@ -224,7 +218,9 @@ if( request.getParameter("tracker")!=null && request.getParameter("tracker").equ
 	
 }else{
 if(request.getParameter("demographic")==null){ %>
-<div class="well well-small" id="demoHeader"></div>
+<div class="navbar" id="demoHeader"><div class="navbar-inner">
+	<a class="brand" href="javascript:void(0)">Create Flowsheet</a>
+</div></div>
 <%}else{%>
 <%@ include file="/share/templates/patient.jspf"%>
 <div style="height:60px;"></div>
@@ -233,7 +229,7 @@ if(request.getParameter("demographic")==null){ %>
 }
 %>
 
-<div class="container" id="container-main">
+<div class="container-fluid" id="container-main">
 
 <div class="row-fluid">
 

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/adminFlowsheet/NewFlowsheet.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/adminFlowsheet/NewFlowsheet.jsp
@@ -32,12 +32,12 @@
 FlowSheetUserCreatedDao flowSheetUserCreatedDao = (FlowSheetUserCreatedDao) SpringUtils.getBean(FlowSheetUserCreatedDao.class);
 List<FlowSheetUserCreated> flowsheets = flowSheetUserCreatedDao.getAllUserCreatedFlowSheets();
 %>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
     <head>
-        <title>Create a new Flowsheet</title>
+        <title>Create New Flowsheet</title>
+        <link href="<%=request.getContextPath()%>/css/bootstrap.css" rel="stylesheet" type="text/css">
         <script type="text/javascript">
         	function checkForm(){
         		  var displayName = document.getElementById("displayName").value;
@@ -70,23 +70,37 @@ List<FlowSheetUserCreated> flowsheets = flowSheetUserCreatedDao.getAllUserCreate
         </script>
     </head>
     <body>
-        <h2>Create a new Flowsheet</h2>        
+    <div class="navbar" id="demoHeader"><div class="navbar-inner">
+        <a class="brand" href="javascript:void(0)">New Flowsheet</a>
+    </div></div>
         <form action="FlowSheetCustomAction.do" onsubmit="return checkForm()">
             <input type="hidden" name="method" value="createNewFlowSheet"/>
         <table border="0">
-        <tr><td>Name: </td><td><input type="text" name="displayName" id="displayName"/></td></tr>
-        <tr><td>Trigger: </td><td><input type="text" name="dxcodeTriggers" id="dxcodeTriggers"/> (eg icd9:250)</td></tr>
-        <tr><td>Warning Colour: </td><td><input type="text" name="warningColour" id="warningColour"/> (eg red or #E00000)</td></tr>
-        <tr><td>Recommendation Colour: </td><td><input type="text" name="recommendationColour" id="recommendationColour"/> (eg yellow)</td></tr>
+<tr>
+    <td><label for="displayName">Name: </label></td>
+    <td><input type="text" name="displayName" id="displayName"/></td>
+</tr>
+<tr>
+    <td><label for="dxcodeTriggers">Trigger: </label></td>
+    <td><input type="text" name="dxcodeTriggers" id="dxcodeTriggers"/> (eg icd9:250)</td>
+</tr>
+<tr>
+    <td><label for="warningColour">Warning Colour: </label></td>
+    <td><input type="text" name="warningColour" id="warningColour"/> (eg red or #E00000)</td>
+</tr>
+<tr>
+    <td><label for="recommendationColour">Recommendation Colour: </label></td>
+    <td><input type="text" name="recommendationColour" id="recommendationColour"/> (eg yellow)</td>
+</tr>
         
         </table>
         <input type="submit" name="Submit" value="Create"/>
         </form>
-        <br>
-        <%
-        for(FlowSheetUserCreated flowsheet: flowsheets){%>
-        <a href="EditFlowsheet.jsp?flowsheet=<%=flowsheet.getName()%>"><%=flowsheet.getDisplayName()%></a></br>
-        <%}%>
-        
+<%--        <br>--%>
+<%--        <%--%>
+<%--        for(FlowSheetUserCreated flowsheet: flowsheets){%>--%>
+<%--        <a href="EditFlowsheet.jsp?flowsheet=<%=flowsheet.getName()%>"><%=flowsheet.getDisplayName()%></a></br>--%>
+<%--        <%}%>--%>
+<%--        --%>
     </body>
 </html>

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/adminFlowsheet/UpdateFlowsheet.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/adminFlowsheet/UpdateFlowsheet.jsp
@@ -102,20 +102,13 @@ FlowSheetItem fsi =mFlowsheet.getFlowSheetItem(measurement);
 //EctMeasurementTypeBeanHandler mType = new EctMeasurementTypeBeanHandler();
 %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <html:html lang="en">
 
 <head>
 <title>Update Flowsheet <%=flowsheet%>  <oscar:nameage demographicNo="<%=demographic%>"/></title><!--I18n-->
 
 <link href="<%=request.getContextPath() %>/css/bootstrap.css" rel="stylesheet">
-
-
-<!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
-<!--[if lt IE 9]>
-  <script src="<%=request.getContextPath() %>/js/html5.js"></script>
-<![endif]-->
-
 
 
 <style type="text/css">
@@ -149,7 +142,10 @@ display:inline-block;
 if(request.getParameter("htracker")==null || ( request.getParameter("htracker")!=null && !request.getParameter("htracker").equals("slim")) ){
 
 if(request.getParameter("demographic")==null){ %>
-<div class="well well-small"></div>
+<div class="navbar" id="demoHeader"><div class="navbar-inner">
+    <a class="brand" href="javascript:void(0)">Update Flowsheet Measurement</a>
+    <em>for <strong><%=flowsheet%></strong> flowsheet </em>
+</div></div>
 <%}else{ %>
 <%@ include file="/share/templates/patient.jspf"%>
 <div style="height:60px;"></div>
@@ -157,11 +153,9 @@ if(request.getParameter("demographic")==null){ %>
 }
 %>
 
-<div class="container" id="container-main">
+<div class="container-fluid" id="container-main">
 
 <div class="span8">
-<h3 style="display:inline">Update Measurement</h3> <em>for <strong><%=flowsheet%></strong> flowsheet </em>
-
 <form action="FlowSheetCustomAction.do" onsubmit="return validateRuleValue();">
 
 		    <%if(request.getParameter("htracker")!=null){ %>

--- a/src/main/webapp/oscarRx/ViewScript2.jsp
+++ b/src/main/webapp/oscarRx/ViewScript2.jsp
@@ -848,16 +848,21 @@ function toggleView(form) {
 							</select>
 						</td>
 					</tr>
+
+					<%
+						String isFaxDisabled = (bean.getStashSize() == 0 || Objects.isNull(bean.getStashItem(0).getDigitalSignatureId()))
+								? "disabled" : "";
+					%>
 					<tr>
 						<td style="padding-top: 0; padding-bottom: 0"><span><input type=button value="Fax"
 										 class="ControlPushButton" id="faxButton" style="width: 210px"
-										 onClick="sendFax();" disabled/></span>
+										 onClick="sendFax();" <%=isFaxDisabled%>/></span>
 						</td>
 					</tr>
 					<tr>
                             <td style="padding-top: 0"><span><input type=button value="Fax &amp; Add to encounter note"
                                     class="ControlPushButton" id="faxPasteButton" style="width: 210px"
-                                    onClick="printPaste2Parent(false, true, true);sendFax();" disabled/></span>
+                                    onClick="printPaste2Parent(false, true, true);sendFax();" <%=isFaxDisabled%>/></span>
 
                            </td>
                     </tr>


### PR DESCRIPTION
### Status Quo
When uploading a lab, OSCAR attempts to match a demographic record even if the Health Card Number (HCN) is an empty string.
The executed SQL query looks like:

```sql
SELECT demographic_no, provider_no 
FROM demographic
WHERE hin = ''
  AND year_of_birth LIKE '2000'
  AND month_of_birth LIKE '12'
  AND date_of_birth LIKE '24'
  AND sex LIKE 'M%';
```

### Change
Added a check to ensure HCN is not empty before executing the match query:
```java
!hinMod.trim().isEmpty()
```

This prevents matching demographics when the HCN is blank, ensuring only valid records are considered.