### PR TITLE
Feature-vRC.25: Concurrent session management

### DIFF
--- a/src/main/java/org/oscarehr/managers/UserSessionManager.java
+++ b/src/main/java/org/oscarehr/managers/UserSessionManager.java
@@ -23,9 +23,8 @@
 
 package org.oscarehr.managers;
 
-import org.oscarehr.common.exception.UserSessionNotFoundException;
-
 import javax.servlet.http.HttpSession;
+import java.util.Collection;
 
 /**
  * Manages user sessions.  Provides methods to register, unregister, and retrieve user sessions based on a user security code.
@@ -35,24 +34,26 @@ import javax.servlet.http.HttpSession;
 public interface UserSessionManager {
 
     /**
-     * Registers a user session.
-     * @param userSecurityCode The user's security code.
-     * @param session The HTTP session object.
+     * Registers a user session with a policy to either invalidate existing sessions or keep them.
+     *
+     * @param userSecurityCode the user's security code
+     * @param session the HTTP session
+     * @param invalidateExisting if true, invalidate all existing sessions for the user before registering the new one; if false, keep existing sessions and add the new one
      */
-    void registerUserSession(Integer userSecurityCode, HttpSession session);
+    void registerUserSession(Integer userSecurityCode, HttpSession session, boolean invalidateExisting);
 
     /**
-     * Unregisters a user session.
-     * @param userSecurityCode The user's security code.
-     * @return The unregistered HTTP session object.
-     * @throws UserSessionNotFoundException If the user session is not found.
+     * Unregister a specific session for a user. If the session or user is not present, this is a no-op.
+     * @param userSecurityCode the user's security code
+     * @param session the HTTP session to unregister
      */
-    HttpSession unregisterUserSession(Integer userSecurityCode) throws UserSessionNotFoundException;
+    void unregisterUserSession(Integer userSecurityCode, HttpSession session);
 
     /**
-     * Retrieves a registered user session.
-     * @param userSecurityCode The user's security code.
-     * @return The registered HTTP session object, or null if not found.
+     * Returns all registered sessions for a user. Returns an empty collection if none are present.
+     * @param userSecurityCode the user's security code
+     * @return collection of sessions
      */
-    HttpSession getRegisteredSession(Integer userSecurityCode);
+    Collection<HttpSession> getRegisteredSessions(Integer userSecurityCode);
+
 }

--- a/src/main/java/org/oscarehr/web/OscarSessionListener.java
+++ b/src/main/java/org/oscarehr/web/OscarSessionListener.java
@@ -57,15 +57,16 @@ public class OscarSessionListener implements HttpSessionListener {
 		}
 
 		HttpSession session = se.getSession();
-		Integer userSecurityCode = (Integer) session.getAttribute(UserSessionManagerImpl.KEY_USER_SECURITY_CODE);
-		if (userSecurityCode != null) {
-			try {
-				UserSessionManager userSessionManager = SpringUtils.getBean(UserSessionManager.class);
-				userSessionManager.unregisterUserSession(userSecurityCode);
-			} catch (UserSessionNotFoundException e) {
-				MiscUtils.getLogger().warn("Failed to unregister session on destroy: {}", e.getMessage());
-			}
-		}
+  		Integer userSecurityCode = (Integer) session.getAttribute(UserSessionManagerImpl.KEY_USER_SECURITY_CODE);
+	    if (userSecurityCode != null) {
+		    try {
+			    UserSessionManager userSessionManager = SpringUtils.getBean(UserSessionManager.class);
+			    // Unregister only this specific session; ignore if not present
+			    userSessionManager.unregisterUserSession(userSecurityCode, session);
+		    } catch (Exception e) {
+			    MiscUtils.getLogger().warn("Failed to unregister session on destroy: {}", e.getMessage());
+		    }
+	  }
 	}
 
 }

--- a/src/main/java/oscar/login/ManageSessionsForm.java
+++ b/src/main/java/oscar/login/ManageSessionsForm.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2005-2012. Centre for Research on Inner City Health, St. Michael's Hospital, Toronto. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for
+ * Centre for Research on Inner City Health, St. Michael's Hospital,
+ * Toronto, Ontario, Canada
+ */
+
+package oscar.login;
+
+import org.apache.struts.action.ActionForm;
+
+public class ManageSessionsForm extends ActionForm {
+
+    public static final String SESSION_CHOICE_INVALIDATE = "invalidate";
+    public static final String SESSION_CHOICE_KEEP = "keep";
+
+    private boolean isManageSessionsFlow;
+    private String sessionChoice;
+
+    public boolean invalidateOtherSessions() {
+        return this.sessionChoice.equalsIgnoreCase("invalidate");
+    }
+
+    public String getSessionChoice() {
+        return sessionChoice;
+    }
+
+    public void setSessionChoice(String sessionChoice) {
+        this.sessionChoice = sessionChoice;
+    }
+
+    public boolean isManageSessionsFlow() {
+        return isManageSessionsFlow;
+    }
+
+    public void setManageSessionsFlow(boolean isManageSessionsFlow) {
+        this.isManageSessionsFlow = isManageSessionsFlow;
+    }
+}

--- a/src/main/webapp/WEB-INF/struts-config.xml
+++ b/src/main/webapp/WEB-INF/struts-config.xml
@@ -626,6 +626,7 @@
 		<form-bean name="eCaresForm" type="org.apache.struts.validator.LazyValidatorForm" />
 
 		<form-bean name="validateMFAForm" type="oscar.login.ValidateMFAForm" />
+		<form-bean name="ManageSessionsForm" type="oscar.login.ManageSessionsForm" />
 
 	</form-beans>
 
@@ -828,6 +829,7 @@
 			<forward name="programLocation" path="/location.jsp" redirect="true"/>
 			<forward name="ssoLogin" path="/ssoLogin.do" redirect="true" />
 			<forward name="mfaHandler" path="/mfa/mfa_handler.jsp" />
+			<forward name="manageSessions" path="/login/manageSessions.jsp" />
 		</action>
 		
 		<action input="/login.jsp" name="loginForm" path="/ssoLogin" scope="request" type="oscar.login.SSOLoginAction" validate="true" parameter="method">
@@ -851,6 +853,19 @@
 
 		<!-- MFA -->
 		<action input="/mfa/mfa_handler.jsp" name="validateMFAForm" path="/mfa/loginMfa" scope="request" type="oscar.login.LoginAction" validate="true">
+			<forward name="provider" path="/provider/providercontrol.jsp" redirect="true" />
+			<forward name="failure" path="/logout.jsp" />
+			<forward name="error" path="/loginfailed.jsp" />
+			<forward name="caisiPMM" path="/PMmodule/ProviderInfo.do" />
+			<forward name="shelterSelection" path="/shelterSelection.do" redirect="true" />
+			<forward name="forcepasswordreset" path="/forcepasswordreset.jsp" />
+			<forward name="programLocation" path="/location.jsp" redirect="true"/>
+			<forward name="ssoLogin" path="/ssoLogin.do" redirect="true" />
+			<forward name="mfaHandler" path="/mfa/mfa_handler.jsp" />
+		</action>
+
+		<!-- MFA -->
+		<action input="/login/manageSessions.jsp" name="ManageSessionsForm" path="/session/loginManageSessions" scope="request" type="oscar.login.LoginAction" validate="true">
 			<forward name="provider" path="/provider/providercontrol.jsp" redirect="true" />
 			<forward name="failure" path="/logout.jsp" />
 			<forward name="error" path="/loginfailed.jsp" />

--- a/src/main/webapp/login/manageSessions.jsp
+++ b/src/main/webapp/login/manageSessions.jsp
@@ -1,0 +1,78 @@
+<%--
+
+   Copyright (c) 2005-2012. Centre for Research on Inner City Health, St. Michael's Hospital, Toronto. All Rights Reserved.
+   This software is published under the GPL GNU General Public License.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+   <p>
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+   <p>
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+   <p>
+   This software was written for
+   Centre for Research on Inner City Health, St. Michael's Hospital,
+   Toronto, Ontario, Canada
+
+--%>
+
+<%@ page import="oscar.login.ManageSessionsForm" %>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Session Choice</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <c:set var="ctx" value="${ pageContext.request.contextPath }" scope="page"/>
+    <link rel="stylesheet" href="${ctx}/library/bootstrap/5.0.2/css/bootstrap.min.css" type="text/css"/>
+    <script type="text/javascript" src="${ctx}/library/bootstrap/5.0.2/js/bootstrap.min.js"></script>
+</head>
+<body>
+<div class="container p-5 d-flex align-items-center justify-content-center">
+    <div class="card shadow-sm w-100" style="max-width: 640px;">
+        <div class="card-body">
+            <h1 class="h5 mb-3">Other active sessions detected</h1>
+            <p class="mb-1">
+                We noticed that you have
+                <strong><c:out value="${requestScope.otherSessionCount}"/></strong>
+                other session<c:if test="${requestScope.otherSessionCount != 1}">s</c:if> currently signed in.
+            </p>
+            <p class="text-muted">Please choose how you want to proceed:</p>
+
+            <form action="<%= request.getContextPath() %>/session/loginManageSessions.do" method="post">
+                <input type="hidden" name="manageSessionsFlow" value="${requestScope.manageSessionFlow}"/>
+
+                <div class="row g-2 mt-2">
+                    <div class="col-12 col-md-6">
+                        <button type="submit"
+                                class="btn btn-outline-secondary w-100"
+                                name="sessionChoice"
+                                value="<%=ManageSessionsForm.SESSION_CHOICE_KEEP%>">
+                            Keep other sessions signed in
+                        </button>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <button type="submit"
+                                class="btn btn-danger w-100"
+                                name="sessionChoice"
+                                value="<%=ManageSessionsForm.SESSION_CHOICE_INVALIDATE%>">
+                            Sign out other sessions
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Added concurrent session management. Previously, a new login would invalidate any existing session for the same user. With this change, users can maintain multiple active sessions across different browsers or devices.
When a user with at least one active session logs in again, they are now presented with a screen asking them how to proceed.

<img width="1919" height="1101" alt="image" src="https://github.com/user-attachments/assets/300673c7-22e4-4e1e-b664-3673bee38dad" />


1. User-Facing Choice:
    - A new page `manageSessions.jsp` is shown after login if other sessions are detected.
    - The user can choose to:
    - Keep other sessions signed in: The new session is created, and all previous sessions remain active.
    - Sign out other sessions: The new session is created, and all other sessions for that user are invalidated.
2. Backend Implementation:
    - `UserSessionManager`: Refactored to handle a collection of HttpSession objects per user instead of a single session. This is the core change enabling multi-session support.
    - `LoginAction`: The login flow is updated to check for existing sessions post-authentication. If multiple sessions exist, it forwards the user to the new session management page. It also contains the logic to handle the user's choice.
    - `OscarSessionListener`: Modified to unregister only the specific session that is being destroyed, preventing unintended logouts of other active sessions.
    - Configuration: Added new form beans and action mappings to struts-config.xml to support the new workflow.