### PR TITLE
Fix email tool crash due to missing _hrm permission in non-Ontario regions

### DIFF
--- a/src/main/java/org/oscarehr/email/action/EmailComposeAction.java
+++ b/src/main/java/org/oscarehr/email/action/EmailComposeAction.java
@@ -58,7 +58,7 @@ public class EmailComposeAction extends DispatchAction {
             emailAttachmentList.addAll(emailComposeManager.prepareEFormAttachments(loggedInInfo, fdid, attachedEForms));
             emailAttachmentList.addAll(emailComposeManager.prepareEDocAttachments(loggedInInfo, attachedDocuments));
             emailAttachmentList.addAll(emailComposeManager.prepareLabAttachments(loggedInInfo, attachedLabs));
-            if (!OscarProperties.getInstance().isBritishColumbiaBillingRegion()) {
+            if (OscarProperties.getInstance().isOntarioBillingRegion()) {
                 emailAttachmentList.addAll(emailComposeManager.prepareHRMAttachments(loggedInInfo, attachedHRMDocuments));
             }
             emailAttachmentList.addAll(emailComposeManager.prepareFormAttachments(request, response, attachedForms, Integer.parseInt(demographicId)));

--- a/src/main/java/org/oscarehr/hospitalReportManager/HRMUtil.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/HRMUtil.java
@@ -57,7 +57,7 @@ public class HRMUtil {
 	 * Because multiple versions of a single HRM document can be received, 
 	 */
 	public static ArrayList<HashMap<String, ? extends Object>> listHRMDocuments(LoggedInInfo loggedInInfo, String sortBy, boolean sortAsc, String demographicNo,boolean filterDuplicates){
-		if (OscarProperties.getInstance().isBritishColumbiaBillingRegion()) {
+		if (!OscarProperties.getInstance().isOntarioBillingRegion()) {
 			return new ArrayList<>();
 		}
 		if (!securityInfoManager.hasPrivilege(loggedInInfo, "_hrm", SecurityInfoManager.READ, null)) {

--- a/src/main/java/org/oscarehr/managers/EmailComposeManager.java
+++ b/src/main/java/org/oscarehr/managers/EmailComposeManager.java
@@ -120,7 +120,7 @@ public class EmailComposeManager {
     }
 
     public List<EmailAttachment> prepareHRMAttachments(LoggedInInfo loggedInInfo, String[] attachedHRMDocuments) throws PDFGenerationException {
-        if (OscarProperties.getInstance().isBritishColumbiaBillingRegion()) {
+        if (!OscarProperties.getInstance().isOntarioBillingRegion()) {
             return new ArrayList<>();
         }
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_hrm", SecurityInfoManager.READ, null)) {


### PR DESCRIPTION
## Problem
The email tool was crashing in non-Ontario regions (e.g., British Columbia) when users attempted to compose emails with attachments. This was caused by the system attempting to check for HRM (Hospital Report Manager) attachments, but non-Ontario regions don't have the `_hrm` security permission configured since HRM is Ontario-specific.

## Solution
Added defensive checks:

  1. `EmailComposeAction.java`: Only prepare HRM attachments for Ontario regions
     ```java
     if (OscarProperties.getInstance().isOntarioBillingRegion()) {
         emailAttachmentList.addAll(emailComposeManager.prepareHRMAttachments(loggedInInfo, attachedHRMDocuments));
     }

  2. `EmailComposeManager.prepareHRMAttachments()`: Return empty list instead of throwing exception
    - Check if Ontario region → if not, return empty list
    - Check if user has `_hrm` permission → if not, return empty list with warning log
    - Changed from throwing RuntimeException to graceful degradation
   
  3. `HRMUtil.listHRMDocuments()`: Added region and permission guards
    - Return empty list for non-Ontario regions
    - Return empty list when `_hrm` permission is missing (with warning log)