### PR TITLE
Allow providers to file results on behalf of other providers

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/ProviderLabRoutingDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ProviderLabRoutingDao.java
@@ -25,7 +25,7 @@ public interface ProviderLabRoutingDao extends AbstractDao<ProviderLabRoutingMod
     }
 
     public enum STATUS {
-        X, N, A, D
+        X, N, A, D, F
     }
 
     public List<ProviderLabRoutingModel> findByLabNoAndLabTypeAndProviderNo(int labNo, String labType,

--- a/src/main/java/ca/openosp/openo/lab/ca/on/CommonLabResultData.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/on/CommonLabResultData.java
@@ -605,6 +605,10 @@ public class CommonLabResultData {
     }
 
     public static boolean fileLabs(ArrayList<String[]> flaggedLabs, String provider) {
+		return fileLabs(flaggedLabs, provider, "");
+	}
+
+    public static boolean fileLabs(ArrayList<String[]> flaggedLabs, String provider, String comment) {
 
         CommonLabResultData data = new CommonLabResultData();
         boolean success = Boolean.FALSE;
@@ -618,12 +622,12 @@ public class CommonLabResultData {
             if (labs != null && !labs.equals("")) {
                 String[] labArray = labs.split(",");
                 for (int j = 0; j < labArray.length; j++) {
-                    success = updateReportStatus(Integer.parseInt(labArray[j]), provider, 'F', "", labType);
+                    success = updateReportStatus(Integer.parseInt(labArray[j]), provider, 'F', comment, labType);
                     removeFromQueue(Integer.parseInt(labArray[j]));
                 }
 
             } else {
-                success = updateReportStatus(Integer.parseInt(lab), provider, 'F', "", labType);
+                success = updateReportStatus(Integer.parseInt(lab), provider, 'F', comment, labType);
                 removeFromQueue(Integer.parseInt(lab));
             }
 

--- a/src/main/java/ca/openosp/openo/lab/ca/on/CommonLabResultData.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/on/CommonLabResultData.java
@@ -59,6 +59,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 public class CommonLabResultData {
 
@@ -408,16 +409,15 @@ public class CommonLabResultData {
             for (ProviderLabRoutingModel providerLabRoutingModel : providerLabRoutingModelList) {
                 providerLabRoutingModel.setStatus("" + status);
 
-                //we don't want to clobber existing comments when filing labs
-                String currentComment = providerLabRoutingModel.getComment();
-                if (currentComment == null) {
-                    currentComment = "";
-                }
-
-                // use the new incoming comment on these conditions.
-                if (!comment.isEmpty() && !comment.equalsIgnoreCase(currentComment.trim())) {
-                    providerLabRoutingModel.setComment(comment.replaceAll(currentComment, currentComment));
-                }
+                // we don't want to clobber existing comments when filing labs
+				// skipCommentOnUpdate: if true, do not update the comment at all
+				if (!skipCommentOnUpdate) {
+					String currentComment = Optional.ofNullable(providerLabRoutingModel.getComment()).orElse("").trim();
+					if (!comment.isEmpty() && !comment.equalsIgnoreCase(currentComment)) {
+						providerLabRoutingModel.setComment(comment.replaceAll(currentComment, currentComment));
+					}
+				}
+                
                 providerLabRoutingModel.setTimestamp(new Date());
                 providerLabRoutingDao.merge(providerLabRoutingModel);
             }
@@ -596,19 +596,17 @@ public class CommonLabResultData {
     }
 
     public static boolean fileLabs(ArrayList<String[]> flaggedLabs, LoggedInInfo loggedInInfo) {
-
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_lab", SecurityInfoManager.WRITE, null)) {
-            throw new SecurityException("missing required sec object (_lab)");
-        }
-        return fileLabs(flaggedLabs, loggedInInfo.getLoggedInProviderNo());
-
+        return fileLabs(flaggedLabs, loggedInInfo.getLoggedInProviderNo(), loggedInInfo);
+        
+    }
+    public static boolean fileLabs(ArrayList<String[]> flaggedLabs, String provider, LoggedInInfo loggedInInfo) {
+        return fileLabs(flaggedLabs, provider, "", loggedInInfo);
     }
 
-    public static boolean fileLabs(ArrayList<String[]> flaggedLabs, String provider) {
-		return fileLabs(flaggedLabs, provider, "");
-	}
-
-    public static boolean fileLabs(ArrayList<String[]> flaggedLabs, String provider, String comment) {
+    public static boolean fileLabs(ArrayList<String[]> flaggedLabs, String provider, String comment, LoggedInInfo loggedInInfo) {
+        if(!securityInfoManager.hasPrivilege(loggedInInfo, "_lab", SecurityInfoManager.WRITE, null)) {
+            throw new SecurityException("missing required security object (_lab)");
+        }
 
         CommonLabResultData data = new CommonLabResultData();
         boolean success = Boolean.FALSE;
@@ -639,7 +637,7 @@ public class CommonLabResultData {
     }
 
 
-    private static void removeFromQueue(Integer lab_no) {
+    public static void removeFromQueue(Integer lab_no) {
         List<QueueDocumentLink> queues = queueDocumentLinkDao.getQueueFromDocument(lab_no);
 
         for (QueueDocumentLink queue : queues) {

--- a/src/main/java/ca/openosp/openo/lab/pageUtil/FileLabs2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/pageUtil/FileLabs2Action.java
@@ -145,11 +145,11 @@ public class FileLabs2Action extends ActionSupport {
         String labType = request.getParameter("labType");
         String comment = request.getParameter("comment");
         boolean fileUpToLabNo = Boolean.valueOf(request.getParameter("fileUpToLabNo"));
-        boolean onBehalfOfMultipleProviders = Boolean.valueOf(request.getParameter("onBehalfOfMultipleProviders"));
+        boolean onBehalfOfOtherProvider = Boolean.valueOf(request.getParameter("onBehalfOfOtherProvider"));
 
         if (providerNo == null || flaggedLab == null) { return null; }
 
-        labManager.fileLabsForProviderUpToFlaggedLab(loggedInInfo, providerNo, flaggedLab, labType, comment, fileUpToLabNo, onBehalfOfMultipleProviders);
+        labManager.fileLabsForProviderUpToFlaggedLab(loggedInInfo, providerNo, flaggedLab, labType, comment, fileUpToLabNo, onBehalfOfOtherProvider);
 
         return null;
     }

--- a/src/main/java/ca/openosp/openo/lab/pageUtil/FileLabs2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/pageUtil/FileLabs2Action.java
@@ -46,6 +46,7 @@ import ca.openosp.openo.lab.ca.on.CommonLabResultData;
 
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.dispatcher.mapper.ActionMapping;
 
 public class FileLabs2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
@@ -126,4 +127,26 @@ public class FileLabs2Action extends ActionSupport {
 
         return null;
     }
+
+    @SuppressWarnings("unused")
+	public String fileLabAjaxByProvider()
+	{
+		if(!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_lab", "w", null)) {
+			throw new SecurityException("missing required security object (_lab)");
+		}
+		
+		String providerNo = request.getParameter("providerNo").trim();
+		String flaggedLab = request.getParameter("flaggedLabId").trim();
+		String labType = request.getParameter("labType").trim();
+		String comment = request.getParameter("comment").trim();
+
+		if (providerNo == null || flaggedLab == null) { return null; }
+
+		ArrayList<String[]> listFlaggedLabs = new ArrayList<String[]>();
+		String[] la = new String[] {flaggedLab,labType};
+		listFlaggedLabs.add(la);
+		CommonLabResultData.fileLabs(listFlaggedLabs, providerNo, comment);
+
+		return null;
+	}
 }

--- a/src/main/java/ca/openosp/openo/lab/pageUtil/FileLabs2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/pageUtil/FileLabs2Action.java
@@ -46,7 +46,6 @@ import ca.openosp.openo.lab.ca.on.CommonLabResultData;
 
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
-import org.apache.struts2.dispatcher.mapper.ActionMapping;
 
 public class FileLabs2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
@@ -61,6 +60,8 @@ public class FileLabs2Action extends ActionSupport {
     public String execute() {
         if ("fileLabAjax".equals(request.getParameter("method"))) {
             return fileLabAjax();
+        } else if ("fileLabAjaxByProvider".equals(request.getParameter("method"))) {
+            return fileLabAjaxByProvider();
         }
 
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/java/ca/openosp/openo/managers/LabManager.java
+++ b/src/main/java/ca/openosp/openo/managers/LabManager.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import ca.openosp.openo.commn.model.Hl7TextInfo;
 import ca.openosp.openo.commn.model.Hl7TextMessage;
+import ca.openosp.openo.commn.model.ProviderLabRoutingModel;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.PDFGenerationException;
 
@@ -44,4 +45,8 @@ public interface LabManager {
     public Hl7TextMessage getHl7Message(LoggedInInfo loggedInInfo, int labId);
 
     public Path renderLab(LoggedInInfo loggedInInfo, Integer segmentId) throws PDFGenerationException;
+
+    public List<ProviderLabRoutingModel> findByLabNoAndLabTypeAndProviderNo(LoggedInInfo loggedInInfo, Integer labId, String labType, String providerNo);
+
+    public void fileLabsForProviderUpToFlaggedLab(LoggedInInfo loggedInInfo, String providerNo, String flaggedLabId, String labType, String comment, boolean fileUpToLabNo, boolean onBehalfOfMultipleProviders);
 }

--- a/src/main/java/ca/openosp/openo/managers/LabManager.java
+++ b/src/main/java/ca/openosp/openo/managers/LabManager.java
@@ -48,5 +48,5 @@ public interface LabManager {
 
     public List<ProviderLabRoutingModel> findByLabNoAndLabTypeAndProviderNo(LoggedInInfo loggedInInfo, Integer labId, String labType, String providerNo);
 
-    public void fileLabsForProviderUpToFlaggedLab(LoggedInInfo loggedInInfo, String providerNo, String flaggedLabId, String labType, String comment, boolean fileUpToLabNo, boolean onBehalfOfMultipleProviders);
+    public void fileLabsForProviderUpToFlaggedLab(LoggedInInfo loggedInInfo, String providerNo, String flaggedLabId, String labType, String comment, boolean fileUpToLabNo, boolean onBehalfOfOtherProvider);
 }

--- a/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
@@ -152,17 +152,21 @@ public class LabManagerImpl implements LabManager {
     /**
      * Files lab results for a provider up to (and including) a specific flagged lab,
      * depending on the fileUpToLabNo flag. Skips acknowledged or already filed results.
+     * 
+     * This method is specifically designed to support filing labs on behalf of another provider,
+     * so the logic and conditions (such as checking for lab status 'N' when filing on behalf) 
+     * are tailored for that use case.
      *
-     * @param loggedInInfo      the currently logged-in user
-     * @param providerNo        the provider number
-     * @param flaggedLabId      the lab ID that was flagged (i.e., selected by the user)
-     * @param labType           the type of the lab
-     * @param comment           the comment to add while filing
-     * @param fileUpToLabNo     if true, file all labs up to and including flaggedLabId
-     * @param onBehalfOfMultipleProviders if true, updates lab status only if it is 'N' (Not Acknowledged)
+     * @param loggedInInfo                 the currently logged-in user
+     * @param providerNo                   the provider number
+     * @param flaggedLabId                 the lab ID that was flagged (i.e., selected by the user)
+     * @param labType                      the type of the lab
+     * @param comment                      the comment to add while filing
+     * @param fileUpToLabNo                if true, file all labs up to and including flaggedLabId
+     * @param onBehalfOfOtherProvider      if true, updates lab status only if it is 'N' (Not Acknowledged)
      */
     @Override
-    public void fileLabsForProviderUpToFlaggedLab(LoggedInInfo loggedInInfo, String providerNo, String flaggedLabId, String labType, String comment, boolean fileUpToLabNo, boolean onBehalfOfMultipleProviders) {
+    public void fileLabsForProviderUpToFlaggedLab(LoggedInInfo loggedInInfo, String providerNo, String flaggedLabId, String labType, String comment, boolean fileUpToLabNo, boolean onBehalfOfOtherProvider) {
         checkPrivilege(loggedInInfo, "w");
 
         CommonLabResultData commonLabResultData = new CommonLabResultData();
@@ -192,7 +196,7 @@ public class LabManagerImpl implements LabManager {
 
             // Skip if lab is already Acknowledged or Filed
             String status = providerLabRouting.getStatus();
-            if (ProviderLabRoutingDao.STATUS.A.name().equals(status) || ProviderLabRoutingDao.STATUS.F.name().equals(status)) {
+            if (onBehalfOfOtherProvider && ProviderLabRoutingDao.STATUS.A.name().equals(status) || ProviderLabRoutingDao.STATUS.F.name().equals(status)) {
                 continue;
             }
 

--- a/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
@@ -33,15 +33,19 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import ca.openosp.openo.commn.dao.Hl7TextInfoDao;
 import ca.openosp.openo.commn.dao.Hl7TextMessageDao;
 import ca.openosp.openo.commn.dao.PatientLabRoutingDao;
+import ca.openosp.openo.commn.dao.ProviderLabRoutingDao;
 import ca.openosp.openo.commn.model.Hl7TextInfo;
 import ca.openosp.openo.commn.model.Hl7TextMessage;
 import ca.openosp.openo.commn.model.PatientLabRouting;
+import ca.openosp.openo.commn.model.ProviderLabRoutingModel;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.PDFGenerationException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +55,7 @@ import com.itextpdf.text.DocumentException;
 
 import ca.openosp.openo.log.LogAction;
 import ca.openosp.openo.lab.ca.all.pageUtil.LabPDFCreator;
+import ca.openosp.openo.lab.ca.on.CommonLabResultData;
 import ca.openosp.openo.util.StringUtils;
 
 
@@ -65,6 +70,9 @@ public class LabManagerImpl implements LabManager {
 
     @Autowired
     Hl7TextMessageDao hl7TextMessageDao;
+
+    @Autowired
+    private ProviderLabRoutingDao providerLabRoutingDao;
 
     @Autowired
     private NioFileManager nioFileManager;
@@ -133,6 +141,65 @@ public class LabManagerImpl implements LabManager {
         }
 
         return path;
+    }
+
+    @Override
+    public List<ProviderLabRoutingModel> findByLabNoAndLabTypeAndProviderNo(LoggedInInfo loggedInInfo, Integer labId, String labType, String providerNo) {
+        checkPrivilege(loggedInInfo, "r");
+        return providerLabRoutingDao.findByLabNoAndLabTypeAndProviderNo(labId, labType, providerNo);
+    }
+
+    /**
+     * Files lab results for a provider up to (and including) a specific flagged lab,
+     * depending on the fileUpToLabNo flag. Skips acknowledged or already filed results.
+     *
+     * @param loggedInInfo      the currently logged-in user
+     * @param providerNo        the provider number
+     * @param flaggedLabId      the lab ID that was flagged (i.e., selected by the user)
+     * @param labType           the type of the lab
+     * @param comment           the comment to add while filing
+     * @param fileUpToLabNo     if true, file all labs up to and including flaggedLabId
+     * @param onBehalfOfMultipleProviders if true, updates lab status only if it is 'N' (Not Acknowledged)
+     */
+    @Override
+    public void fileLabsForProviderUpToFlaggedLab(LoggedInInfo loggedInInfo, String providerNo, String flaggedLabId, String labType, String comment, boolean fileUpToLabNo, boolean onBehalfOfMultipleProviders) {
+        checkPrivilege(loggedInInfo, "w");
+
+        CommonLabResultData commonLabResultData = new CommonLabResultData();
+
+        // Gets lab IDs in order from oldest to latest (e.g., v1, v2, ..., vn)
+        String labs = commonLabResultData.getMatchingLabs(flaggedLabId, labType);
+
+        // Filter labs: if fileUpToLabNo is true, include only those <= flaggedLabId
+        List<Integer> filteredLabs = Arrays.stream(labs.split(","))
+                .map(String::trim)
+                .map(Integer::parseInt)
+                .filter(labId -> !fileUpToLabNo || labId <= Integer.parseInt(flaggedLabId))
+                .collect(Collectors.toList());
+
+        for (Integer labId : filteredLabs) {
+            // Get routing info for the lab and provider
+            List<ProviderLabRoutingModel> providerLabRoutings = findByLabNoAndLabTypeAndProviderNo(loggedInInfo, labId, labType, providerNo);
+            if (providerLabRoutings.isEmpty()) continue;
+
+            ProviderLabRoutingModel providerLabRouting = providerLabRoutings.get(0);
+
+            // Determine whether to skip updating comment based on existing content
+            boolean skipCommentOnUpdate = true;
+            if (providerLabRouting.getComment() == null || providerLabRouting.getComment().trim().isEmpty()) {
+                skipCommentOnUpdate = false;
+            }
+
+            // Skip if lab is already Acknowledged or Filed
+            String status = providerLabRouting.getStatus();
+            if (ProviderLabRoutingDao.STATUS.A.name().equals(status) || ProviderLabRoutingDao.STATUS.F.name().equals(status)) {
+                continue;
+            }
+
+            // Update report status and remove it from the queue
+            CommonLabResultData.updateReportStatus(labId, providerNo, ProviderLabRoutingDao.STATUS.F.name().charAt(0),comment, labType, skipCommentOnUpdate);
+            CommonLabResultData.removeFromQueue(labId);
+        }
     }
 
     private void checkPrivilege(LoggedInInfo loggedInInfo, String privilege) {

--- a/src/main/java/ca/openosp/openo/managers/ProviderManager2.java
+++ b/src/main/java/ca/openosp/openo/managers/ProviderManager2.java
@@ -758,7 +758,7 @@ public class ProviderManager2 {
 		return propertyDao.isActiveBooleanProperty(Property.PROPERTY_KEY.auto_link_to_mrp);
 	}
 
-	// If no property is found, it returns true by default.
+	// If no property is found, it returns false by default.
 	public boolean isHl7OfferFileForOthers(LoggedInInfo loggedInInfo, String providerNo) {
 		if (!securityInfoManager.hasPrivilege(loggedInInfo, "_lab", SecurityInfoManager.READ, null)) {
 			throw new RuntimeException("missing required security object _lab");
@@ -768,7 +768,7 @@ public class ProviderManager2 {
 				.stream()
 				.findFirst()
 				.map(p -> "true".equals(p.getValue()))
-				.orElse(true); // default to true
+				.orElse(false); // default to false
 	}
 
 	public boolean isHl7AllowOthersFileForYou(LoggedInInfo loggedInInfo, String providerNo) {

--- a/src/main/java/ca/openosp/openo/mds/data/ReportStatus.java
+++ b/src/main/java/ca/openosp/openo/mds/data/ReportStatus.java
@@ -46,6 +46,8 @@ public class ReportStatus {
 
     private String oscarProviderNo;
 
+    private boolean isHl7AllowOthersFileForYou;
+
     public ReportStatus() {
         // allow empty constructor
     }
@@ -173,6 +175,14 @@ public class ReportStatus {
      */
     public void setOscarProviderNo(String oscarProviderNo) {
         this.oscarProviderNo = oscarProviderNo;
+    }
+
+    public boolean isHl7AllowOthersFileForYou() {
+        return isHl7AllowOthersFileForYou;
+    }
+
+    public void setHl7AllowOthersFileForYou(boolean isHl7AllowOthersFileForYou) {
+        this.isHl7AllowOthersFileForYou = isHl7AllowOthersFileForYou;
     }
 
 }

--- a/src/main/java/ca/openosp/openo/olis/OLISAddToInbox2Action.java
+++ b/src/main/java/ca/openosp/openo/olis/OLISAddToInbox2Action.java
@@ -104,7 +104,7 @@ public class OLISAddToInbox2Action extends ActionSupport {
                         ArrayList<String[]> labsToFile = new ArrayList<String[]>();
                         String item[] = new String[]{String.valueOf(msgHandler.getLastSegmentId()), "HL7"};
                         labsToFile.add(item);
-                        CommonLabResultData.fileLabs(labsToFile, providerNo);
+                        CommonLabResultData.fileLabs(labsToFile, providerNo, loggedInInfo);
                     }
                     if (doAck) {
                         String demographicID = getDemographicIdFromLab("HL7", msgHandler.getLastSegmentId());

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -1758,6 +1758,7 @@ provider.preventionPrefs.btnCancel=Cancel
 provider.preventionPrefs.btnClose=Close
 provider.btnViewClinicalConnectPrefs=Set ClinicalConnect Preferences
 provider.btnViewLabMacroPrefs=Set Lab Macros
+provider.btnViewHl7LabPrefs=Set HL7 Lab Result Preferences
 
 provider.btnViewTicklerPreferences=Set Tickler Preferences
 provider.ticklerPreference.title=Tickler Preferences

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -713,6 +713,7 @@ provider.setDefaultDocumentQueue.btnSubmit=Guardar
 provider.setDefaultDocumentQueue.msgSuccess=Cola por defecto para documentos guardada
 provider.setDefaultDocumentQueue.msgNotSaved=Cola de documentos predeterminada NO se ha guardado
 provider.btnCaisiBillPreferenceNotDelete=No borrar facturacion previa
+provider.btnViewHl7LabPrefs=Configurar preferencias de resultados de laboratorio HL7
 
 provider.btnSetIntegratorPreferences=Preferencias de Integrador
 provider.integratorPreferences.preferences=Preferencias de Integrador

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -586,6 +586,8 @@ provider.setDefaultDocumentQueue.msgEditSaveNew=Enregistrer une nouvelle file
 provider.setDefaultDocumentQueue.btnSubmit=Enregistrer
 provider.setDefaultDocumentQueue.msgSuccess=File par d\u00e9faut des documents enregistr\u00e9e
 provider.setDefaultDocumentQueue.msgNotSaved=File d'attente de documents par d\u00e9faut n'a PAS \u00e9t\u00e9 enregistr\u00e9e
+provider.btnViewHl7LabPrefs=D\u00e9finir les pr\u00e9f\u00e9rences des r\u00e9sultats de laboratoire HL7
+
 
 provider.btnCaisiBillPreferenceNotDelete=Ne pas supprimer la facturation pr\u00e9c\u00e9dente
 provider.btnSetIntegratorPreferences=Pr\u00e9ferences pour l'int\u00e9gration

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -583,6 +583,7 @@ provider.setRxDefaultQuantity.msgDefaultQuantity=Rx Default Ilo&#X15b;&#X107;
 provider.setRxDefaultQuantity.msgEdit=Wprowad&#X17a; &#X17c;&#X105;dan&#X105; ilo&#X15b;&#X107; domy&#X15b;lnie
 provider.setRxDefaultQuantity.btnSubmit=Zapisz
 provider.setRxDefaultQuantity.msgSuccess=Rx Default Ilo&#X15b;&#X107; zapisanych
+provider.btnViewHl7LabPrefs=Ustaw preferencje wynik&#xF3;w bada&#x144; HL7
 
 # Global wiadomo&#X15b;ci. Wiadomo&#X15b;ci te s&#X105; wykorzystywane na wiele stron systemu.
 global.caseload=Caseload

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -1886,6 +1886,7 @@ provider.preventionPrefs.btnCancel=Cancelar
 provider.preventionPrefs.btnClose=Fechar
 provider.btnViewClinicalConnectPrefs=Definir prefer\u00EAncias do ClinicalConnect
 provider.btnViewLabMacroPrefs=Definir macros de laborat\u00F3rio
+provider.btnViewHl7LabPrefs=Definir prefer\u00EAncias de resultados de laborat\u00F3rio HL7
 
 provider.btnViewTicklerPreferences=Definir prefer\u00EAncias da queixa
 provider.ticklerPreference.title=Prefer\u00EAncias da queixa

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -2902,7 +2902,7 @@ request.setAttribute("missingTests", missingTests);
                         // Case: Current provider has not acknowledged the lab
                     %>
                     <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnAcknowledge"/>"
-                           onclick="openAcknowledgementDialog()" />
+                           onclick="openFileDialog(false)" />
                     <% } else if (isLabNotFiledOrAckFlag) { 
                         // Flag is true if any provider has NOT filed OR NOT acknowledged the lab 
                         // Case: Current provider has acknowledged the lab,

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -943,7 +943,7 @@ request.setAttribute("missingTests", missingTests);
                                     jQuery("#labStatus_"+labid).val("A")
                                     updateStatus(formid,labid);
                                 }
-                            })
+                            });
                         }
 
                     } else {
@@ -1057,14 +1057,17 @@ request.setAttribute("missingTests", missingTests);
             });
         });
 
+        // Global flag to track if "file on behalf" was triggered
         var doFileOnBehalfOfProviders = false;
-        function openAcknowledgementDialog() {
-            if (jQuery(".ackProviderCheckbox").length === 0) {
+
+        // Opens the modal dialog asking if the user wants to file on behalf of others.
+        function openFileDialog(isFileOnly) {
+            if (jQuery(".ackProviderCheckbox").length === 0 && !isFileOnly) {
                 jQuery('#tempAckBtn').click();
                 return;
             }
 
-            jQuery("#acknowledgementDialog").dialog({
+            jQuery("#fileDialog").dialog({
                 autoOpen: false,
                 modal: true,
                 height: 'auto',
@@ -1074,12 +1077,8 @@ request.setAttribute("missingTests", missingTests);
                     {
                         text: "No",
                         click: function() {
-                            jQuery("#acknowledgementDialog").dialog("close");
-
-                            // Add a slight delay before triggering tempAckBtn to ensure the dialog is fully closed 
-                            setTimeout(function() {
-                                jQuery("#tempAckBtn").click();
-                            }, 50);
+                            jQuery("#fileDialog").dialog("close");
+                            if (!isFileOnly) { jQuery("#tempAckBtn").click(); }
                         }
                     },
                     {
@@ -1087,13 +1086,17 @@ request.setAttribute("missingTests", missingTests);
                         id: "ackYesButton",
                         click: function() {
                             doFileOnBehalfOfProviders = true;
-                            jQuery("#acknowledgementDialog").dialog("close");
+                            jQuery("#fileDialog").dialog("close");
 
-                            const skipAckComment = jQuery("#skipAckComment").val() === 'true';
-                            if (skipAckComment) {
-                                handleLab('acknowledgeForm_'+jQuery("#segmentID").val(),jQuery("#segmentID").val(), 'ackLabAndFileForOther');
+                            if (isFileOnly) {
+                                fileOnBehalfOfMultipleProviders().then(() => location.reload());
                             } else {
-                                getComment('ackLabAndFileForOther', jQuery("#segmentID").val());
+                                const skipAckComment = jQuery("#skipAckComment").val() === 'true';
+                                if (skipAckComment) {
+                                    handleLab('acknowledgeForm_'+jQuery("#segmentID").val(),jQuery("#segmentID").val(), 'ackLabAndFileForOther');
+                                } else {
+                                    getComment('ackLabAndFileForOther', jQuery("#segmentID").val());
+                                }
                             }
                         },
                         disabled: true // Initially disabled
@@ -1102,6 +1105,7 @@ request.setAttribute("missingTests", missingTests);
             }).dialog("open");
         }
 
+        // Sends file requests for all selected providers.
         function fileOnBehalfOfMultipleProviders() {
             const selectedProviders = jQuery(".ackProviderCheckbox:checked").map(function() {
                 return jQuery(this).val();
@@ -1185,6 +1189,7 @@ request.setAttribute("missingTests", missingTests);
 
         boolean notBeenAcked = ackList.size() == 0;
         boolean ackFlag = false;
+        boolean isLabNotFiledOrAckFlag = false; // Flag is true if any provider has NOT filed OR NOT acknowledged the lab
         String labStatus = "";
         if (ackList != null) {
             for (int i = 0; i < ackList.size(); i++) {
@@ -1195,6 +1200,10 @@ request.setAttribute("missingTests", missingTests);
                         ackFlag = true;//lab has been ack by this providers.
                         break;
                     }
+                }
+
+                if ("N".equals(reportStatus.getStatus())) {
+                    isLabNotFiledOrAckFlag = true; // Flag is true if any provider has NOT filed OR NOT acknowledged the lab
                 }
             }
         }
@@ -1288,10 +1297,18 @@ request.setAttribute("missingTests", missingTests);
 <!-- Save logged-in provider details -->
 <input type="hidden" id="loggedInProviderNo" value="${e:forHtml(sessionScope.user)}" />
 <input type="hidden" id="loggedInProviderName" value="${e:forHtml(loggedInProviderName)}" />
-<div id="acknowledgementDialog" title="Acknowledge Document" style="display: none;">
+
+<!-- Hidden dialog that appears when a locum MD clicks "Acknowledge" -->
+<div id="fileDialog" title="File Document" style="display: none;">
+
+    <!-- Hidden button used to trigger temp acknowledgment logic if no providers are found -->
     <button id="tempAckBtn" onclick="${e:forHtml(ackLabFunc)}" style="display:none;"></button>
+
+    <!-- Flag to determine if skip comment logic should be applied -->
     <input id="skipAckComment" type="hidden" value="${e:forHtml(skipComment)}" />
-    <form id="acknowledgementForm">
+
+    <!-- Form that lists providers to file on behalf of -->
+    <form id="fileForm">
         <p>Do you wish to "file" this document on behalf of any of the following providers?</p>
         <input type="checkbox" id="ackSelectAllCheckbox" />
         <label for="ackSelectAllCheckbox"><b>Select All</b></label><br/>
@@ -1304,6 +1321,7 @@ request.setAttribute("missingTests", missingTests);
                     <input type="hidden" id="loggedInProviderName" value="${e:forHtml(report.providerName)}" />
                 </c:when>
                 <c:otherwise>
+                    <!-- Show only providers that have not already filed (status != 'F') -->
                     <c:if test="${report.status != 'F'}">
                         <input type="checkbox"
                             name="providers"
@@ -1444,7 +1462,15 @@ request.setAttribute("missingTests", missingTests);
 
                                 <input type="button"
                                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnAcknowledge"/>"
-                                       onclick="openAcknowledgementDialog()" />
+                                       onclick="openFileDialog(false)" />
+                                <% } else if (isLabNotFiledOrAckFlag) {
+                                    // Flag is true if any provider has NOT filed OR NOT acknowledged the lab 
+                                    // Case: Current provider has acknowledged the lab,
+                                    // but at least one of the linked providers has NOT filed or acknowledged
+                                %>
+                                <input type="button"
+                                    value="File for..."
+                                    onclick="openFileDialog(true)" />
                                 <% } %>
                                 <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnComment"/>"
                                        onclick="return getComment('addComment',<%=Encode.forJavaScript(segmentID)%>);">
@@ -2851,9 +2877,19 @@ request.setAttribute("missingTests", missingTests);
                bgcolor="#003399">
             <tr>
                 <td align="left" width="50%">
-                    <% if (!ackFlag) { %>
+                    <% if (!ackFlag) {
+                        // Case: Current provider has not acknowledged the lab
+                    %>
                     <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnAcknowledge"/>"
                            onclick="openAcknowledgementDialog()" />
+                    <% } else if (isLabNotFiledOrAckFlag) { 
+                        // Flag is true if any provider has NOT filed OR NOT acknowledged the lab 
+                        // Case: Current provider has acknowledged the lab,
+                        // but at least one of the linked providers has NOT filed or acknowledged
+                    %>
+                    <input type="button"
+                        value="File for..."
+                        onclick="openFileDialog(true)" />
                     <% } %>
                     <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnComment"/>"
                            onclick="return getComment('addComment',<%=Encode.forJavaScript(segmentID)%>);">

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -1332,8 +1332,8 @@ request.setAttribute("missingTests", missingTests);
                     <input type="hidden" id="loggedInProviderName" value="${e:forHtml(report.providerName)}" />
                 </c:when>
                 <c:otherwise>
-                    <!-- Show only providers that have not already filed (status != 'F') -->
-                    <c:if test="${report.status != 'F'}">
+                    <!-- Show only providers that have not already filed or ack (status != 'F' && status != 'A') -->
+                    <c:if test="${report.status != 'F' && report.status != 'A'}">
                         <c:set var="isDisabled" value="${!report.isHl7AllowOthersFileForYou()}" />
                         <c:set var="providerId" value="ackProvider${status.index}" />
                         <c:set var="providerNo" value="${e:forHtml(report.oscarProviderNo)}" />

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -1334,19 +1334,25 @@ request.setAttribute("missingTests", missingTests);
                     <!-- Show only providers that have not already filed (status != 'F') -->
                     <c:if test="${report.status != 'F'}">
                         <c:set var="isDisabled" value="${!report.isHl7AllowOthersFileForYou()}" />
+                        <c:set var="providerId" value="ackProvider${status.index}" />
+                        <c:set var="providerNo" value="${e:forHtml(report.oscarProviderNo)}" />
+                        <c:set var="providerName" value="${e:forHtml(report.providerName)}" />
+                        
                         <input type="checkbox"
                             name="providers"
-                            class="ackProviderCheckbox 
-                                <c:if test='${isDisabled}'> disabled-checkbox</c:if>"
-                            id="ackProvider${status.index}"
-                            value="${e:forHtml(report.oscarProviderNo)}" 
-                            <c:if test="${isDisabled}">disabled</c:if> />
-                        <label for="ackProvider${status.index}">
-                            <e:forHtml value="${report.providerName}" />
+                            id="${providerId}"
+                            value="${providerNo}"
+                            class="ackProviderCheckbox${isDisabled ? ' disabled-checkbox' : ''}"
+                            ${isDisabled ? 'disabled' : ''} />
+                        
+                        <label for="${providerId}" 
+                            style="${isDisabled ? 'color: gray; cursor: not-allowed;' : ''}">
+                            <e:forHtml value="${providerName}${isDisabled ? ' (opted out by user preference)' : ''}" />
                         </label>
+                        
                         <input type="hidden"
                             class="ackProviderName"
-                            data-provider-no="${e:forHtml(report.oscarProviderNo)}"
+                            data-provider-no="${providerNo}"
                             value="${e:forHtml(report.providerName)}" /><br/>
                     </c:if>
                 </c:otherwise>

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -1137,7 +1137,7 @@ request.setAttribute("missingTests", missingTests);
                             labType: labType,
                             comment: comment,
                             fileUpToLabNo: true,
-                            onBehalfOfMultipleProviders: true
+                            onBehalfOfOtherProvider: true
                         },
                         success: function(response) {
                             console.log("Filed lab for provider: " + providerNo);
@@ -1321,7 +1321,6 @@ request.setAttribute("missingTests", missingTests);
         <p>This result is linked to other providers who have not acknowledged or filed it yet.</p>
         <p>Do you want to "file" this result on their behalf?</p>
         <p>Important - doing so will mean they likely will not see this result. Only proceed if you are sure they will not need to see this result.</p>
-        <input type="checkbox" id="ackSelectAllCheckbox" />
         <input type="checkbox" id="ackSelectAllCheckbox" />
         <label for="ackSelectAllCheckbox"><b>Select All</b></label><br/>
 

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -70,6 +70,7 @@
 <%@ page import="ca.openosp.openo.lab.ca.all.AcknowledgementData" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" prefix="e" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/oscarProperties-tag.tld" prefix="oscarProperties" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
@@ -934,6 +935,15 @@ request.setAttribute("missingTests", missingTests);
                         } else if (action === 'addComment') {
                             console.log("Adding comment. Formid: " + formid + " labid: " + labid);
                             addComment(formid, labid);
+                        } else if (action === 'ackLabAndFileForOther') {
+                            fileOnBehalfOfMultipleProviders().then(() => {
+                                console.log("Acknowledging lab results");
+                                if(confirmAck()){
+                                    console.log("Acknowledge confirmed. Labid: " + labid);
+                                    jQuery("#labStatus_"+labid).val("A")
+                                    updateStatus(formid,labid);
+                                }
+                            })
                         }
 
                     } else {
@@ -1035,8 +1045,129 @@ request.setAttribute("missingTests", missingTests);
                     tdisForm.label.value = newlabelvalue;
                 }
             }
+       	}
+
+        jQuery(document).ready(function() {
+            jQuery(document).on('change', '.ackProviderCheckbox, #ackSelectAllCheckbox', function() {
+                if (this.id === 'ackSelectAllCheckbox') {
+                    // When "Select All" changes, update all checkboxes
+                    jQuery(".ackProviderCheckbox").prop('checked', this.checked);
+                }
+                jQuery("#ackYesButton").button("option", "disabled", jQuery(".ackProviderCheckbox:checked").length === 0);
+            });
+        });
+
+        var doFileOnBehalfOfProviders = false;
+        function openAcknowledgementDialog() {
+            if (jQuery(".ackProviderCheckbox").length === 0) {
+                jQuery('#tempAckBtn').click();
+                return;
+            }
+
+            jQuery("#acknowledgementDialog").dialog({
+                autoOpen: false,
+                modal: true,
+                height: 'auto',
+                width: 'auto',
+                resizable: true,
+                buttons: [
+                    {
+                        text: "No",
+                        click: function() {
+                            jQuery("#acknowledgementDialog").dialog("close");
+
+                            // Add a slight delay before triggering tempAckBtn to ensure the dialog is fully closed 
+                            setTimeout(function() {
+                                jQuery("#tempAckBtn").click();
+                            }, 50);
+                        }
+                    },
+                    {
+                        text: "Yes",
+                        id: "ackYesButton",
+                        click: function() {
+                            doFileOnBehalfOfProviders = true;
+                            jQuery("#acknowledgementDialog").dialog("close");
+
+                            const skipAckComment = jQuery("#skipAckComment").val() === 'true';
+                            if (skipAckComment) {
+                                handleLab('acknowledgeForm_'+jQuery("#segmentID").val(),jQuery("#segmentID").val(), 'ackLabAndFileForOther');
+                            } else {
+                                getComment('ackLabAndFileForOther', jQuery("#segmentID").val());
+                            }
+                        },
+                        disabled: true // Initially disabled
+                    }
+                ]
+            }).dialog("open");
         }
-    </script>
+
+        function fileOnBehalfOfMultipleProviders() {
+            const selectedProviders = jQuery(".ackProviderCheckbox:checked").map(function() {
+                return jQuery(this).val();
+            }).get();
+
+            if (selectedProviders.length === 0) {
+                return Promise.reject(new Error("No providers selected"));
+            }
+
+            const flaggedLabId = jQuery("#segmentID").val();
+            const labType = jQuery("#labType").val();
+            const loggedInProviderNo = jQuery("#loggedInProviderNo").val();
+            const loggedInProviderName = jQuery("#loggedInProviderName").val();
+
+            const ajaxCalls = selectedProviders.map(providerNo => {
+                const providerName = jQuery(".ackProviderName[data-provider-no='" + providerNo + "']").val();
+                const comment = createFilingComment(providerName, loggedInProviderName);
+                const url = "${e:forJavaScript(pageContext.servletContext.contextPath)}" + "/oscarMDS/FileLabs.do";
+
+                return new Promise((resolve, reject) => {
+                    jQuery.ajax({
+                        url: url,
+                        type: 'POST',
+                        data: {
+                            method: 'fileLabAjaxByProvider',
+                            providerNo: providerNo,
+                            flaggedLabId: flaggedLabId,
+                            labType: labType,
+                            comment: comment
+                        },
+                        success: function(response) {
+                            console.log("Filed lab for provider: " + providerNo);
+                            resolve(response);
+                        },
+                        error: function(xhr) {
+                            console.error("Failed filing for provider: " + providerNo);
+                            reject(new Error("Failed for provider: " + providerNo));
+                        }
+                    });
+                });
+            });
+
+            return Promise.allSettled(ajaxCalls).then(results => {
+                const failed = results.filter(r => r.status === 'rejected');
+                if (failed.length > 0) {
+                    console.error("Some AJAX calls failed:", failed);
+                }
+
+                doFileOnBehalfOfProviders = false;
+            });
+        }
+
+        function createFilingComment(providerName, loggedInProviderName) {
+            const now = new Date();
+            const yyyy = now.getFullYear();
+            const mm = String(now.getMonth() + 1).padStart(2, '0');
+            const dd = String(now.getDate()).padStart(2, '0');
+            let hours = now.getHours();
+            const minutes = String(now.getMinutes()).padStart(2, '0');
+            const ampm = hours >= 12 ? 'PM' : 'AM';
+            hours = hours % 12 || 12;
+            const formattedDate = yyyy + '.' + mm + '.' + dd + ' @ ' + hours + ':' + minutes + ampm;
+
+            return 'Filed by ' + loggedInProviderName + ' on behalf of ' + providerName + ' on ' + formattedDate;
+        }
+        </script>
 
 </head>
 
@@ -1068,6 +1199,8 @@ request.setAttribute("missingTests", missingTests);
             }
         }
 
+        request.setAttribute("ackList", ackList);
+
         Hl7TextInfoDao hl7TextInfoDao = (Hl7TextInfoDao) SpringUtils.getBean(Hl7TextInfoDao.class);
         int lab_no = Integer.parseInt(segmentID);
         Hl7TextInfo hl7Lab = hl7TextInfoDao.findLabId(lab_no);
@@ -1080,6 +1213,9 @@ request.setAttribute("missingTests", missingTests);
         } else {
             ackLabFunc = "getComment('ackLab', " + segmentID + ");";
         }
+
+        request.setAttribute("ackLabFunc", ackLabFunc);
+        request.setAttribute("skipComment", skipComment);
 
 %>
 <script type="text/javascript">
@@ -1148,6 +1284,42 @@ request.setAttribute("missingTests", missingTests);
         });
     }
 </script>
+
+<div id="acknowledgementDialog" title="Acknowledge Document" style="display: none;">
+    <button id="tempAckBtn" onclick="${e:forHtml(ackLabFunc)}" style="display:none;"></button>
+    <input id="skipAckComment" type="hidden" value="${e:forHtml(skipComment)}" />
+    <form id="acknowledgementForm">
+        <p>Do you wish to "file" this document on behalf of any of the following providers?</p>
+        <input type="checkbox" id="ackSelectAllCheckbox" />
+        <label for="ackSelectAllCheckbox"><b>Select All</b></label><br/>
+
+        <c:forEach var="report" items="${ackList}" varStatus="status">
+            <c:choose>
+                <c:when test="${report.oscarProviderNo == sessionScope.user}">
+                    <!-- Save logged-in provider details -->
+                    <input type="hidden" id="loggedInProviderNo" value="${e:forHtml(report.oscarProviderNo)}" />
+                    <input type="hidden" id="loggedInProviderName" value="${e:forHtml(report.providerName)}" />
+                </c:when>
+                <c:otherwise>
+                    <c:if test="${report.status != 'F'}">
+                        <input type="checkbox"
+                            name="providers"
+                            class="ackProviderCheckbox"
+                            id="ackProvider${status.index}"
+                            value="${e:forHtml(report.oscarProviderNo)}" />
+                        <label for="ackProvider${status.index}">
+                            <e:forHtml value="${report.providerName}" />
+                        </label>
+                        <input type="hidden"
+                            class="ackProviderName"
+                            data-provider-no="${e:forHtml(report.oscarProviderNo)}"
+                            value="${e:forHtml(report.providerName)}" /><br/>
+                    </c:if>
+                </c:otherwise>
+            </c:choose>
+        </c:forEach>
+    </form>
+</div>
 
 <div id="lab_<%= Encode.forHtmlAttribute(segmentID) %>">
 
@@ -1222,7 +1394,7 @@ request.setAttribute("missingTests", missingTests);
                     <table class="MainTableTopRowRightColumn" width="100%" border="0" cellspacing="0" cellpadding="3">
                         <tr>
                             <td>
-                                <input type="hidden" name="segmentID"
+                                <input type="hidden" name="segmentID" id="segmentID"
                                        value="<%= Encode.forHtmlAttribute(segmentID) %>"/>
                                 <input type="hidden" name="multiID" value="<%= Encode.forHtmlAttribute(multiLabId) %>"/>
                                 <input type="hidden" name="providerNo" id="providerNo"
@@ -1230,7 +1402,7 @@ request.setAttribute("missingTests", missingTests);
                                 <input type="hidden" name="status" value="<%=Encode.forHtmlAttribute(labStatus)%>"
                                        id="labStatus_<%=Encode.forHtmlAttribute(segmentID)%>"/>
                                 <input type="hidden" name="comment" value=""/>
-                                <input type="hidden" name="labType" value="HL7"/>
+                                <input type="hidden" name="labType" id="labType" value="HL7"/>
                                 <%
                                     if (!ackFlag) {
                                 %>
@@ -1269,7 +1441,7 @@ request.setAttribute("missingTests", missingTests);
 
                                 <input type="button"
                                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnAcknowledge"/>"
-                                       onclick="<%=ackLabFunc%>">
+                                       onclick="openAcknowledgementDialog()" />
                                 <% } %>
                                 <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnComment"/>"
                                        onclick="return getComment('addComment',<%=Encode.forJavaScript(segmentID)%>);">
@@ -2678,7 +2850,7 @@ request.setAttribute("missingTests", missingTests);
                 <td align="left" width="50%">
                     <% if (!ackFlag) { %>
                     <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnAcknowledge"/>"
-                           onclick="<%=ackLabFunc%>">
+                           onclick="openAcknowledgementDialog()" />
                     <% } %>
                     <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnComment"/>"
                            onclick="return getComment('addComment',<%=Encode.forJavaScript(segmentID)%>);">

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -1131,11 +1131,13 @@ request.setAttribute("missingTests", missingTests);
                         url: url,
                         type: 'POST',
                         data: {
-                            method: 'fileLabAjaxByProvider',
+                            method: 'fileOnBehalfOfMultipleProviders',
                             providerNo: providerNo,
                             flaggedLabId: flaggedLabId,
                             labType: labType,
-                            comment: comment
+                            comment: comment,
+                            fileUpToLabNo: true,
+                            onBehalfOfMultipleProviders: true
                         },
                         success: function(response) {
                             console.log("Filed lab for provider: " + providerNo);

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -1214,11 +1214,11 @@ request.setAttribute("missingTests", missingTests);
             ackLabFunc = "getComment('ackLab', " + segmentID + ");";
         }
 
-        request.setAttribute("ackLabFunc", ackLabFunc);
-        request.setAttribute("skipComment", skipComment);
-
-%>
-<script type="text/javascript">
+                request.setAttribute("ackLabFunc", ackLabFunc);
+                request.setAttribute("skipComment", skipComment);
+                request.setAttribute("loggedInProviderName", loggedInInfo.getLoggedInProvider().getFullName());
+        %>
+        <script type="text/javascript">
 
     jQuery(function () {
         jQuery("#createLabel_<%=Encode.forJavaScript(segmentID)%>").click(function () {
@@ -1285,6 +1285,9 @@ request.setAttribute("missingTests", missingTests);
     }
 </script>
 
+<!-- Save logged-in provider details -->
+<input type="hidden" id="loggedInProviderNo" value="${e:forHtml(sessionScope.user)}" />
+<input type="hidden" id="loggedInProviderName" value="${e:forHtml(loggedInProviderName)}" />
 <div id="acknowledgementDialog" title="Acknowledge Document" style="display: none;">
     <button id="tempAckBtn" onclick="${e:forHtml(ackLabFunc)}" style="display:none;"></button>
     <input id="skipAckComment" type="hidden" value="${e:forHtml(skipComment)}" />

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -796,36 +796,85 @@ request.setAttribute("missingTests", missingTests);
         }
 
         /* Change the background color of the dropdown button when the dropdown content is shown */
-.dropdown:hover .dropbtn {background-color: #3e8e41;}
+        .dropdown:hover .dropbtn {background-color: #3e8e41;}
 
-#labVersionInfoModal .modal-title {
-    font-size: 18px;
-    font-weight: bold;
-    margin-bottom: 15px;
-}
+        #labVersionInfoModal .modal-title {
+            font-size: 18px;
+            font-weight: bold;
+            margin-bottom: 15px;
+        }
 
-#labVersionInfoModal .info-section {
-    margin-bottom: 20px;
-}
+        #labVersionInfoModal .info-section {
+            margin-bottom: 20px;
+        }
 
-#labVersionInfoModal .info-section p {
-    margin: 5px 0;
-    color: #555;
-}
+        #labVersionInfoModal .info-section p {
+            margin: 5px 0;
+            color: #555;
+        }
 
-#labVersionInfoModal .test-list {
-    margin-left: 10px;
-}
+        #labVersionInfoModal .test-list {
+            margin-left: 10px;
+        }
 
-#labVersionInfoModal .test-item {
-    display: flex;
-    justify-content: space-between;
-    margin: 5px 0;
-}
+        #labVersionInfoModal .test-item {
+            display: flex;
+            justify-content: space-between;
+            margin: 5px 0;
+        }
 
-#labVersionInfoModal .status {
-    font-weight: bold;
-}
+        #labVersionInfoModal .status {
+            font-weight: bold;
+        }
+
+        /* White background and shadow for fileDialog and combinedAckFileDialog */
+        .ui-dialog:has(#fileDialog),
+        .ui-dialog:has(#combinedAckFileDialog) {
+            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
+        }
+
+        /* Center Submit/Cancel buttons for both dialogs */
+        /* .ui-dialog:has(#fileDialog) .ui-dialog-buttonpane, */
+        .ui-dialog:has(#combinedAckFileDialog) .ui-dialog-buttonpane {
+            text-align: center;
+        }
+        /* .ui-dialog:has(#fileDialog) .ui-dialog-buttonset, */
+        .ui-dialog:has(#combinedAckFileDialog) .ui-dialog-buttonset {
+            float: none;
+            display: inline-block;
+        }
+
+        /* Primary color for Submit button in combinedAckFileDialog */
+        #combinedAckOkButton.ui-button {
+            background: #0d6efd;
+            border-color: #0d6efd;
+            color: #fff;
+        }
+        #combinedAckOkButton.ui-button:hover {
+            background: #0b5ed7;
+            border-color: #0a58ca;
+        }
+
+        /* Accordion border on expanded content panel */
+        #combinedAckAccordion .ui-accordion-content {
+            border: 1px solid #dee2e6;
+        }
+
+        /* Keep accordion header color unchanged when active/focused */
+        #combinedAckAccordion .ui-accordion-header,
+        #combinedAckAccordion .ui-accordion-header.ui-state-active,
+        #combinedAckAccordion .ui-accordion-header:hover {
+            color: inherit;
+            background: #e9ecef;
+            border-color: #dee2e6;
+        }
+
+        /* Prevent icon from turning white on active/hover (designed for dark backgrounds) */
+        #combinedAckAccordion .ui-accordion-header.ui-state-active .ui-icon,
+        #combinedAckAccordion .ui-accordion-header:hover .ui-icon {
+            filter: brightness(0);
+        }
+
     </style>
 
     <script language="JavaScript">
@@ -1049,25 +1098,77 @@ request.setAttribute("missingTests", missingTests);
        	}
 
         jQuery(document).ready(function() {
+            // "Acknowledge/File Document" modal checkbox handler (Acknowledge button flow).
+            // Keeps "Select All" in sync with individual provider checkboxes.
+            // The OK button is always enabled — the provider can acknowledge without selecting anyone.
+            jQuery(document).on('change', '.combinedAckProviderCheckbox, #combinedAckSelectAllCheckbox', function() {
+                if (this.id === 'combinedAckSelectAllCheckbox') {
+                    jQuery(".combinedAckProviderCheckbox:not(.combined-disabled-checkbox)").prop('checked', this.checked);
+                }
+            });
+
+            // "File Document" dialog checkbox handler ("File for..." button flow).
+            // Keeps "Select All" in sync with individual provider checkboxes.
+            // The OK button stays disabled until at least one provider is checked,
+            // because filing requires an explicit provider target.
             jQuery(document).on('change', '.ackProviderCheckbox, #ackSelectAllCheckbox', function() {
                 if (this.id === 'ackSelectAllCheckbox') {
-                    // When "Select All" changes, update all checkboxes
                     jQuery(".ackProviderCheckbox:not(.disabled-checkbox)").prop('checked', this.checked);
                 }
-                jQuery("#ackYesButton").button("option", "disabled", jQuery(".ackProviderCheckbox:checked").length === 0);
+                const hasChecked = jQuery(".ackProviderCheckbox:checked").length > 0;
+                jQuery("#fileDialogOkButton").button("option", "disabled", !hasChecked);
+            });
+
+            // Accordion for "File Document" section in combinedAckFileDialog.
+            // Expanded by default when the lab is linked to other providers (isHl7OfferFileForOthers=true), collapsed otherwise.
+            jQuery("#combinedAckAccordion").accordion({
+                collapsible: true,
+                active: jQuery("#isHl7OfferFileForOthers").val() === "true" ? 0 : false,
+                heightStyle: "content"
+            });
+
+            // Submit the dialog when Enter is pressed in the comment input.
+            jQuery("#combinedAckComment").on("keydown", function(e) {
+                if (e.key === "Enter") {
+                    e.preventDefault();
+                    jQuery("#combinedAckOkButton").trigger("click");
+                }
             });
         });
 
-        // Global flag to track if "file on behalf" was triggered
-        var doFileOnBehalfOfProviders = false;
-
-        // Opens the modal dialog asking if the user wants to file on behalf of others.
+        // Entry point for both the "Acknowledge" button (isFileOnly=false) and
+        // the "File for..." button (isFileOnly=true). Routes to the correct dialog.
+        //
+        // isFileOnly=true  — "File for..." button:
+        //   The logged-in provider has already acknowledged. Opens the "File Document"
+        //   dialog (#fileDialog) so they can file on behalf of other providers.
+        //
+        // isFileOnly=false — "Acknowledge" button:
+        //   If skipComment=true: acknowledges directly via #tempAckBtn without any prompt.
+        //   Otherwise (skipComment=false): opens the combined "Acknowledge/File Document"
+        //   modal so the provider can enter a comment. When isHl7OfferFileForOthers=true,
+        //   the modal also allows optionally filing for other linked providers.
         function openFileDialog(isFileOnly) {
-            if ((jQuery(".ackProviderCheckbox:not(.disabled-checkbox)").length === 0 && !isFileOnly) || jQuery("#isHl7OfferFileForOthers").val() === "false") {
+            if (isFileOnly) {
+                openFileOnlyDialog();
+                return;
+            }
+            if (jQuery("#skipAckComment").val() === "true") {
                 jQuery('#tempAckBtn').click();
                 return;
             }
+            openCombinedAckFileDialog(false);
+        }
 
+        // Opens the "File Document" dialog (#fileDialog) for the "File for..." button flow.
+        // Reached only when the logged-in provider has already acknowledged the lab and at
+        // least one other linked provider has not yet filed or acknowledged.
+        //
+        // The provider selects one or more providers from the list and confirms. FileLabs.do
+        // is called for each selected provider in parallel, then the page reloads to reflect
+        // the updated filing status. The OK button starts disabled and enables only once
+        // at least one provider is checked.
+        function openFileOnlyDialog() {
             jQuery("#fileDialog").dialog({
                 autoOpen: false,
                 modal: true,
@@ -1079,40 +1180,121 @@ request.setAttribute("missingTests", missingTests);
                         text: "No",
                         click: function() {
                             jQuery("#fileDialog").dialog("close");
-                            if (!isFileOnly) { jQuery("#tempAckBtn").click(); }
                         }
                     },
                     {
                         text: "Yes",
-                        id: "ackYesButton",
+                        id: "fileDialogOkButton",
                         click: function() {
-                            doFileOnBehalfOfProviders = true;
+                            const selectedProviders = jQuery(".ackProviderCheckbox:checked").map(function() {
+                                return jQuery(this).val();
+                            }).get();
                             jQuery("#fileDialog").dialog("close");
-
-                            if (isFileOnly) {
-                                fileOnBehalfOfMultipleProviders().then(() => location.reload());
-                            } else {
-                                const skipAckComment = jQuery("#skipAckComment").val() === 'true';
-                                if (skipAckComment) {
-                                    handleLab('acknowledgeForm_'+jQuery("#segmentID").val(),jQuery("#segmentID").val(), 'ackLabAndFileForOther');
-                                } else {
-                                    getComment('ackLabAndFileForOther', jQuery("#segmentID").val());
-                                }
-                            }
+                            fileOnBehalfOfMultipleProviders(selectedProviders).then(function() {
+                                location.reload();
+                            });
                         },
-                        disabled: true // Initially disabled
+                        disabled: true
                     }
                 ]
             }).dialog("open");
         }
 
-        // Sends file requests for all selected providers.
-        function fileOnBehalfOfMultipleProviders() {
-            const selectedProviders = jQuery(".ackProviderCheckbox:checked").map(function() {
-                return jQuery(this).val();
-            }).get();
+        // Opens the "Acknowledge/File Document" modal (#combinedAckFileDialog).
+        // Used when the logged-in provider clicks "Acknowledge" and has opted in to
+        // offer filing for others (isHl7OfferFileForOthers=true).
+        //
+        // Combines two actions into a single step:
+        //   1. Enter an acknowledgement comment (pre-populated if one already exists).
+        //   2. Optionally select other linked providers to file the result on their behalf.
+        //
+        // OK button behaviour:
+        //   - Providers selected: files for each via FileLabs.do, then acknowledges.
+        //   - No providers selected: acknowledges with the entered comment directly.
+        //   - Cancel: closes the modal without acknowledging or filing.
+        function openCombinedAckFileDialog(isFileOnly) {
+            const segmentId = jQuery("#segmentID").val();
 
-            if (selectedProviders.length === 0) {
+            // Pre-populate the comment field with any comment the provider has already saved for this lab.
+            const textEl = document.getElementById(providerNo + "_" + segmentId + "commentText");
+            jQuery("#combinedAckComment").val(textEl ? textEl.innerHTML : "");
+
+            // Persist isFileOnly on the dialog element so the checkbox change handler can read it
+            // without it needing to be in scope as a closure variable.
+            jQuery("#combinedAckFileDialog").data("isFileOnly", isFileOnly);
+
+            jQuery("#combinedAckFileDialog").dialog({
+                autoOpen: false,
+                modal: true,
+                height: 'auto',
+                minWidth: 700,
+                resizable: true,
+                buttons: [
+                    {
+                        text: "Submit",
+                        id: "combinedAckOkButton",
+                        click: function() {
+                            const selectedProviders = jQuery(".combinedAckProviderCheckbox:checked").map(function() {
+                                return jQuery(this).val();
+                            }).get();
+                            const comment = jQuery("#combinedAckComment").val();
+
+                            jQuery("#combinedAckFileDialog").dialog("close");
+
+                            if (selectedProviders.length > 0) {
+                                // File on behalf of selected providers, then acknowledge if needed.
+                                fileOnBehalfOfMultipleProviders(selectedProviders).then(function() {
+                                    if (!isFileOnly) {
+                                        acknowledgeWithComment(comment, segmentId);
+                                    } else {
+                                        location.reload();
+                                    }
+                                });
+                            } else if (!isFileOnly) {
+                                // No providers selected — just acknowledge with the entered comment.
+                                acknowledgeWithComment(comment, segmentId);
+                            }
+                        },
+                        // Require at least one provider when filing only; always enabled when acknowledging.
+                        disabled: isFileOnly
+                    },
+                    {
+                        text: "Cancel",
+                        click: function() {
+                            jQuery("#combinedAckFileDialog").dialog("close");
+                        }
+                    }
+                ]
+            }).dialog("open");
+
+            jQuery("#combinedAckComment").focus();
+        }
+
+        // Writes the acknowledgement comment into the lab's hidden form field and triggers
+        // the acknowledge action. Called from the combined modal after the provider confirms.
+        function acknowledgeWithComment(comment, segmentId) {
+            const ackForm = document.forms['acknowledgeForm_' + segmentId];
+            if (ackForm && ackForm.comment) {
+                ackForm.comment.value = comment;
+            }
+            handleLab('acknowledgeForm_' + segmentId, segmentId, 'ackLab');
+        }
+
+        // Files the lab result on behalf of each provider in selectedProviders by calling
+        // FileLabs.do for each one. Called from both the "File Document" dialog (#fileDialog)
+        // and the "Acknowledge/File Document" modal (#combinedAckFileDialog).
+        //
+        // For each provider, an auto-generated comment is recorded that includes the logged-in
+        // provider's name, the target provider's name, and a timestamp.
+        //
+        // All requests run in parallel via Promise.allSettled, so a failure for one provider
+        // does not block the others. Individual failures are logged to the console.
+        // The returned promise always resolves, allowing the caller to proceed with the next
+        // step (acknowledge or page reload) regardless of individual filing outcomes.
+        //
+        // @param {string[]} selectedProviders - provider numbers to file the lab on behalf of
+        function fileOnBehalfOfMultipleProviders(selectedProviders) {
+            if (!selectedProviders || selectedProviders.length === 0) {
                 return Promise.reject(new Error("No providers selected"));
             }
 
@@ -1122,7 +1304,7 @@ request.setAttribute("missingTests", missingTests);
             const loggedInProviderName = jQuery("#loggedInProviderName").val();
 
             const ajaxCalls = selectedProviders.map(providerNo => {
-                const providerName = jQuery(".ackProviderName[data-provider-no='" + providerNo + "']").val();
+                const providerName = jQuery(".combinedAckProviderName[data-provider-no='" + providerNo + "'], .ackProviderName[data-provider-no='" + providerNo + "']").first().val();
                 const comment = createFilingComment(providerName, loggedInProviderName);
                 const url = "${e:forJavaScript(pageContext.servletContext.contextPath)}" + "/oscarMDS/FileLabs.do";
 
@@ -1156,11 +1338,14 @@ request.setAttribute("missingTests", missingTests);
                 if (failed.length > 0) {
                     console.error("Some AJAX calls failed:", failed);
                 }
-
-                doFileOnBehalfOfProviders = false;
             });
         }
 
+        // Generates the auto-filing comment recorded when a lab is filed on behalf of another provider.
+        // Produces: "Filed by <loggedInProviderName> on behalf of <providerName> on YYYY.MM.DD @ H:MMam/pm"
+        //
+        // @param {string} providerName         - name of the provider being filed for
+        // @param {string} loggedInProviderName - name of the provider performing the filing
         function createFilingComment(providerName, loggedInProviderName) {
             const now = new Date();
             const yyyy = now.getFullYear();
@@ -1195,23 +1380,34 @@ request.setAttribute("missingTests", missingTests);
         }
 
         boolean notBeenAcked = ackList.size() == 0;
+        // True when the logged-in provider has already acknowledged this lab result.
+        // Controls which action button is rendered: "Acknowledge" (false) or "File for..." (true).
         boolean ackFlag = false;
-        boolean isLabNotFiledOrAckFlag = false; // Flag is true if any provider has NOT filed OR NOT acknowledged the lab
+
+        // True when at least one OTHER linked provider has not yet filed or acknowledged this lab.
+        // When both ackFlag and this flag are true, the "File for..." button is shown so the
+        // logged-in provider can file the result on behalf of those providers.
+        boolean isLabNotFiledOrAckFlag = false;
+
         String labStatus = "";
         if (ackList != null) {
             for (int i = 0; i < ackList.size(); i++) {
                 ReportStatus reportStatus = ackList.get(i);
+
+                // Resolve each provider's hl7AllowOthersFileForYou preference up front so the
+                // filing dialogs can disable providers who have opted out of being filed for by others.
                 reportStatus.setHl7AllowOthersFileForYou(providerManager.isHl7AllowOthersFileForYou(loggedInInfo, reportStatus.getOscarProviderNo()));
+
                 if (providerNo.equals(reportStatus.getOscarProviderNo())) {
+                    // Found the logged-in provider's entry — capture their current lab status.
                     labStatus = reportStatus.getStatus();
                     if (labStatus.equals("A")) {
-                        ackFlag = true;//lab has been ack by this providers.
-                        break;
+                        ackFlag = true;
                     }
-                }
-
-                if ("N".equals(reportStatus.getStatus())) {
-                    isLabNotFiledOrAckFlag = true; // Flag is true if any provider has NOT filed OR NOT acknowledged the lab
+                } else if ("N".equals(reportStatus.getStatus())) {
+                    // A different linked provider has not yet filed or acknowledged this lab.
+                    // Once the logged-in provider acknowledges, the "File for..." button will appear.
+                    isLabNotFiledOrAckFlag = true;
                 }
             }
         }
@@ -1224,6 +1420,11 @@ request.setAttribute("missingTests", missingTests);
         String label = "";
         if (hl7Lab != null && hl7Lab.getLabel() != null) label = hl7Lab.getLabel();
 
+        // JS expression fired by #tempAckBtn in the fallback acknowledge flow
+        // (when isHl7OfferFileForOthers=false). Behaviour depends on the provider's
+        // lab_ack_comment preference (skipComment):
+        //   true  → acknowledge immediately without prompting for a comment (handleLab).
+        //   false → open a JS prompt() to collect a comment before acknowledging (getComment).
         String ackLabFunc;
         if (skipComment) {
             ackLabFunc = "handleLab('acknowledgeForm_" + segmentID + "','" + segmentID + "','ackLab');";
@@ -1307,13 +1508,26 @@ request.setAttribute("missingTests", missingTests);
 <input type="hidden" id="loggedInProviderName" value="${e:forHtml(loggedInProviderName)}" />
 <input type="hidden" id="isHl7OfferFileForOthers" value="${e:forHtml(isHl7OfferFileForOthers)}" />
 
-<!-- Hidden dialog that appears when a locum MD clicks "Acknowledge" -->
+<!--
+    Hidden button used by the legacy fallback acknowledge flow (isHl7OfferFileForOthers=false).
+    Its onclick is set server-side to ackLabFunc, which either prompts for an acknowledgement
+    comment via getComment() or acknowledges directly via handleLab(), depending on the
+    provider's lab_ack_comment preference (skipComment).
+-->
+<button id="tempAckBtn" onclick="${e:forHtml(ackLabFunc)}" style="display:none;"></button>
+
+<!--
+    "File Document" dialog (#fileDialog) — opened by the "File for..." button.
+    Reached when the logged-in provider has already acknowledged the lab and at least
+    one other linked provider has not yet filed or acknowledged.
+    Lists eligible providers; those who have opted out appear greyed out and cannot be selected.
+    Managed by openFileOnlyDialog() in the script block above.
+-->
 <div id="fileDialog" title="File Document" style="display: none;">
 
-    <!-- Hidden button used to trigger temp acknowledgment logic if no providers are found -->
-    <button id="tempAckBtn" onclick="${e:forHtml(ackLabFunc)}" style="display:none;"></button>
-
-    <!-- Flag to determine if skip comment logic should be applied -->
+    <!-- skipAckComment: mirrors the server-side skipComment flag. When "true", the legacy
+         #tempAckBtn flow acknowledges without prompting for a comment. Unused in the
+         combined modal flow. -->
     <input id="skipAckComment" type="hidden" value="${e:forHtml(skipComment)}" />
 
     <!-- Form that lists providers to file on behalf of -->
@@ -1327,7 +1541,9 @@ request.setAttribute("missingTests", missingTests);
         <c:forEach var="report" items="${ackList}" varStatus="status">
             <c:choose>
                 <c:when test="${report.oscarProviderNo == sessionScope.user}">
-                    <!-- Save logged-in provider details -->
+                    <!-- The logged-in provider's details are also stored as top-level hidden inputs
+                         outside this dialog (see #loggedInProviderNo / #loggedInProviderName above).
+                         These inner values mirror those and are retained for historical reasons. -->
                     <input type="hidden" id="loggedInProviderNo" value="${e:forHtml(report.oscarProviderNo)}" />
                     <input type="hidden" id="loggedInProviderName" value="${e:forHtml(report.providerName)}" />
                 </c:when>
@@ -1359,7 +1575,70 @@ request.setAttribute("missingTests", missingTests);
                 </c:otherwise>
             </c:choose>
         </c:forEach>
-        <p>Tip: In your user preferences, you can hide this prompt or prevent others from filing results on your behalf. See "Set HL7 Lab Result Preferences".</p>
+        <p>Tip: In your user preferences, you can prevent others from filing results on your behalf.  See "Set HL7 Lab Result Preferences"</p>
+    </form>
+</div>
+
+<!--
+    "Acknowledge/File Document" modal (#combinedAckFileDialog) — opened by the "Acknowledge" button
+    when the provider has opted in to offer filing for others (isHl7OfferFileForOthers=true).
+    Lets the provider complete two actions in one step:
+      - Enter or confirm an acknowledgement comment.
+      - Optionally select other linked providers to file the result on their behalf.
+    Managed by openCombinedAckFileDialog() in the script block above.
+-->
+<div id="combinedAckFileDialog" title="Acknowledge/File Document" style="display: none;">
+    <form id="combinedFileForm">
+        <label for="combinedAckComment" style="display: block; margin-bottom: 4px;"><b>Please enter a comment (max 255 characters):</b></label>
+        <input type="text" id="combinedAckComment" maxlength="255" style="width: 99%; margin-bottom: 10px;" />
+
+        <c:set var="eligibleProviderCount" value="0" />
+        <c:forEach var="report" items="${ackList}">
+            <c:if test="${report.oscarProviderNo != sessionScope.user && report.status != 'F' && report.status != 'A'}">
+                <c:set var="eligibleProviderCount" value="${eligibleProviderCount + 1}" />
+            </c:if>
+        </c:forEach>
+        <c:if test="${eligibleProviderCount > 0}">
+        <div id="combinedAckAccordion">
+            <span>(Optional) File Document On Behalf of Others</span>
+            <div>
+                <p>This result is linked to other providers who have not acknowledged or filed it yet.</p>
+                <p>Do you want to "file" this result on their behalf?</p>
+                <p>Important - doing so will mean they likely will not see this result. Only proceed if you are sure they will not need to see this result.</p>
+
+                <input type="checkbox" id="combinedAckSelectAllCheckbox" />
+                <label for="combinedAckSelectAllCheckbox"><b>Select All</b></label><br/>
+
+                <c:forEach var="report" items="${ackList}" varStatus="status">
+                    <c:if test="${report.oscarProviderNo != sessionScope.user && report.status != 'F' && report.status != 'A'}">
+                        <c:set var="isDisabled" value="${!report.isHl7AllowOthersFileForYou()}" />
+                        <c:set var="combinedProviderId" value="combinedAckProvider${status.index}" />
+                        <c:set var="combinedProviderNo" value="${e:forHtml(report.oscarProviderNo)}" />
+                        <c:set var="combinedProviderName" value="${e:forHtml(report.providerName)}" />
+
+                        <input type="checkbox"
+                            name="combinedProviders"
+                            id="${combinedProviderId}"
+                            value="${combinedProviderNo}"
+                            class="combinedAckProviderCheckbox${isDisabled ? ' combined-disabled-checkbox' : ''}"
+                            ${isDisabled ? 'disabled' : ''} />
+
+                        <label for="${combinedProviderId}"
+                            style="${isDisabled ? 'color: gray; cursor: not-allowed;' : ''}">
+                            <e:forHtml value="${combinedProviderName}${isDisabled ? ' (opted out by user preference)' : ''}" />
+                        </label>
+
+                        <input type="hidden"
+                            class="combinedAckProviderName"
+                            data-provider-no="${combinedProviderNo}"
+                            value="${e:forHtml(report.providerName)}" /><br/>
+                    </c:if>
+                </c:forEach>
+
+                <p>Tip: in your user preferences, you can automatically show this prompt or prevent others from filing results on your behalf.  See "Set HL7 Lab Result Preferences"</p>
+            </div>
+        </div>
+        </c:if>
     </form>
 </div>
 
@@ -1485,9 +1764,9 @@ request.setAttribute("missingTests", missingTests);
                                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnAcknowledge"/>"
                                        onclick="openFileDialog(false)" />
                                 <% } else if (isLabNotFiledOrAckFlag) {
-                                    // Flag is true if any provider has NOT filed OR NOT acknowledged the lab 
-                                    // Case: Current provider has acknowledged the lab,
-                                    // but at least one of the linked providers has NOT filed or acknowledged
+                                    // The logged-in provider has acknowledged, at least one other linked
+                                    // provider has not yet filed or acknowledged. Show "File for..." so they can file
+                                    // the result on behalf of those providers via the File Document dialog.
                                 %>
                                 <input type="button"
                                     value="File for..."
@@ -2899,14 +3178,14 @@ request.setAttribute("missingTests", missingTests);
             <tr>
                 <td align="left" width="50%">
                     <% if (!ackFlag) {
-                        // Case: Current provider has not acknowledged the lab
+                        // The logged-in provider has not yet acknowledged this lab. Show "Acknowledge".
                     %>
                     <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnAcknowledge"/>"
                            onclick="openFileDialog(false)" />
-                    <% } else if (isLabNotFiledOrAckFlag) { 
-                        // Flag is true if any provider has NOT filed OR NOT acknowledged the lab 
-                        // Case: Current provider has acknowledged the lab,
-                        // but at least one of the linked providers has NOT filed or acknowledged
+                    <% } else if (isLabNotFiledOrAckFlag) {
+                        // The logged-in provider has acknowledged, at least one other linked provider
+                        // has not yet filed or acknowledged. Show "File for..." so they can file the result on behalf
+                        // of those providers via the File Document dialog.
                     %>
                     <input type="button"
                         value="File for..."

--- a/src/main/webapp/provider/providerpreference.jsp
+++ b/src/main/webapp/provider/providerpreference.jsp
@@ -816,6 +816,9 @@
                                   onClick="popupPage(700,860,'<%=request.getContextPath()%>/setProviderStaleDate.do?method=viewLabMacroPrefs');return false;"><fmt:setBundle basename="oscarResources"/><fmt:message key="provider.btnViewLabMacroPrefs"/></a></td>
         </tr>
         <tr>
+            <td align="center"><a href=# onClick ="popupPage(350,860,'<%=request.getContextPath()%>/setProviderStaleDate.do?method=viewHl7LabResultPrefs');return false;"><fmt:setBundle basename="oscarResources"/><fmt:message key="provider.btnViewHl7LabPrefs"/></a></td>
+        </tr>
+        <tr>
             <td align="center"><a href=#
                                   onClick="popupPage(280,730,'<%=request.getContextPath()%>/setTicklerPreferences.do?method=viewTicklerTaskAssignee');return false;"><fmt:setBundle basename="oscarResources"/><fmt:message key="provider.btnViewTicklerPreferences"/></a></td>
         </tr>

--- a/src/main/webapp/provider/setHl7LabResultPrefs.jsp
+++ b/src/main/webapp/provider/setHl7LabResultPrefs.jsp
@@ -35,7 +35,7 @@
                 <label class="form-check-label" for="offerFileForOthers">
                     Automatically offer to file results on behalf of other providers when acknowledging HL7 lab results
                 </label>
-                <div class="form-text text-muted">(default: yes)</div>
+                <div class="form-text text-muted">(default: no)</div>
             </div>
 
             <div class="form-check form-switch mb-3">


### PR DESCRIPTION
## Status Quo
Currently, a logged-in provider **cannot** file lab results on behalf of another provider.  

---

## Change
We have added functionality to allow a provider to **file results on behalf of other providers**.  
(Example shown logged in as `doctor oscardoc`.)

> [!IMPORTANT]  
> This PR is designed to **minimize support burden on OpenOSP**.  
> - By default, this PR will NOT change any behaviour because the functionality defaults to "off" for all providers.  
> - Only if providers **actively turn on this feature within the user preferences** will this option to “file on their behalf” become enabled.  
> - Note that for Magenta, we decided to turn on this feature for all providers automatically in our production, without any significant complaints.    

---

## Main Workflow

- **When more than one provider is attached to a lab:**
  - Clicking `Acknowledge` now opens a **File Dialog**.
    - <img width="713" height="334" alt="1" src="https://github.com/user-attachments/assets/1c2f17ab-817f-4295-95ed-cda8747323ef" />
    - <img width="974" height="478" alt="2" src="https://github.com/user-attachments/assets/d4fc9060-aee5-4dab-a63f-9f556b6fa679" />

- **User selects providers** they want to file for and clicks `Yes`.
  - <img width="893" height="308" alt="3" src="https://github.com/user-attachments/assets/7dbb1f4d-8869-4aa4-aebf-02341444320f" />

- **After confirmation**, the user adds an acknowledgement comment, and the UI updates accordingly:
  - <img width="536" height="237" alt="4" src="https://github.com/user-attachments/assets/b9a8b463-c875-44f8-85d1-11bd8a33e2dd" />
  - <img width="808" height="260" alt="5" src="https://github.com/user-attachments/assets/d462f4cb-758f-47bb-9ab5-e3295efbd220" />

---

## Preferences

Providers can configure the behavior under **Preferences**:

<img width="1136" height="363" alt="6" src="https://github.com/user-attachments/assets/faf795b4-d643-429f-81b4-5bbcd6249f5b" />

1. **Disable the file dialog**  
   Turn off the option:  
   *“Automatically offer to file results on behalf of other providers…”*

2. **Prevent others from filing on your behalf**  
   Turn off the option:  
   *“Allow other providers to file results on your behalf…”*  
   - <img width="835" height="272" alt="7" src="https://github.com/user-attachments/assets/1c66ce5b-2a06-4787-8bc3-a200c0a5c061" />

---

## Additional Feature

- Even if a user has **already acknowledged a lab**, they can still file it for other providers using the `File for…` button.
  - <img width="940" height="377" alt="8" src="https://github.com/user-attachments/assets/1f94ea1b-73b7-4618-9ec2-1a0dcfed7472" />
  - <img width="922" height="455" alt="9" src="https://github.com/user-attachments/assets/95cd6dd3-eddc-4f2b-abe0-1c3a17f9df99" />
  - <img width="807" height="280" alt="10" src="https://github.com/user-attachments/assets/2a684931-ed57-43ab-a8e5-3e281c35bf54" />
