### PR TITLE
Prevent demographic match when Health Card Number is empty during lab upload

### DIFF
--- a/src/main/java/oscar/oscarLab/ca/all/upload/MessageUploader.java
+++ b/src/main/java/oscar/oscarLab/ca/all/upload/MessageUploader.java
@@ -676,7 +676,7 @@ public final class MessageUploader {
 				
 	
 				// HIN is ALWAYS required for lab matching. Please do not revert this code. Previous iterations have caused fatal patient miss-matches.				
-				if( hinMod != null ) {
+				if( hinMod != null && !hinMod.trim().isEmpty()) {
 					if (OscarProperties.getInstance().getBooleanProperty("LAB_NOMATCH_NAMES", "yes")) {
 						sql = "select demographic_no, provider_no from demographic where hin='" + hinMod + "' and " + " year_of_birth like '" + dobYear + "' and " + " month_of_birth like '" + dobMonth + "' and " + " date_of_birth like '" + dobDay + "' and " + " sex like '" + sex + "%' ";
 					} else {


### PR DESCRIPTION
### Status Quo
When uploading a lab, OSCAR attempts to match a demographic record even if the Health Card Number (HCN) is an empty string.
The executed SQL query looks like:

```sql
SELECT demographic_no, provider_no 
FROM demographic
WHERE hin = ''
  AND year_of_birth LIKE '2000'
  AND month_of_birth LIKE '12'
  AND date_of_birth LIKE '24'
  AND sex LIKE 'M%';
```

> [!IMPORTANT]
> **Why this is a problem:**
> 
> - If the incoming HL7 lab document does **not** contain a Health Card Number, OSCAR currently treats it as an empty string (`""`).  
> - The existing code only checks for `null` and not for empty values.  
> - As a result, OSCAR may attempt to match patients **without HCN**, which can lead to **attaching labs to the wrong patient** - a serious clinical safety issue.
> - Real-world scenario: A lab report for **John Doe** comes in without an HCN. OSCAR might incorrectly attach it to **Alex Smith**, another patient without an HCN, leading to potential clinical confusion.

---

### Change
Added a check to ensure HCN is not empty before executing the match query:
```java
!hinMod.trim().isEmpty()
```

This prevents matching demographics when the HCN is blank, ensuring only valid records are considered.