### PR TITLE
Hotfix-vRC.25: Fix type mismatch error for status parameter in search_scheduledate_datep method

### DIFF
--- a/src/main/java/org/oscarehr/common/dao/ScheduleDateDao.java
+++ b/src/main/java/org/oscarehr/common/dao/ScheduleDateDao.java
@@ -38,6 +38,6 @@ public interface ScheduleDateDao extends AbstractDao<ScheduleDate> {
     List<ScheduleDate> search_numgrpscheduledate(String myGroupNo, Date sDate);
     List<Object[]> search_appttimecode(Date sDate, String providerNo);
     List<ScheduleDate> search_scheduledate_teamp(Date date, Date date2, Character status, List<String> providerNos);
-    List<ScheduleDate> search_scheduledate_datep(Date date, Date date2, String status);
+    List<ScheduleDate> search_scheduledate_datep(Date date, Date date2, Character status);
     List<ScheduleDate> findByProviderStartDateAndPriority(String providerNo, Date apptDate, String priority);
 }

--- a/src/main/java/org/oscarehr/common/dao/ScheduleDateDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/ScheduleDateDaoImpl.java
@@ -123,7 +123,7 @@ public class ScheduleDateDaoImpl extends AbstractDaoImpl<ScheduleDate> implement
 	}
 	
     @Override
-	public List<ScheduleDate> search_scheduledate_datep(Date date, Date date2, String status) {
+	public List<ScheduleDate> search_scheduledate_datep(Date date, Date date2, Character status) {
 		Query query = entityManager.createQuery("select s from ScheduleDate s where s.date>=:sdate and s.date <=:edate and s.status=:status  order by s.date");
 		query.setParameter("sdate", date);
 		query.setParameter("edate", date2);

--- a/src/main/webapp/provider/appointmentprovideradminmonth.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminmonth.jsp
@@ -661,7 +661,7 @@
                                         param[0] = year + "-" + month + "-" + "1";
                                         param[1] = cal.get(Calendar.YEAR) + "-" + (cal.get(Calendar.MONTH) + 1) + "-" + "1";
                                         if (selectedSite == null) {
-                                            sds = scheduleDateDao.search_scheduledate_datep(ConversionUtils.fromDateString(year + "-" + month + "-" + "01"), ConversionUtils.fromDateString(cal.get(Calendar.YEAR) + "-" + (cal.get(Calendar.MONTH) + 1) + "-" + "01"), "A");
+                                            sds = scheduleDateDao.search_scheduledate_datep(ConversionUtils.fromDateString(year + "-" + month + "-" + "01"), ConversionUtils.fromDateString(cal.get(Calendar.YEAR) + "-" + (cal.get(Calendar.MONTH) + 1) + "-" + "01"), 'A');
                                         } else {
                                             List<String> ps = providerSiteDao.findByProviderNoBySiteName(selectedSite);
                                             sds = scheduleDateDao.search_scheduledate_teamp(ConversionUtils.fromDateString(year + "-" + month + "-" + "01"), ConversionUtils.fromDateString(cal.get(Calendar.YEAR) + "-" + (cal.get(Calendar.MONTH) + 1) + "-" + "01"), 'A', ps);


### PR DESCRIPTION
Fixed a `java.lang.IllegalArgumentException` caused by passing a String value ("A") to a parameter expecting a Character in the `search_scheduledate_datep` method.

**Changes made:**
- Updated the status parameter type from String to Character in ScheduleDateDao and ScheduleDateDaoImpl.
- Modified JSP and other relevant usage to pass Character type instead of String.

This resolves a runtime Hibernate binding error and ensures proper type handling for the status parameter.