### PR TITLE
Hotfix-v24.09: Update textarea wrap attribute to 'soft' for edit note

### DIFF
--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -1986,7 +1986,7 @@ function editNote(e) {
     Element.remove(txtId);
     caseNote = "caseNote_note" + nId;
 
-    var input = "<textarea tabindex='7' cols='84' rows='10' wrap='hard' class='txtArea boxsizingBorder edit-textarea' style='line-height:1.1em;' name='caseNote_note' id='" + caseNote + "'>" + payload + "<\/textarea>";
+    var input = "<textarea tabindex='7' cols='84' rows='10' wrap='soft' class='txtArea boxsizingBorder edit-textarea' style='line-height:1.1em;' name='caseNote_note' id='" + caseNote + "'>" + payload + "<\/textarea>";
     new Insertion.Top(txt, input);
     var printimg = "<div class='tool-button print-button'><img title='Print' id='print" + nId + "' alt='Toggle Print Note' onclick='togglePrint(" + nId + ", event)' style='float:right; margin-right:5px;' src='" + ctx + "/oscarEncounter/graphics/printer.png'></div>";
 
@@ -2901,7 +2901,7 @@ function newNote(e) {
     var newNoteIdx = "0" + newNoteCounter;
     var id = "nc" + newNoteIdx;
     var sigId = "sig"+ newNoteIdx;
-    var input = "<textarea tabindex='7' cols='84' rows='1' wrap='hard' class='txtArea boxsizingBorder' style='line-height:1.0em;' name='caseNote_note' id='caseNote_note" + newNoteIdx + "'>" + reason + "<\/textarea>";
+    var input = "<textarea tabindex='7' cols='84' rows='1' wrap='soft' class='txtArea boxsizingBorder' style='line-height:1.0em;' name='caseNote_note' id='caseNote_note" + newNoteIdx + "'>" + reason + "<\/textarea>";
     var passwd = "";
     if( passwordEnabled ) {
         passwd = "<p style='background-color:#CCCCFF; display:none; margin:0;' id='notePasswd'>Password:&nbsp;<input type='password' name='caseNote.password'/><\/p>";


### PR DESCRIPTION
- Changed 'wrap' attribute from 'hard' to 'soft' in case note textareas
- Prevents Firefox 145+ from inserting unwanted CRLF line breaks during text wrapping