### PR TITLE
Hotfix-vRC.25: Fix billing submission issue by refactoring DAO resolution to use Class<?> instead of bean names

### DIFF
--- a/src/main/java/org/oscarehr/common/dao/AbstractCodeSystemDao.java
+++ b/src/main/java/org/oscarehr/common/dao/AbstractCodeSystemDao.java
@@ -43,18 +43,18 @@ public interface AbstractCodeSystemDao<T extends AbstractCodeSystemModel<?>> ext
 
     public static enum codingSystem {icd9,icd10,ichppccode,msp,SnomedCore}
 
-    public static String getDaoName(codingSystem codeSystem) {
-        String object;
+    public static Class<?> getDaoName(codingSystem codeSystem) {
+        Class<?> object;
         switch(codeSystem) {
-            case SnomedCore: object = "snomedCoreDao";
+            case SnomedCore: object = SnomedCoreDao.class;
                 break;
-            case icd10: object = "icd10Dao";
+            case icd10: object = Icd10Dao.class;
                 break;
-            case icd9: object = "icd9Dao";
+            case icd9: object = Icd9Dao.class;
                 break;
-            case ichppccode: object = "ichppccodeDao";
+            case ichppccode: object = IchppccodeDao.class;
                 break;
-            case msp: object = "diagnosticCodeDao";
+            case msp: object = DiagnosticCodeDao.class;
                 break;
             default: throw new IllegalArgumentException("Unsupported code system: " + codeSystem + ". Please use one of icd9, ichppccode, snomedcore");
         }

--- a/src/main/java/org/oscarehr/common/dao/DiagnosticCodeDao.java
+++ b/src/main/java/org/oscarehr/common/dao/DiagnosticCodeDao.java
@@ -30,7 +30,7 @@ import java.util.List;
 import org.oscarehr.common.model.AbstractCodeSystemModel;
 import org.oscarehr.common.model.DiagnosticCode;
 
-public interface DiagnosticCodeDao extends AbstractDao<DiagnosticCode> {
+public interface DiagnosticCodeDao extends AbstractCodeSystemDao<DiagnosticCode> {
     List<DiagnosticCode> findByDiagnosticCode(String diagnosticCode);
     List<DiagnosticCode> findByDiagnosticCodeAndRegion(String diagnosticCode, String region);
     List<DiagnosticCode> search(String searchString);

--- a/src/main/java/org/oscarehr/common/dao/DxresearchDAOImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/DxresearchDAOImpl.java
@@ -475,7 +475,7 @@ public class DxresearchDAOImpl extends AbstractDaoImpl<Dxresearch> implements Dx
 	public String getDescription(String codingSystem, String code){
 		String description = null;
         try{ 
-	        String daoName = AbstractCodeSystemDao.getDaoName(AbstractCodeSystemDaoImpl.codingSystem.valueOf(codingSystem));
+	        Class<?> daoName = AbstractCodeSystemDao.getDaoName(AbstractCodeSystemDaoImpl.codingSystem.valueOf(codingSystem));
 	        @SuppressWarnings("unchecked")
 	        AbstractCodeSystemDao<AbstractCodeSystemModel<?>> csDao = (AbstractCodeSystemDao<AbstractCodeSystemModel<?>>) SpringUtils.getBean(daoName);
 	        

--- a/src/main/java/org/oscarehr/common/dao/Icd10Dao.java
+++ b/src/main/java/org/oscarehr/common/dao/Icd10Dao.java
@@ -30,7 +30,7 @@ import org.oscarehr.common.model.AbstractCodeSystemModel;
 import org.oscarehr.common.model.Icd10;
 import java.util.List;
 
-public interface Icd10Dao extends AbstractDao<Icd10> {
+public interface Icd10Dao extends AbstractCodeSystemDao<Icd10> {
     List<Icd10> searchCode(String term);
     Icd10 findByCode(String code);
     AbstractCodeSystemModel<?> findByCodingSystem(String codingSystem);

--- a/src/main/java/org/oscarehr/common/dao/Icd10DaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/Icd10DaoImpl.java
@@ -28,10 +28,13 @@ package org.oscarehr.common.dao;
 
 import org.oscarehr.common.model.AbstractCodeSystemModel;
 import org.oscarehr.common.model.Icd10;
+import org.springframework.stereotype.Repository;
+
 import javax.persistence.Query;
 import java.util.Collections;
 import java.util.List;
 
+@Repository
 public class Icd10DaoImpl extends AbstractDaoImpl<Icd10> implements Icd10Dao {
 
     public Icd10DaoImpl() {

--- a/src/main/java/org/oscarehr/managers/CodingSystemManager.java
+++ b/src/main/java/org/oscarehr/managers/CodingSystemManager.java
@@ -35,7 +35,7 @@ public class CodingSystemManager {
 
 	public String getCodeDescription(String codingSystem, String code) {
 		if(codingSystem != null && ! codingSystem.isEmpty() && code != null && ! code.isEmpty()) {		
-			String daoName = AbstractCodeSystemDao.getDaoName(AbstractCodeSystemDaoImpl.codingSystem.valueOf(codingSystem));
+			Class<?> daoName = AbstractCodeSystemDao.getDaoName(AbstractCodeSystemDaoImpl.codingSystem.valueOf(codingSystem));
 			if (daoName != null) {
 				AbstractCodeSystemDao<AbstractCodeSystemModel<?>> csDao = (AbstractCodeSystemDao<AbstractCodeSystemModel<?>>) SpringUtils.getBean(daoName);
 				if (csDao != null) {

--- a/src/main/java/oscar/oscarResearch/oscarDxResearch/bean/dxQuickListItemsHandler.java
+++ b/src/main/java/oscar/oscarResearch/oscarDxResearch/bean/dxQuickListItemsHandler.java
@@ -150,7 +150,7 @@ public class dxQuickListItemsHandler {
 	}
 
 	public static void updatePatientCodeDesc(String type, String code, String desc) {
-		String daoName = AbstractCodeSystemDao.getDaoName(AbstractCodeSystemDaoImpl.codingSystem.valueOf(type));
+		Class<?> daoName = AbstractCodeSystemDao.getDaoName(AbstractCodeSystemDaoImpl.codingSystem.valueOf(type));
 		@SuppressWarnings("unchecked")
 		AbstractCodeSystemDao<AbstractCodeSystemModel<?>> csDao = (AbstractCodeSystemDao<AbstractCodeSystemModel<?>>) SpringUtils.getBean(daoName);
 

--- a/src/main/java/oscar/oscarResearch/oscarDxResearch/pageUtil/dxResearchAction.java
+++ b/src/main/java/oscar/oscarResearch/oscarDxResearch/pageUtil/dxResearchAction.java
@@ -123,7 +123,7 @@ public class dxResearchAction extends Action {
 				}
 
 				if (count == 0) {
-					String daoName = AbstractCodeSystemDao.getDaoName(AbstractCodeSystemDao.codingSystem.valueOf(codingSystem));
+					Class<?> daoName = AbstractCodeSystemDao.getDaoName(AbstractCodeSystemDao.codingSystem.valueOf(codingSystem));
 					@SuppressWarnings("unchecked")
 					AbstractCodeSystemDao<AbstractCodeSystemModel<?>> csDao = (AbstractCodeSystemDao<AbstractCodeSystemModel<?>>) SpringUtils.getBean(daoName);
 

--- a/src/main/webapp/billing/CA/BC/billingCreated.jsp
+++ b/src/main/webapp/billing/CA/BC/billingCreated.jsp
@@ -55,7 +55,7 @@ if(!authed) {
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.util.ArrayList" %>
 <%
-	BillingreferralDao billingReferralDao = (BillingreferralDao)SpringUtils.getBean(BillingreferralDAO.class);
+	BillingreferralDao billingReferralDao = (BillingreferralDao)SpringUtils.getBean(BillingreferralDao.class);
 %>
 <%
 

--- a/src/test/java/org/oscarehr/common/dao/AbstractCodeSystemDaoTest.java
+++ b/src/test/java/org/oscarehr/common/dao/AbstractCodeSystemDaoTest.java
@@ -39,18 +39,18 @@ public class AbstractCodeSystemDaoTest extends DaoTestFixtures {
 	@Test
 	public void testGetDaoName_Valid() {
 		String codeSystem = "icd9";
-		assertEquals("icd9Dao", getDaoName(AbstractCodeSystemDao.codingSystem.valueOf(codeSystem)));
+		assertEquals(Icd9Dao.class, getDaoName(AbstractCodeSystemDao.codingSystem.valueOf(codeSystem)));
 		
 		codeSystem = "ichppccode";
-		assertEquals("ichppccodeDao", getDaoName(AbstractCodeSystemDao.codingSystem.valueOf(codeSystem)));
+		assertEquals(IchppccodeDao.class, getDaoName(AbstractCodeSystemDao.codingSystem.valueOf(codeSystem)));
 		
 		codeSystem = "SnomedCore";
-		assertEquals("snomedCoreDao", getDaoName(AbstractCodeSystemDao.codingSystem.valueOf(codeSystem)));
+		assertEquals(SnomedCoreDao.class, getDaoName(AbstractCodeSystemDao.codingSystem.valueOf(codeSystem)));
 	}
 	
 	@Test(expected=IllegalArgumentException.class)
 	public void testGetDaoName_Invalid() {
 		String codeSystem = "FAIL";
-		assertEquals("failDao", getDaoName(AbstractCodeSystemDao.codingSystem.valueOf(codeSystem)));
+		assertEquals(Object.class, getDaoName(AbstractCodeSystemDao.codingSystem.valueOf(codeSystem)));
 	}
 }


### PR DESCRIPTION
Fixed a critical issue where billing submission was failing due to Spring being unable to resolve the correct DAO bean by name.

**Changes:**
- Replaced string-based DAO name resolution with class-based resolution using `Class<?>`
- Updated `getDaoName` method to return DAO class types instead of strings
- Ensured all DAO implementations extend `AbstractCodeSystemDao` for consistent typing
- Verified compatibility across modules including billing, tests, and JSP files
