### PR TITLE
Enhancement Package 20260401

### DIFF
--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -987,7 +987,7 @@ INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `me
 ( '24UR', '24-hr Urine cr clearance & albuminuria', 'Renal 24-hr Urine cr clearance & albuminuria', 'q 6-12 months, unit mg', '3', '2013-02-01 00:00:00'),
 ( '5DAA', '5 Day Adherence if on ART', '5 Day Adherence if on ART', 'number', '4', '2013-02-01 00:00:00'),
 ( 'A1C', 'A1C', 'A1C', 'Range:0.040-0.200', '3', '2013-02-01 00:00:00'),
-( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Yes/No', '7', '2013-02-01 00:00:00'),
+( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Provided/Revised/Reviewed', '18', '2013-02-01 00:00:00'),
 ( 'ABO', 'Blood Group', 'ABO RhD blood type group', 'Blood Type', '11', '2014-05-09 00:00:00'),
 ( 'ACOS', 'Asthma Coping Strategies', 'Asthma Coping Strategies', 'Yes/No', '7', '2013-02-01 00:00:00'),
 ( 'ACR', 'Alb creat ratio', 'ACR', 'in mg/mmol', '5', '2013-02-01 00:00:00'),
@@ -1455,7 +1455,8 @@ INSERT INTO `validations` (`id`, `name`, `regularExp`, `maxValue1`, `minValue`, 
 (14,'Numeric Value greater than or equal to 0',NULL,0,0,0,0,1,NULL,0),
 (15, 'Yes/No/Maybe', 'YES|yes|Yes|Y|NO|no|No|N|MAYBE|maybe|Maybe', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
 (16, 'Review', 'REVIEWED|reviewed|Reviewed', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-(17,'pos or neg', 'pos|neg|positive|negative', NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+(17,'pos or neg', 'pos|neg|positive|negative', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+(18,'Provided/Revised/Reviewed', 'Provided|Revised|Reviewed', NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 
 insert into `secRole` values(1, 'receptionist', 'receptionist');

--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -987,7 +987,7 @@ INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `me
 ( '24UR', '24-hr Urine cr clearance & albuminuria', 'Renal 24-hr Urine cr clearance & albuminuria', 'q 6-12 months, unit mg', '3', '2013-02-01 00:00:00'),
 ( '5DAA', '5 Day Adherence if on ART', '5 Day Adherence if on ART', 'number', '4', '2013-02-01 00:00:00'),
 ( 'A1C', 'A1C', 'A1C', 'Range:0.040-0.200', '3', '2013-02-01 00:00:00'),
-( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Plan', '18', '2013-02-01 00:00:00'),
+( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Provided/Revised/Reviewed', '18', '2013-02-01 00:00:00'),
 ( 'ABO', 'Blood Group', 'ABO RhD blood type group', 'Blood Type', '11', '2014-05-09 00:00:00'),
 ( 'ACOS', 'Asthma Coping Strategies', 'Asthma Coping Strategies', 'Yes/No', '7', '2013-02-01 00:00:00'),
 ( 'ACR', 'Alb creat ratio', 'ACR', 'in mg/mmol', '5', '2013-02-01 00:00:00'),

--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -987,7 +987,7 @@ INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `me
 ( '24UR', '24-hr Urine cr clearance & albuminuria', 'Renal 24-hr Urine cr clearance & albuminuria', 'q 6-12 months, unit mg', '3', '2013-02-01 00:00:00'),
 ( '5DAA', '5 Day Adherence if on ART', '5 Day Adherence if on ART', 'number', '4', '2013-02-01 00:00:00'),
 ( 'A1C', 'A1C', 'A1C', 'Range:0.040-0.200', '3', '2013-02-01 00:00:00'),
-( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Provided/Revised/Reviewed', '18', '2013-02-01 00:00:00'),
+( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Plan', '18', '2013-02-01 00:00:00'),
 ( 'ABO', 'Blood Group', 'ABO RhD blood type group', 'Blood Type', '11', '2014-05-09 00:00:00'),
 ( 'ACOS', 'Asthma Coping Strategies', 'Asthma Coping Strategies', 'Yes/No', '7', '2013-02-01 00:00:00'),
 ( 'ACR', 'Alb creat ratio', 'ACR', 'in mg/mmol', '5', '2013-02-01 00:00:00'),

--- a/database/mysql/oscarinit.sql
+++ b/database/mysql/oscarinit.sql
@@ -341,7 +341,15 @@ CREATE TABLE IF NOT EXISTS consultationRequests (
   `lastUpdateDate` datetime not null,
   fdid int(10),
   source varchar(50),
-  PRIMARY KEY  (requestId)
+  PRIMARY KEY  (requestId),
+  KEY `idx_consult_status_referaldate` (`status`, `referalDate`),
+  KEY `idx_consult_sendto_status_referaldate` (`sendTo`, `status`, `referalDate`),
+  KEY `idx_consult_providerno_status_referaldate` (`providerNo`, `status`, `referalDate`),
+  KEY `idx_consult_status_appointmentdate` (`status`, `appointmentDate`),
+  KEY `idx_consult_demographicno` (`demographicNo`),
+  KEY `idx_consult_serviceid` (`serviceId`),
+  KEY `idx_consult_specid` (`specId`),
+  KEY `idx_consult_lastupdatedate` (`lastUpdateDate`)
 ) ;
 
 CREATE TABLE consultationRequestsArchive (

--- a/database/mysql/oscarinit.sql
+++ b/database/mysql/oscarinit.sql
@@ -341,15 +341,7 @@ CREATE TABLE IF NOT EXISTS consultationRequests (
   `lastUpdateDate` datetime not null,
   fdid int(10),
   source varchar(50),
-  PRIMARY KEY  (requestId),
-  KEY `idx_consult_status_referaldate` (`status`, `referalDate`),
-  KEY `idx_consult_sendto_status_referaldate` (`sendTo`, `status`, `referalDate`),
-  KEY `idx_consult_providerno_status_referaldate` (`providerNo`, `status`, `referalDate`),
-  KEY `idx_consult_status_appointmentdate` (`status`, `appointmentDate`),
-  KEY `idx_consult_demographicno` (`demographicNo`),
-  KEY `idx_consult_serviceid` (`serviceId`),
-  KEY `idx_consult_specid` (`specId`),
-  KEY `idx_consult_lastupdatedate` (`lastUpdateDate`)
+  PRIMARY KEY  (requestId)
 ) ;
 
 CREATE TABLE consultationRequestsArchive (

--- a/database/mysql/updates/update-2026-01-26-consultation-indexes.sql
+++ b/database/mysql/updates/update-2026-01-26-consultation-indexes.sql
@@ -1,0 +1,26 @@
+-- Indexes for consultationRequests table to improve query performance
+-- Addresses slow consultation page load times by optimizing common query patterns
+
+-- Index for status + referral date filtering (common filter pattern)
+CREATE INDEX IF NOT EXISTS idx_consult_status_referaldate ON consultationRequests (status, referalDate);
+
+-- Index for team-based queries with status and date filtering (main team listing query)
+CREATE INDEX IF NOT EXISTS idx_consult_sendto_status_referaldate ON consultationRequests (sendTo, status, referalDate);
+
+-- Index for provider workload queries
+CREATE INDEX IF NOT EXISTS idx_consult_providerno_status_referaldate ON consultationRequests (providerNo, status, referalDate);
+
+-- Index for appointment date search mode
+CREATE INDEX IF NOT EXISTS idx_consult_status_appointmentdate ON consultationRequests (status, appointmentDate);
+
+-- Index for demographic lookups (heavily used)
+CREATE INDEX IF NOT EXISTS idx_consult_demographicno ON consultationRequests (demographicNo);
+
+-- Index for service foreign key lookups
+CREATE INDEX IF NOT EXISTS idx_consult_serviceid ON consultationRequests (serviceId);
+
+-- Index for specialist foreign key lookups
+CREATE INDEX IF NOT EXISTS idx_consult_specid ON consultationRequests (specId);
+
+-- Index for sync/update tracking queries
+CREATE INDEX IF NOT EXISTS idx_consult_lastupdatedate ON consultationRequests (lastUpdateDate);

--- a/database/mysql/updates/update-2026-03-09-aacp-validation.sql
+++ b/database/mysql/updates/update-2026-03-09-aacp-validation.sql
@@ -11,5 +11,5 @@ WHERE NOT EXISTS (
 
 -- Point AACP to the Provided/Revised/Reviewed validation instead of the generic Yes/No/NA
 UPDATE measurementType
-SET validation = (SELECT id FROM validations WHERE name = 'Provided/Revised/Reviewed' LIMIT 1)
+SET validation = (SELECT id FROM validations WHERE name = 'Provided/Revised/Reviewed' ORDER BY id LIMIT 1)
 WHERE type = 'AACP';

--- a/database/mysql/updates/update-2026-03-09-aacp-validation.sql
+++ b/database/mysql/updates/update-2026-03-09-aacp-validation.sql
@@ -6,10 +6,10 @@
 INSERT INTO validations (name, regularExp)
 SELECT 'Provided/Revised/Reviewed', 'Provided|Revised|Reviewed'
 WHERE NOT EXISTS (
-    SELECT 1 FROM validations WHERE name = 'Provided/Revised/Reviewed'
+    SELECT 1 FROM validations WHERE name = 'Provided/Revised/Reviewed' AND regularExp = 'Provided|Revised|Reviewed'
 );
 
 -- Point AACP to the Provided/Revised/Reviewed validation instead of the generic Yes/No/NA
 UPDATE measurementType
-SET validation = (SELECT id FROM validations WHERE name = 'Provided/Revised/Reviewed' ORDER BY id LIMIT 1)
+SET validation = (SELECT id FROM validations WHERE name = 'Provided/Revised/Reviewed' AND regularExp = 'Provided|Revised|Reviewed' ORDER BY id LIMIT 1)
 WHERE type = 'AACP';

--- a/database/mysql/updates/update-2026-03-09-aacp-validation.sql
+++ b/database/mysql/updates/update-2026-03-09-aacp-validation.sql
@@ -1,0 +1,15 @@
+-- Update Asthma Action Plan (AACP) dropdown options
+-- Changes from generic Yes/No/NA to Provided/Revised/Reviewed per OMD DE16.098 conformance
+-- Issue: https://github.com/openo-beta/Open-O/issues/2319
+
+-- Create the Provided/Revised/Reviewed validation row if it doesn't already exist
+INSERT INTO validations (name, regularExp)
+SELECT 'Provided/Revised/Reviewed', 'Provided|Revised|Reviewed'
+WHERE NOT EXISTS (
+    SELECT 1 FROM validations WHERE name = 'Provided/Revised/Reviewed'
+);
+
+-- Point AACP to the Provided/Revised/Reviewed validation instead of the generic Yes/No/NA
+UPDATE measurementType
+SET validation = (SELECT id FROM validations WHERE name = 'Provided/Revised/Reviewed' LIMIT 1)
+WHERE type = 'AACP';

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
@@ -86,8 +86,9 @@ public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest>
 
     /**
      * Retrieves all consultation requests for a specific patient as lightweight DTOs, ordered by
-     * referral date descending. Uses the same DTO projection and batch extension loading as
-     * {@link #getConsultationDTOs}.
+     * referral date ascending. The ascending order is intentional because {@code EctDisplayConsult2Action}
+     * iterates the result list in reverse, producing a newest-first display.
+     * Uses the same DTO projection and batch extension loading as {@link #getConsultationDTOs}.
      *
      * @param demoNo Integer the demographic number of the patient
      * @return List of ConsultationListDTO for the specified patient

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.List;
 
 import ca.openosp.openo.commn.model.ConsultationRequest;
+import ca.openosp.openo.consultation.dto.ConsultationListDTO;
 
 public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest> {
 
@@ -59,4 +60,38 @@ public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest>
     List<ConsultationRequest> findByDemographicAndServices(Integer demographicNo, List<String> serviceNameList);
 
     List<Integer> findNewConsultationsSinceDemoKey(String keyName);
+
+    /**
+     * Retrieves consultation requests as lightweight DTOs using a single JPQL constructor projection
+     * query with LEFT JOINs to Demographic, Provider (MRP and consulting), ConsultationServices, and
+     * ProfessionalSpecialist. Extensions (eReferral data) are batch-loaded in one additional query.
+     * <p>
+     * This replaces the previous N+1 pattern where each consultation triggered individual queries
+     * for demographics, providers, services, and extensions, reducing total queries from ~5N to 2.
+     * </p>
+     *
+     * @param team String the team/sendTo filter value (empty string for all teams)
+     * @param showCompleted boolean whether to include completed (status 4) consultations
+     * @param startDate Date the start date filter (null for no lower bound)
+     * @param endDate Date the end date filter (null for no upper bound)
+     * @param orderby String the sort column identifier (1-9), null for default referral date desc
+     * @param desc String "1" for descending sort, null/other for ascending
+     * @param searchDate String "1" to filter on appointment date instead of referral date
+     * @param offset Integer the pagination offset (null defaults to 0)
+     * @param limit Integer the page size (null defaults to {@link #DEFAULT_CONSULT_REQUEST_RESULTS_LIMIT})
+     * @return List of ConsultationListDTO with all display fields populated
+     * @since 2026-02-03
+     */
+    List<ConsultationListDTO> getConsultationDTOs(String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate, Integer offset, Integer limit);
+
+    /**
+     * Retrieves all consultation requests for a specific patient as lightweight DTOs, ordered by
+     * referral date descending. Uses the same DTO projection and batch extension loading as
+     * {@link #getConsultationDTOs}.
+     *
+     * @param demoNo Integer the demographic number of the patient
+     * @return List of ConsultationListDTO for the specified patient
+     * @since 2026-02-03
+     */
+    List<ConsultationListDTO> getConsultationDTOsByDemographic(Integer demoNo);
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
@@ -278,7 +278,7 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
     public List<ConsultationListDTO> getConsultationDTOsByDemographic(Integer demoNo) {
         String sql = DTO_SELECT + DTO_FROM +
                 "WHERE cr.demographicId = ?1 " +
-                "ORDER BY cr.referralDate DESC";
+                "ORDER BY cr.referralDate ASC";
 
         Query query = entityManager.createQuery(sql, ConsultationListDTO.class);
         query.setParameter(1, demoNo);

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
@@ -110,30 +110,23 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
             }
         }
 
-        String orderDesc = desc != null && desc.equals("1") ? "DESC" : "";
-        String service = ", service.serviceDesc";
         if (orderby == null) {
             sql.append("order by cr.referralDate desc ");
-        } else if (orderby.equals("1")) {               //1 = msgStatus
-            sql.append("order by cr.status " + orderDesc + service);
-        } else if (orderby.equals("2")) {               //2 = msgTeam
-            sql.append("order by cr.sendTo " + orderDesc + service);
-        } else if (orderby.equals("3")) {               //3 = msgPatient
-            sql.append("order by d.LastName " + orderDesc + service);
-        } else if (orderby.equals("4")) {               //4 = msgProvider
-            sql.append("order by p.LastName " + orderDesc + service);
-        } else if (orderby.equals("5")) {               //5 = msgService Desc
-            sql.append("order by service.serviceDesc " + orderDesc);
-        } else if (orderby.equals("6")) {               //6 = msgSpecialist Name
-            sql.append("order by specialist.lastName " + orderDesc + service);
-        } else if (orderby.equals("7")) {               //7 = msgRefDate
-            sql.append("order by cr.referralDate " + orderDesc);
-        } else if (orderby.equals("8")) {               //8 = Appointment Date
-            sql.append("order by cr.appointmentDate " + orderDesc);
-        } else if (orderby.equals("9")) {               //9 = FollowUp Date
-            sql.append("order by cr.followUpDate " + orderDesc);
         } else {
-            sql.append("order by cr.referralDate desc");
+            String orderDesc = desc != null && desc.equals("1") ? "DESC" : "";
+            String service = ", service.serviceDesc";
+            switch (orderby) {
+                case "1": sql.append("order by cr.status ").append(orderDesc).append(service); break;
+                case "2": sql.append("order by cr.sendTo ").append(orderDesc).append(service); break;
+                case "3": sql.append("order by d.LastName ").append(orderDesc).append(service); break;
+                case "4": sql.append("order by p.LastName ").append(orderDesc).append(service); break;
+                case "5": sql.append("order by service.serviceDesc ").append(orderDesc); break;
+                case "6": sql.append("order by specialist.lastName ").append(orderDesc).append(service); break;
+                case "7": sql.append("order by cr.referralDate ").append(orderDesc); break;
+                case "8": sql.append("order by cr.appointmentDate ").append(orderDesc); break;
+                case "9": sql.append("order by cr.followUpDate ").append(orderDesc); break;
+                default: sql.append("order by cr.referralDate desc"); break;
+            }
         }
 
 
@@ -342,30 +335,23 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
             paramList.add(endDate);
         }
 
-        String orderDesc = desc != null && desc.equals("1") ? "DESC" : "";
-        String svcSort = ", svc.serviceDesc";
         if (orderby == null) {
             sql.append("ORDER BY cr.referralDate DESC ");
-        } else if (orderby.equals("1")) {
-            sql.append("ORDER BY cr.status ").append(orderDesc).append(svcSort);
-        } else if (orderby.equals("2")) {
-            sql.append("ORDER BY cr.sendTo ").append(orderDesc).append(svcSort);
-        } else if (orderby.equals("3")) {
-            sql.append("ORDER BY d.LastName ").append(orderDesc).append(svcSort);
-        } else if (orderby.equals("4")) {
-            sql.append("ORDER BY mrp.LastName ").append(orderDesc).append(svcSort);
-        } else if (orderby.equals("5")) {
-            sql.append("ORDER BY svc.serviceDesc ").append(orderDesc);
-        } else if (orderby.equals("6")) {
-            sql.append("ORDER BY specialist.lastName ").append(orderDesc).append(svcSort);
-        } else if (orderby.equals("7")) {
-            sql.append("ORDER BY cr.referralDate ").append(orderDesc);
-        } else if (orderby.equals("8")) {
-            sql.append("ORDER BY cr.appointmentDate ").append(orderDesc);
-        } else if (orderby.equals("9")) {
-            sql.append("ORDER BY cr.followUpDate ").append(orderDesc);
         } else {
-            sql.append("ORDER BY cr.referralDate DESC");
+            String orderDesc = desc != null && desc.equals("1") ? "DESC" : "";
+            String svcSort = ", svc.serviceDesc";
+            switch (orderby) {
+                case "1": sql.append("ORDER BY cr.status ").append(orderDesc).append(svcSort); break;
+                case "2": sql.append("ORDER BY cr.sendTo ").append(orderDesc).append(svcSort); break;
+                case "3": sql.append("ORDER BY d.LastName ").append(orderDesc).append(svcSort); break;
+                case "4": sql.append("ORDER BY mrp.LastName ").append(orderDesc).append(svcSort); break;
+                case "5": sql.append("ORDER BY svc.serviceDesc ").append(orderDesc); break;
+                case "6": sql.append("ORDER BY specialist.lastName ").append(orderDesc).append(svcSort); break;
+                case "7": sql.append("ORDER BY cr.referralDate ").append(orderDesc); break;
+                case "8": sql.append("ORDER BY cr.appointmentDate ").append(orderDesc); break;
+                case "9": sql.append("ORDER BY cr.followUpDate ").append(orderDesc); break;
+                default: sql.append("ORDER BY cr.referralDate DESC"); break;
+            }
         }
 
         return sql.toString();

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
@@ -28,14 +28,21 @@
 package ca.openosp.openo.commn.dao;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.persistence.Query;
 
 import org.apache.commons.lang3.time.DateFormatUtils;
 import ca.openosp.openo.commn.NativeSql;
 import ca.openosp.openo.commn.model.ConsultationRequest;
+import ca.openosp.openo.commn.model.ConsultationRequestExt;
+import ca.openosp.openo.consultation.dto.ConsultationListDTO;
 
 @SuppressWarnings("unchecked")
 public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequest> implements ConsultationRequestDao {
@@ -212,5 +219,192 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
         Query query = entityManager.createNativeQuery(sql);
         query.setParameter(1, keyName);
         return query.getResultList();
+    }
+
+    /**
+     * JPQL SELECT clause for DTO constructor projection. Field order must exactly match
+     * the {@link ConsultationListDTO} constructor parameter order.
+     */
+    private static final String DTO_SELECT = "SELECT NEW ca.openosp.openo.consultation.dto.ConsultationListDTO(" +
+            "cr.id, cr.status, cr.urgency, " +
+            "cr.demographicId, d.LastName, d.FirstName, " +
+            "d.ProviderNo, mrp.LastName, mrp.FirstName, " +
+            "cr.providerNo, cp.LastName, cp.FirstName, " +
+            "cr.serviceId, svc.serviceDesc, " +
+            "specialist.lastName, specialist.firstName, " +
+            "cr.referralDate, cr.appointmentDate, cr.appointmentTime, " +
+            "cr.patientWillBook, cr.followUpDate, " +
+            "cr.sendTo, cr.siteName) ";
+
+    /**
+     * JPQL FROM clause with LEFT JOINs for DTO projection. Joins:
+     * <ul>
+     *   <li>Demographic (patient name, provider number)</li>
+     *   <li>Provider as mrp (Most Responsible Provider from demographic)</li>
+     *   <li>Provider as cp (consulting provider from consultation request)</li>
+     *   <li>ConsultationServices (service description)</li>
+     *   <li>ProfessionalSpecialist (specialist name via entity relationship)</li>
+     * </ul>
+     */
+    private static final String DTO_FROM = "FROM ConsultationRequest cr " +
+            "LEFT JOIN Demographic d ON d.DemographicNo = cr.demographicId " +
+            "LEFT JOIN Provider mrp ON mrp.ProviderNo = d.ProviderNo " +
+            "LEFT JOIN Provider cp ON cp.ProviderNo = cr.providerNo " +
+            "LEFT JOIN ConsultationServices svc ON svc.serviceId = cr.serviceId " +
+            "LEFT JOIN cr.professionalSpecialist specialist ";
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2026-02-03
+     */
+    @Override
+    public List<ConsultationListDTO> getConsultationDTOs(String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate, Integer offset, Integer limit) {
+        List<Object> paramList = new ArrayList<>();
+        String sql = buildConsultationDTOQuery(paramList, team, showCompleted, startDate, endDate, orderby, desc, searchDate);
+
+        Query query = entityManager.createQuery(sql, ConsultationListDTO.class);
+        for (int i = 0; i < paramList.size(); i++) {
+            query.setParameter(i + 1, paramList.get(i));
+        }
+        query.setFirstResult(offset != null ? offset : 0);
+        int myLimit = limit != null ? limit : DEFAULT_CONSULT_REQUEST_RESULTS_LIMIT;
+        query.setMaxResults(Math.min(myLimit, MAX_LIST_RETURN_SIZE));
+
+        List<ConsultationListDTO> dtos = query.getResultList();
+        loadExtensionsForDTOs(dtos);
+        return dtos;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2026-02-03
+     */
+    @Override
+    public List<ConsultationListDTO> getConsultationDTOsByDemographic(Integer demoNo) {
+        String sql = DTO_SELECT + DTO_FROM +
+                "WHERE cr.demographicId = ?1 " +
+                "ORDER BY cr.referralDate DESC";
+
+        Query query = entityManager.createQuery(sql, ConsultationListDTO.class);
+        query.setParameter(1, demoNo);
+
+        List<ConsultationListDTO> dtos = query.getResultList();
+        loadExtensionsForDTOs(dtos);
+        return dtos;
+    }
+
+    /**
+     * Builds the complete JPQL query string for DTO projection with parameterized filters and sorting.
+     * Uses positional parameters to prevent SQL injection (replacing the previous string concatenation pattern).
+     *
+     * @param paramList List to populate with positional query parameter values
+     * @param team String the team filter (null or empty to skip)
+     * @param showCompleted boolean whether to include completed consultations
+     * @param startDate Date the start date bound (null to skip)
+     * @param endDate Date the end date bound (null to skip)
+     * @param orderby String the sort column identifier (1-9)
+     * @param desc String "1" for descending, otherwise ascending
+     * @param searchDate String "1" to filter on appointment date instead of referral date
+     * @return String the complete JPQL query
+     */
+    private String buildConsultationDTOQuery(List<Object> paramList, String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate) {
+        int paramIndex = 1;
+        StringBuilder sql = new StringBuilder(DTO_SELECT);
+        sql.append(DTO_FROM);
+        sql.append("WHERE 1=1 ");
+
+        if (!showCompleted) {
+            sql.append("AND cr.status != '4' ");
+        }
+
+        if (team != null && !team.isEmpty()) {
+            sql.append("AND cr.sendTo = ?").append(paramIndex++).append(" ");
+            paramList.add(team);
+        }
+
+        if (startDate != null) {
+            if ("1".equals(searchDate)) {
+                sql.append("AND cr.appointmentDate >= ?").append(paramIndex++).append(" ");
+            } else {
+                sql.append("AND cr.referralDate >= ?").append(paramIndex++).append(" ");
+            }
+            paramList.add(startDate);
+        }
+
+        if (endDate != null) {
+            if ("1".equals(searchDate)) {
+                sql.append("AND cr.appointmentDate <= ?").append(paramIndex++).append(" ");
+            } else {
+                sql.append("AND cr.referralDate <= ?").append(paramIndex++).append(" ");
+            }
+            paramList.add(endDate);
+        }
+
+        String orderDesc = desc != null && desc.equals("1") ? "DESC" : "";
+        String svcSort = ", svc.serviceDesc";
+        if (orderby == null) {
+            sql.append("ORDER BY cr.referralDate DESC ");
+        } else if (orderby.equals("1")) {
+            sql.append("ORDER BY cr.status ").append(orderDesc).append(svcSort);
+        } else if (orderby.equals("2")) {
+            sql.append("ORDER BY cr.sendTo ").append(orderDesc).append(svcSort);
+        } else if (orderby.equals("3")) {
+            sql.append("ORDER BY d.LastName ").append(orderDesc).append(svcSort);
+        } else if (orderby.equals("4")) {
+            sql.append("ORDER BY mrp.LastName ").append(orderDesc).append(svcSort);
+        } else if (orderby.equals("5")) {
+            sql.append("ORDER BY svc.serviceDesc ").append(orderDesc);
+        } else if (orderby.equals("6")) {
+            sql.append("ORDER BY specialist.lastName ").append(orderDesc).append(svcSort);
+        } else if (orderby.equals("7")) {
+            sql.append("ORDER BY cr.referralDate ").append(orderDesc);
+        } else if (orderby.equals("8")) {
+            sql.append("ORDER BY cr.appointmentDate ").append(orderDesc);
+        } else if (orderby.equals("9")) {
+            sql.append("ORDER BY cr.followUpDate ").append(orderDesc);
+        } else {
+            sql.append("ORDER BY cr.referralDate DESC");
+        }
+
+        return sql.toString();
+    }
+
+    /**
+     * Batch-loads all {@link ConsultationRequestExt} records for the given DTOs in a single
+     * {@code IN(:ids)} query, then groups them by request ID and applies each group to its
+     * corresponding DTO via {@link ConsultationListDTO#applyExtensions(Map)}.
+     * <p>
+     * This handles eReferral extension fields (ereferral_ref, ereferral_service, ereferral_doctor)
+     * that were previously fetched individually per consultation request in the N+1 loop.
+     * </p>
+     *
+     * @param dtos List of ConsultationListDTO to enrich with extension data
+     */
+    private void loadExtensionsForDTOs(List<ConsultationListDTO> dtos) {
+        if (dtos == null || dtos.isEmpty()) {
+            return;
+        }
+
+        List<Integer> consultIds = dtos.stream()
+                .map(ConsultationListDTO::getId)
+                .collect(Collectors.toList());
+
+        List<ConsultationRequestExt> allExts = entityManager
+                .createQuery("SELECT e FROM ConsultationRequestExt e WHERE e.requestId IN (:ids)", ConsultationRequestExt.class)
+                .setParameter("ids", consultIds)
+                .getResultList();
+
+        Map<Integer, Map<String, String>> extsByRequest = new HashMap<>();
+        for (ConsultationRequestExt ext : allExts) {
+            extsByRequest
+                    .computeIfAbsent(ext.getRequestId(), k -> new HashMap<>())
+                    .put(ext.getKey(), ext.getValue());
+        }
+
+        for (ConsultationListDTO dto : dtos) {
+            dto.applyExtensions(extsByRequest.getOrDefault(dto.getId(), Collections.emptyMap()));
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationServiceDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationServiceDao.java
@@ -30,6 +30,7 @@ package ca.openosp.openo.commn.dao;
 import java.util.List;
 
 import ca.openosp.openo.commn.model.ConsultationServices;
+import ca.openosp.openo.encounter.oscarConsultationRequest.config.data.ConsultationServiceDto;
 
 public interface ConsultationServiceDao extends AbstractDao<ConsultationServices> {
     public String REFERRING_DOCTOR = "Referring Doctor";
@@ -47,4 +48,21 @@ public interface ConsultationServiceDao extends AbstractDao<ConsultationServices
     public ConsultationServices findByDescription(String description);
 
     public ConsultationServices findReferringDoctorService(boolean activeOnly);
+
+    /**
+     * Retrieves only the service description for a given service ID, without loading
+     * the full entity or its associated specialists collection.
+     *
+     * @param serviceId Integer the consultation service ID
+     * @return String the service description, or null if not found
+     */
+    public String getServiceDescription(Integer serviceId);
+
+    /**
+     * Retrieves active consultation service summaries (ID and description only) without
+     * loading the full entity or its associated specialists collection.
+     *
+     * @return List&lt;ConsultationServiceDto&gt; containing serviceId and serviceDesc
+     */
+    public List<ConsultationServiceDto> findActiveServiceSummaries();
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationServiceDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationServiceDaoImpl.java
@@ -35,6 +35,7 @@ import java.util.List;
 import javax.persistence.Query;
 
 import ca.openosp.openo.commn.model.ConsultationServices;
+import ca.openosp.openo.encounter.oscarConsultationRequest.config.data.ConsultationServiceDto;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -89,6 +90,29 @@ public class ConsultationServiceDaoImpl extends AbstractDaoImpl<ConsultationServ
         query.setParameter(2, description);
 
         return this.getSingleResultOrNull(query);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<ConsultationServiceDto> findActiveServiceSummaries() {
+        Query query = entityManager.createQuery("SELECT NEW ca.openosp.openo.encounter.oscarConsultationRequest.config.data.ConsultationServiceDto(cs.serviceId, cs.serviceDesc) FROM ConsultationServices cs WHERE cs.active = :active ORDER BY cs.serviceDesc");
+        query.setParameter("active", ACTIVE);
+        return query.getResultList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getServiceDescription(Integer serviceId) {
+        Query query = entityManager.createQuery("SELECT cs.serviceDesc FROM ConsultationServices cs WHERE cs.serviceId = :id");
+        query.setParameter("id", serviceId);
+        @SuppressWarnings("unchecked")
+        List<String> results = query.getResultList();
+        return results.isEmpty() ? null : results.get(0);
     }
 
     public ConsultationServices findReferringDoctorService(boolean activeOnly) {

--- a/src/main/java/ca/openosp/openo/commn/dao/FaxJobDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/FaxJobDao.java
@@ -42,6 +42,13 @@ public interface FaxJobDao extends AbstractDao<FaxJob> {
 
     public List<FaxJob> getInprogressFaxesByJobId();
 
+    /**
+     * Retrieves fax jobs by a list of IDs in a single batch query.
+     *
+     * @param ids List&lt;Integer&gt; the fax job IDs to retrieve
+     * @return List&lt;FaxJob&gt; the matching fax jobs, or an empty list if ids is null or empty
+     * @since 2026-02-03
+     */
     public List<FaxJob> findByIds(List<Integer> ids);
 
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/FaxJobDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/FaxJobDao.java
@@ -42,4 +42,6 @@ public interface FaxJobDao extends AbstractDao<FaxJob> {
 
     public List<FaxJob> getInprogressFaxesByJobId();
 
+    public List<FaxJob> findByIds(List<Integer> ids);
+
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/FaxJobDaoImpl.java
@@ -131,6 +131,11 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
         return query.getResultList();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2026-02-03
+     */
     @SuppressWarnings("unchecked")
     @Override
     public List<FaxJob> findByIds(List<Integer> ids) {

--- a/src/main/java/ca/openosp/openo/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/FaxJobDaoImpl.java
@@ -133,6 +133,17 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
 
     @SuppressWarnings("unchecked")
     @Override
+    public List<FaxJob> findByIds(List<Integer> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Query query = entityManager.createQuery("SELECT f FROM FaxJob f WHERE f.id IN (:ids)");
+        query.setParameter("ids", ids);
+        return query.getResultList();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
     public List<FaxJob> getInprogressFaxesByJobId() {
         Query query = entityManager.createQuery(
                 "select job from FaxJob job where (job.status = ?1 or job.status = ?2) and job.jobId is not null");

--- a/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDao.java
@@ -29,10 +29,20 @@ package ca.openosp.openo.commn.dao;
 import java.util.List;
 
 import ca.openosp.openo.commn.model.ProfessionalSpecialist;
+import ca.openosp.openo.consultation.dto.SpecialistListDTO;
 
 public interface ProfessionalSpecialistDao extends AbstractDao<ProfessionalSpecialist> {
 
     List<ProfessionalSpecialist> findAll();
+
+    /**
+     * Returns lightweight projections of all specialists for list display,
+     * fetching only the columns needed (id, name, letters, address, phone, fax).
+     * Avoids full entity hydration of heavy text fields.
+     *
+     * @return List&lt;SpecialistListDTO&gt; specialists ordered by last name, first name
+     */
+    List<SpecialistListDTO> findAllListDTOs();
 
     List<ProfessionalSpecialist> findByEDataUrlNotNull();
 

--- a/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDaoImpl.java
@@ -36,6 +36,7 @@ import javax.persistence.Query;
 
 import org.apache.commons.lang3.StringUtils;
 import ca.openosp.openo.commn.model.ProfessionalSpecialist;
+import ca.openosp.openo.consultation.dto.SpecialistListDTO;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -53,6 +54,22 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
         List<ProfessionalSpecialist> results = query.getResultList();
 
         return (results);
+    }
+
+    @Override
+    public List<SpecialistListDTO> findAllListDTOs() {
+        Query query = entityManager.createQuery(
+                "SELECT NEW ca.openosp.openo.consultation.dto.SpecialistListDTO("
+                        + "x.id, x.firstName, x.lastName, x.professionalLetters, "
+                        + "x.streetAddress, x.phoneNumber, x.faxNumber) "
+                        + "FROM ProfessionalSpecialist x "
+                        + "ORDER BY x.lastName, x.firstName"
+        );
+
+        @SuppressWarnings("unchecked")
+        List<SpecialistListDTO> results = query.getResultList();
+
+        return results;
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDaoImpl.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 
 import org.apache.commons.lang3.StringUtils;
 import ca.openosp.openo.commn.model.ProfessionalSpecialist;
@@ -58,18 +59,16 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
 
     @Override
     public List<SpecialistListDTO> findAllListDTOs() {
-        Query query = entityManager.createQuery(
+        TypedQuery<SpecialistListDTO> query = entityManager.createQuery(
                 "SELECT NEW ca.openosp.openo.consultation.dto.SpecialistListDTO("
                         + "x.id, x.firstName, x.lastName, x.professionalLetters, "
                         + "x.streetAddress, x.phoneNumber, x.faxNumber) "
                         + "FROM ProfessionalSpecialist x "
-                        + "ORDER BY x.lastName, x.firstName"
+                        + "ORDER BY x.lastName, x.firstName",
+                SpecialistListDTO.class
         );
 
-        @SuppressWarnings("unchecked")
-        List<SpecialistListDTO> results = query.getResultList();
-
-        return results;
+        return query.getResultList();
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/commn/dao/TicklerDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/TicklerDao.java
@@ -80,7 +80,7 @@ public interface TicklerDao extends AbstractDao<Tickler> {
      *
      * @param filter CustomFilter the filter criteria including status, provider, date range, etc.
      * @param offset int the starting position for pagination (0-based)
-     * @param limit int the maximum number of results to return
+     * @param limit int the maximum number of results to return, or &lt;= 0 for no limit
      * @return List&lt;TicklerListDTO&gt; matching the filter with comments and links populated,
      *         or empty list if no matches found
      * @since 2026-01-30

--- a/src/main/java/ca/openosp/openo/commn/dao/TicklerDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/TicklerDaoImpl.java
@@ -439,7 +439,9 @@ public class TicklerDaoImpl extends AbstractDaoImpl<Tickler> implements TicklerD
             query.setParameter(x + 1, paramList.get(x));
         }
         query.setFirstResult(offset);
-        setLimit(query, limit);
+        if (limit > 0) {
+            setLimit(query, limit);
+        }
 
         List<TicklerListDTO> ticklerDTOs = query.getResultList();
 

--- a/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
+++ b/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
@@ -27,6 +27,11 @@
 package ca.openosp.openo.commn.model;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 
 import javax.persistence.*;
 import java.io.Serializable;
@@ -53,10 +58,16 @@ public class ConsultationRequest extends AbstractModel<Integer> implements Seria
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = ProfessionalSpecialist.class, cascade = CascadeType.MERGE)
     @JoinColumn(name = "specId", referencedColumnName = "specId")
+    @NotFound(action = NotFoundAction.IGNORE)
+    @Fetch(FetchMode.SELECT)
+    @BatchSize(size = 25)
     private ProfessionalSpecialist professionalSpecialist;
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = DemographicContact.class)
     @JoinColumn(name = "demographicContactId", referencedColumnName = "id")
+    @NotFound(action = NotFoundAction.IGNORE)
+    @Fetch(FetchMode.SELECT)
+    @BatchSize(size = 25)
     private DemographicContact demographicContact;
 
     @Temporal(TemporalType.DATE)
@@ -103,6 +114,9 @@ public class ConsultationRequest extends AbstractModel<Integer> implements Seria
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = LookupListItem.class)
     @JoinColumn(name = "appointmentInstructions", referencedColumnName = "value", insertable = false, updatable = false)
+    @NotFound(action = NotFoundAction.IGNORE)
+    @Fetch(FetchMode.SELECT)
+    @BatchSize(size = 25)
     private LookupListItem lookupListItem;
 
     @Transient

--- a/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
+++ b/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
@@ -58,14 +58,12 @@ public class ConsultationRequest extends AbstractModel<Integer> implements Seria
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = ProfessionalSpecialist.class, cascade = CascadeType.MERGE)
     @JoinColumn(name = "specId", referencedColumnName = "specId")
-    @NotFound(action = NotFoundAction.IGNORE)
     @Fetch(FetchMode.SELECT)
     @BatchSize(size = 25)
     private ProfessionalSpecialist professionalSpecialist;
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = DemographicContact.class)
     @JoinColumn(name = "demographicContactId", referencedColumnName = "id")
-    @NotFound(action = NotFoundAction.IGNORE)
     @Fetch(FetchMode.SELECT)
     @BatchSize(size = 25)
     private DemographicContact demographicContact;
@@ -114,7 +112,6 @@ public class ConsultationRequest extends AbstractModel<Integer> implements Seria
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = LookupListItem.class)
     @JoinColumn(name = "appointmentInstructions", referencedColumnName = "value", insertable = false, updatable = false)
-    @NotFound(action = NotFoundAction.IGNORE)
     @Fetch(FetchMode.SELECT)
     @BatchSize(size = 25)
     private LookupListItem lookupListItem;

--- a/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
+++ b/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
@@ -30,8 +30,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.NotFound;
-import org.hibernate.annotations.NotFoundAction;
 
 import javax.persistence.*;
 import java.io.Serializable;

--- a/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
@@ -1,0 +1,290 @@
+//CHECKSTYLE:OFF
+/**
+ * Copyright (c) 2026. Magenta Health. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+package ca.openosp.openo.consultation.dto;
+
+import org.apache.commons.lang3.time.DateFormatUtils;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Data Transfer Object for consultation request list views.
+ * <p>
+ * Provides a lightweight, flat representation of consultation request data optimized for list display,
+ * eliminating N+1 query issues by fetching all display fields via a single JOIN query with batch-loaded
+ * extensions. Replaces the previous pattern of loading full entities and then individually querying
+ * related Demographics, Providers, Services, and Specialists per row.
+ * </p>
+ *
+ * @since 2026-02-03
+ */
+public class ConsultationListDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String NOT_APPLICABLE = "N/A";
+
+    private Integer id;
+    private String status;
+    private String urgency;
+    private Integer demographicNo;
+    private String demographicLastName;
+    private String demographicFirstName;
+    private String demographicProviderNo;
+    private String mrpLastName;
+    private String mrpFirstName;
+    private String consultProviderNo;
+    private String consultProviderLastName;
+    private String consultProviderFirstName;
+    private Integer serviceId;
+    private String serviceDescription;
+    private String specialistLastName;
+    private String specialistFirstName;
+    private Date referralDate;
+    private Date appointmentDate;
+    private Date appointmentTime;
+    private boolean patientWillBook;
+    private Date followUpDate;
+    private String sendTo;
+    private String siteName;
+
+    private boolean eReferral;
+    private String ereferralService;
+    private String ereferralDoctor;
+
+    /**
+     * Default constructor.
+     */
+    public ConsultationListDTO() {
+    }
+
+    /**
+     * Constructor for JPQL projection queries. Parameter order must match the SELECT NEW clause exactly.
+     *
+     * @param id Integer the consultation request ID
+     * @param status String the consultation status code
+     * @param urgency String the urgency level
+     * @param demographicNo Integer the patient demographic number
+     * @param demographicLastName String the patient's last name
+     * @param demographicFirstName String the patient's first name
+     * @param demographicProviderNo String the patient's MRP provider number
+     * @param mrpLastName String the MRP provider's last name
+     * @param mrpFirstName String the MRP provider's first name
+     * @param consultProviderNo String the consulting provider number
+     * @param consultProviderLastName String the consulting provider's last name
+     * @param consultProviderFirstName String the consulting provider's first name
+     * @param serviceId Integer the consultation service ID
+     * @param serviceDescription String the service description
+     * @param specialistLastName String the specialist's last name
+     * @param specialistFirstName String the specialist's first name
+     * @param referralDate Date the referral date
+     * @param appointmentDate Date the appointment date
+     * @param appointmentTime Date the appointment time
+     * @param patientWillBook boolean whether the patient will book
+     * @param followUpDate Date the follow-up date
+     * @param sendTo String the team/send-to value
+     * @param siteName String the site name
+     */
+    public ConsultationListDTO(Integer id, String status, String urgency,
+                               Integer demographicNo, String demographicLastName, String demographicFirstName,
+                               String demographicProviderNo, String mrpLastName, String mrpFirstName,
+                               String consultProviderNo, String consultProviderLastName, String consultProviderFirstName,
+                               Integer serviceId, String serviceDescription,
+                               String specialistLastName, String specialistFirstName,
+                               Date referralDate, Date appointmentDate, Date appointmentTime,
+                               boolean patientWillBook, Date followUpDate,
+                               String sendTo, String siteName) {
+        this.id = id;
+        this.status = status;
+        this.urgency = urgency;
+        this.demographicNo = demographicNo;
+        this.demographicLastName = demographicLastName;
+        this.demographicFirstName = demographicFirstName;
+        this.demographicProviderNo = demographicProviderNo;
+        this.mrpLastName = mrpLastName;
+        this.mrpFirstName = mrpFirstName;
+        this.consultProviderNo = consultProviderNo;
+        this.consultProviderLastName = consultProviderLastName;
+        this.consultProviderFirstName = consultProviderFirstName;
+        this.serviceId = serviceId;
+        this.serviceDescription = serviceDescription;
+        this.specialistLastName = specialistLastName;
+        this.specialistFirstName = specialistFirstName;
+        this.referralDate = referralDate;
+        this.appointmentDate = appointmentDate;
+        this.appointmentTime = appointmentTime;
+        this.patientWillBook = patientWillBook;
+        this.followUpDate = followUpDate;
+        this.sendTo = sendTo;
+        this.siteName = siteName;
+    }
+
+    /**
+     * Returns patient name formatted as "LastName, FirstName".
+     *
+     * @return String the formatted patient name
+     */
+    public String getPatientFormattedName() {
+        if (demographicLastName == null && demographicFirstName == null) {
+            return "";
+        }
+        if (demographicLastName == null) {
+            return demographicFirstName;
+        }
+        if (demographicFirstName == null) {
+            return demographicLastName;
+        }
+        return demographicLastName + ", " + demographicFirstName;
+    }
+
+    /**
+     * Returns MRP provider name formatted as "LastName, FirstName".
+     *
+     * @return String the formatted MRP name, or "N/A" if not available
+     */
+    public String getMrpFormattedName() {
+        if (mrpLastName == null && mrpFirstName == null) {
+            return NOT_APPLICABLE;
+        }
+        if (mrpLastName == null) {
+            return mrpFirstName;
+        }
+        if (mrpFirstName == null) {
+            return mrpLastName;
+        }
+        return mrpLastName + ", " + mrpFirstName;
+    }
+
+    /**
+     * Returns consulting provider name formatted as "LastName, FirstName".
+     *
+     * @return String the formatted consulting provider name, or "N/A" if not available
+     */
+    public String getConsultProviderFormattedName() {
+        if (consultProviderLastName == null && consultProviderFirstName == null) {
+            return NOT_APPLICABLE;
+        }
+        if (consultProviderLastName == null) {
+            return consultProviderFirstName;
+        }
+        if (consultProviderFirstName == null) {
+            return consultProviderLastName;
+        }
+        return consultProviderLastName + ", " + consultProviderFirstName;
+    }
+
+    /**
+     * Returns specialist name formatted as "LastName, FirstName".
+     * Falls back to eReferral doctor name if no specialist is set and serviceId is 0.
+     *
+     * @return String the formatted specialist name, or "N/A" if not available
+     */
+    public String getSpecialistFormattedName() {
+        if (specialistLastName != null || specialistFirstName != null) {
+            if (specialistLastName == null) return specialistFirstName;
+            if (specialistFirstName == null) return specialistLastName;
+            return specialistLastName + ", " + specialistFirstName;
+        }
+        if (serviceId != null && serviceId == 0 && ereferralDoctor != null) {
+            return ereferralDoctor;
+        }
+        return NOT_APPLICABLE;
+    }
+
+    /**
+     * Returns the effective service description.
+     * Falls back to eReferral service name if serviceId is 0.
+     *
+     * @return String the service description
+     */
+    public String getEffectiveServiceDescription() {
+        if (serviceId != null && serviceId == 0 && ereferralService != null) {
+            return ereferralService;
+        }
+        return serviceDescription != null ? serviceDescription : "";
+    }
+
+    /**
+     * Returns the referral date formatted as ISO date string.
+     *
+     * @return String the formatted referral date
+     */
+    public String getReferralDateFormatted() {
+        if (referralDate == null) return "";
+        return DateFormatUtils.ISO_DATE_FORMAT.format(referralDate);
+    }
+
+    /**
+     * Returns the appointment date and time formatted for display.
+     *
+     * @return String the formatted appointment date/time, or "N/A" if not set
+     */
+    public String getAppointmentDateFormatted() {
+        if (appointmentDate == null) {
+            return NOT_APPLICABLE;
+        }
+        if (appointmentTime == null) {
+            return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " T00:00:00";
+        }
+        return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " " + DateFormatUtils.ISO_TIME_FORMAT.format(appointmentTime);
+    }
+
+    /**
+     * Returns the follow-up date formatted as ISO date string.
+     *
+     * @return String the formatted follow-up date, or "N/A" if not set
+     */
+    public String getFollowUpDateFormatted() {
+        if (followUpDate == null) return NOT_APPLICABLE;
+        return DateFormatUtils.ISO_DATE_FORMAT.format(followUpDate);
+    }
+
+    /**
+     * Applies extension data (eReferral fields) from a pre-loaded map.
+     *
+     * @param extMap Map of extension key to value for this consultation request
+     */
+    public void applyExtensions(Map<String, String> extMap) {
+        if (extMap == null) return;
+        this.eReferral = extMap.containsKey("ereferral_ref");
+        this.ereferralService = extMap.getOrDefault("ereferral_service", null);
+        this.ereferralDoctor = extMap.getOrDefault("ereferral_doctor", null);
+    }
+
+    public Integer getId() { return id; }
+    public String getStatus() { return status; }
+    public String getUrgency() { return urgency; }
+    public Integer getDemographicNo() { return demographicNo; }
+    public String getDemographicProviderNo() { return demographicProviderNo; }
+    public String getConsultProviderNo() { return consultProviderNo; }
+    public String getConsultProviderLastName() { return consultProviderLastName; }
+    public String getConsultProviderFirstName() { return consultProviderFirstName; }
+    public Integer getServiceId() { return serviceId; }
+    public String getServiceDescription() { return serviceDescription; }
+    public Date getReferralDate() { return referralDate; }
+    public Date getAppointmentDate() { return appointmentDate; }
+    public Date getAppointmentTime() { return appointmentTime; }
+    public boolean isPatientWillBook() { return patientWillBook; }
+    public Date getFollowUpDate() { return followUpDate; }
+    public String getSendTo() { return sendTo; }
+    public String getSiteName() { return siteName; }
+    public boolean isEReferral() { return eReferral; }
+}

--- a/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
@@ -1,21 +1,3 @@
-//CHECKSTYLE:OFF
-/**
- * Copyright (c) 2026. Magenta Health. All Rights Reserved.
- * This software is published under the GPL GNU General Public License.
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * <p>
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * <p>
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package ca.openosp.openo.consultation.dto;
 
 import org.apache.commons.lang3.time.DateFormatUtils;

--- a/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
@@ -242,9 +242,9 @@ public class ConsultationListDTO implements Serializable {
             return NOT_APPLICABLE;
         }
         if (appointmentTime == null) {
-            return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + "T00:00:00";
+            return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " T00:00:00";
         }
-        return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + DateFormatUtils.ISO_TIME_FORMAT.format(appointmentTime);
+        return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " " + DateFormatUtils.ISO_TIME_FORMAT.format(appointmentTime);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
@@ -242,9 +242,9 @@ public class ConsultationListDTO implements Serializable {
             return NOT_APPLICABLE;
         }
         if (appointmentTime == null) {
-            return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " T00:00:00";
+            return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + "T00:00:00";
         }
-        return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " " + DateFormatUtils.ISO_TIME_FORMAT.format(appointmentTime);
+        return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + DateFormatUtils.ISO_TIME_FORMAT.format(appointmentTime);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
@@ -20,6 +20,8 @@ package ca.openosp.openo.consultation.dto;
 
 import org.apache.commons.lang3.time.DateFormatUtils;
 
+import ca.openosp.openo.commn.model.enumerator.ConsultationRequestExtKey;
+
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
@@ -264,9 +266,9 @@ public class ConsultationListDTO implements Serializable {
      */
     public void applyExtensions(Map<String, String> extMap) {
         if (extMap == null) return;
-        this.eReferral = extMap.containsKey("ereferral_ref");
-        this.ereferralService = extMap.getOrDefault("ereferral_service", null);
-        this.ereferralDoctor = extMap.getOrDefault("ereferral_doctor", null);
+        this.eReferral = extMap.containsKey(ConsultationRequestExtKey.EREFERRAL_REF.getKey());
+        this.ereferralService = extMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_SERVICE.getKey(), null);
+        this.ereferralDoctor = extMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_DOCTOR.getKey(), null);
     }
 
     public Integer getId() { return id; }

--- a/src/main/java/ca/openosp/openo/consultation/dto/SpecialistListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/SpecialistListDTO.java
@@ -1,0 +1,58 @@
+package ca.openosp.openo.consultation.dto;
+
+import java.io.Serializable;
+
+/**
+ * Lightweight DTO for specialist list views (Edit Specialists, Display Service).
+ * <p>
+ * Uses JPQL constructor projection to fetch only the columns needed for list display,
+ * avoiding full {@code ProfessionalSpecialist} entity hydration which includes heavy
+ * text fields ({@code eDataOscarKey}, {@code eDataServiceKey}, {@code annotation}).
+ * With 10k+ specialist records, this eliminates significant unnecessary data transfer.
+ * </p>
+ *
+ * @since 2026-03-09
+ */
+public class SpecialistListDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Integer id;
+    private final String firstName;
+    private final String lastName;
+    private final String professionalLetters;
+    private final String streetAddress;
+    private final String phoneNumber;
+    private final String faxNumber;
+
+    /**
+     * JPQL constructor projection target.
+     *
+     * @param id Integer the specialist ID (maps to {@code specId} column)
+     * @param firstName String the specialist's first name
+     * @param lastName String the specialist's last name
+     * @param professionalLetters String professional designation letters (e.g. "MD, FRCPC")
+     * @param streetAddress String the specialist's street address
+     * @param phoneNumber String the specialist's phone number
+     * @param faxNumber String the specialist's fax number
+     */
+    public SpecialistListDTO(Integer id, String firstName, String lastName,
+                             String professionalLetters, String streetAddress,
+                             String phoneNumber, String faxNumber) {
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.professionalLetters = professionalLetters;
+        this.streetAddress = streetAddress;
+        this.phoneNumber = phoneNumber;
+        this.faxNumber = faxNumber;
+    }
+
+    public Integer getId() { return id; }
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
+    public String getProfessionalLetters() { return professionalLetters; }
+    public String getStreetAddress() { return streetAddress; }
+    public String getPhoneNumber() { return phoneNumber; }
+    public String getFaxNumber() { return faxNumber; }
+}

--- a/src/main/java/ca/openosp/openo/consultation/dto/SpecialistListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/SpecialistListDTO.java
@@ -48,11 +48,24 @@ public class SpecialistListDTO implements Serializable {
         this.faxNumber = faxNumber;
     }
 
+    /** @return Integer the specialist ID (maps to {@code specId} column) */
     public Integer getId() { return id; }
+
+    /** @return String the specialist's first name */
     public String getFirstName() { return firstName; }
+
+    /** @return String the specialist's last name */
     public String getLastName() { return lastName; }
+
+    /** @return String professional designation letters (e.g. "MD, FRCPC"), may be null */
     public String getProfessionalLetters() { return professionalLetters; }
+
+    /** @return String the specialist's street address, may be null */
     public String getStreetAddress() { return streetAddress; }
+
+    /** @return String the specialist's phone number, may be null */
     public String getPhoneNumber() { return phoneNumber; }
+
+    /** @return String the specialist's fax number, may be null */
     public String getFaxNumber() { return faxNumber; }
 }

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/ConsultationLookup2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/ConsultationLookup2Action.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ca.openosp.openo.commn.dao.ConsultationServiceDao;
 import ca.openosp.openo.commn.dao.ServiceSpecialistsDao;
-import ca.openosp.openo.commn.model.ConsultationServices;
 import ca.openosp.openo.commn.model.ProfessionalSpecialist;
 import ca.openosp.openo.commn.model.ServiceSpecialists;
 import ca.openosp.openo.encounter.oscarConsultationRequest.config.data.ConsultationServiceDto;
@@ -92,16 +91,7 @@ public class ConsultationLookup2Action extends ActionSupport {
      */
     private String getServices() {
         try {
-            List<ConsultationServices> services = consultationServiceDao.findActive();
-            List<ConsultationServiceDto> serviceList = new ArrayList<>();
-
-            for (ConsultationServices service : services) {
-                serviceList.add(new ConsultationServiceDto(
-                    service.getServiceId(),
-                    service.getServiceDesc()
-                ));
-            }
-
+            List<ConsultationServiceDto> serviceList = consultationServiceDao.findActiveServiceSummaries();
             writeJsonResponse(serviceList);
             return null; // Response already written
 

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
@@ -26,6 +26,7 @@
 
 package ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 
@@ -42,15 +43,18 @@ import ca.openosp.openo.util.ConversionUtils;
 public class EctConDisplayServiceUtil {
     private ConsultationServiceDao consultationServiceDao = (ConsultationServiceDao) SpringUtils.getBean(ConsultationServiceDao.class);
 
-    public Vector<String> fNameVec;
-    public Vector<String> lNameVec;
-    public Vector<String> proLettersVec;
-    public Vector<String> addressVec;
-    public Vector<String> phoneVec;
-    public Vector<String> faxVec;
-    public Vector<String> specIdVec;
+    private List<SpecialistListDTO> specialists = Collections.emptyList();
     public Vector<String> serviceName;
     public Vector<String> serviceId;
+
+    /**
+     * Returns the lightweight specialist list loaded by {@link #loadSpecialists()}.
+     *
+     * @return List&lt;SpecialistListDTO&gt; specialists ordered by last name, first name
+     */
+    public List<SpecialistListDTO> getSpecialists() {
+        return specialists;
+    }
 
     public String getServiceDesc(String serId) {
         String retval = new String();
@@ -64,28 +68,19 @@ public class EctConDisplayServiceUtil {
     }
 
     public void estSpecialist() {
-        estSpecialistVector();
+        loadSpecialists();
     }
 
     public void estSpecialistVector() {
-        fNameVec = new Vector<String>();
-        lNameVec = new Vector<String>();
-        proLettersVec = new Vector<String>();
-        addressVec = new Vector<String>();
-        phoneVec = new Vector<String>();
-        faxVec = new Vector<String>();
-        specIdVec = new Vector<String>();
+        loadSpecialists();
+    }
 
+    /**
+     * Loads all specialists as lightweight DTO projections for list display.
+     */
+    public void loadSpecialists() {
         ProfessionalSpecialistDao dao = SpringUtils.getBean(ProfessionalSpecialistDao.class);
-        for (SpecialistListDTO dto : dao.findAllListDTOs()) {
-            fNameVec.add(dto.getFirstName());
-            lNameVec.add(dto.getLastName());
-            proLettersVec.add(dto.getProfessionalLetters());
-            addressVec.add(dto.getStreetAddress());
-            phoneVec.add(dto.getPhoneNumber());
-            faxVec.add(dto.getFaxNumber());
-            specIdVec.add(dto.getId().toString());
-        }
+        specialists = dao.findAllListDTOs();
     }
 
     public Vector<String> getSpecialistInField(String serviceId) {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
@@ -26,7 +26,6 @@
 
 package ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
@@ -34,8 +33,8 @@ import ca.openosp.openo.commn.dao.ConsultationServiceDao;
 import ca.openosp.openo.commn.dao.ProfessionalSpecialistDao;
 import ca.openosp.openo.commn.dao.ServiceSpecialistsDao;
 import ca.openosp.openo.commn.model.ConsultationServices;
-import ca.openosp.openo.commn.model.ProfessionalSpecialist;
 import ca.openosp.openo.commn.model.ServiceSpecialists;
+import ca.openosp.openo.consultation.dto.SpecialistListDTO;
 import ca.openosp.openo.utility.SpringUtils;
 
 import ca.openosp.openo.util.ConversionUtils;
@@ -49,13 +48,9 @@ public class EctConDisplayServiceUtil {
     public Vector<String> addressVec;
     public Vector<String> phoneVec;
     public Vector<String> faxVec;
-    public Vector<String> websiteVec;
-    public Vector<String> emailVec;
-    public Vector<String> specTypeVec;
     public Vector<String> specIdVec;
     public Vector<String> serviceName;
     public Vector<String> serviceId;
-    public ArrayList<String> referralNoVec;
 
     public String getServiceDesc(String serId) {
         String retval = new String();
@@ -79,24 +74,17 @@ public class EctConDisplayServiceUtil {
         addressVec = new Vector<String>();
         phoneVec = new Vector<String>();
         faxVec = new Vector<String>();
-        websiteVec = new Vector<String>();
-        emailVec = new Vector<String>();
-        specTypeVec = new Vector<String>();
         specIdVec = new Vector<String>();
-        referralNoVec = new ArrayList<String>();
 
         ProfessionalSpecialistDao dao = SpringUtils.getBean(ProfessionalSpecialistDao.class);
-        for (ProfessionalSpecialist ps : dao.findAll()) {
-            fNameVec.add(ps.getFirstName());
-            lNameVec.add(ps.getLastName());
-            proLettersVec.add(ps.getProfessionalLetters());
-            addressVec.add(ps.getStreetAddress());
-            phoneVec.add(ps.getPhoneNumber());
-            faxVec.add(ps.getFaxNumber());
-            websiteVec.add(ps.getWebSite());
-            emailVec.add(ps.getEmailAddress());
-            specTypeVec.add(ps.getSpecialtyType());
-            specIdVec.add(ps.getId().toString());
+        for (SpecialistListDTO dto : dao.findAllListDTOs()) {
+            fNameVec.add(dto.getFirstName());
+            lNameVec.add(dto.getLastName());
+            proLettersVec.add(dto.getProfessionalLetters());
+            addressVec.add(dto.getStreetAddress());
+            phoneVec.add(dto.getPhoneNumber());
+            faxVec.add(dto.getFaxNumber());
+            specIdVec.add(dto.getId().toString());
         }
     }
 

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
@@ -26,35 +26,18 @@
 
 package ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 
 import ca.openosp.openo.commn.dao.ConsultationServiceDao;
-import ca.openosp.openo.commn.dao.ProfessionalSpecialistDao;
-import ca.openosp.openo.commn.dao.ServiceSpecialistsDao;
 import ca.openosp.openo.commn.model.ConsultationServices;
-import ca.openosp.openo.commn.model.ServiceSpecialists;
-import ca.openosp.openo.consultation.dto.SpecialistListDTO;
 import ca.openosp.openo.utility.SpringUtils;
-
-import ca.openosp.openo.util.ConversionUtils;
 
 public class EctConDisplayServiceUtil {
     private ConsultationServiceDao consultationServiceDao = (ConsultationServiceDao) SpringUtils.getBean(ConsultationServiceDao.class);
 
-    private List<SpecialistListDTO> specialists = Collections.emptyList();
     public Vector<String> serviceName;
     public Vector<String> serviceId;
-
-    /**
-     * Returns the lightweight specialist list loaded by {@link #loadSpecialists()}.
-     *
-     * @return List&lt;SpecialistListDTO&gt; specialists ordered by last name, first name
-     */
-    public List<SpecialistListDTO> getSpecialists() {
-        return specialists;
-    }
 
     public String getServiceDesc(String serId) {
         String retval = new String();
@@ -65,32 +48,6 @@ public class EctConDisplayServiceUtil {
         }
 
         return retval;
-    }
-
-    public void estSpecialist() {
-        loadSpecialists();
-    }
-
-    public void estSpecialistVector() {
-        loadSpecialists();
-    }
-
-    /**
-     * Loads all specialists as lightweight DTO projections for list display.
-     */
-    public void loadSpecialists() {
-        ProfessionalSpecialistDao dao = SpringUtils.getBean(ProfessionalSpecialistDao.class);
-        specialists = dao.findAllListDTOs();
-    }
-
-    public Vector<String> getSpecialistInField(String serviceId) {
-        Vector<String> vector = new Vector<String>();
-        ServiceSpecialistsDao dao = SpringUtils.getBean(ServiceSpecialistsDao.class);
-
-        for (ServiceSpecialists ss : dao.findByServiceId(ConversionUtils.fromIntString(serviceId))) {
-            vector.add("" + ss.getId().getSpecId());
-        }
-        return vector;
     }
 
     public void estServicesVectors() {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
@@ -60,6 +60,15 @@ public class SpecialistList2Action extends ActionSupport {
      */
     @Override
     public String execute() {
+        if (!"POST".equals(request.getMethod())) {
+            try {
+                response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "POST required");
+            } catch (IOException e) {
+                MiscUtils.getLogger().error("Error sending 405 response", e);
+            }
+            return null;
+        }
+
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_con", "r", null)) {
             throw new SecurityException("missing required security object (_con)");
         }
@@ -90,21 +99,8 @@ public class SpecialistList2Action extends ActionSupport {
     private String getSpecialists() {
         try {
             List<SpecialistListDTO> specialists = professionalSpecialistDao.findAllListDTOs();
-
-            ArrayNode array = MAPPER.createArrayNode();
-            for (SpecialistListDTO dto : specialists) {
-                ArrayNode row = MAPPER.createArrayNode();
-                row.add(dto.getId());
-                row.add(buildDisplayName(dto));
-                row.add(StringUtils.defaultString(dto.getStreetAddress()));
-                row.add(StringUtils.defaultString(dto.getPhoneNumber()));
-                row.add(StringUtils.defaultString(dto.getFaxNumber()));
-                array.add(row);
-            }
-
-            writeJsonResponse(array);
+            writeSpecialistRows(specialists, null);
             return null;
-
         } catch (Exception e) {
             return handleServerError("Error loading specialist list", e);
         }
@@ -131,25 +127,47 @@ public class SpecialistList2Action extends ActionSupport {
 
             List<SpecialistListDTO> specialists = professionalSpecialistDao.findAllListDTOs();
             Set<String> assignedIds = loadAssignedSpecialistIds(serviceId);
-
-            ArrayNode array = MAPPER.createArrayNode();
-            for (SpecialistListDTO dto : specialists) {
-                ArrayNode row = MAPPER.createArrayNode();
-                row.add(dto.getId());
-                row.add(buildDisplayName(dto));
-                row.add(StringUtils.defaultString(dto.getStreetAddress()));
-                row.add(StringUtils.defaultString(dto.getPhoneNumber()));
-                row.add(StringUtils.defaultString(dto.getFaxNumber()));
-                row.add(assignedIds.contains(dto.getId().toString()));
-                array.add(row);
-            }
-
-            writeJsonResponse(array);
+            writeSpecialistRows(specialists, assignedIds);
             return null;
-
         } catch (Exception e) {
             return handleServerError("Error loading specialist list for service", e);
         }
+    }
+
+    /**
+     * Builds a JSON row for a single specialist DTO.
+     *
+     * @param dto SpecialistListDTO the specialist data
+     * @return ArrayNode row: {@code [id, "name", "address", "phone", "fax"]}
+     */
+    private static ArrayNode buildRow(SpecialistListDTO dto) {
+        ArrayNode row = MAPPER.createArrayNode();
+        row.add(dto.getId());
+        row.add(buildDisplayName(dto));
+        row.add(StringUtils.defaultString(dto.getStreetAddress()));
+        row.add(StringUtils.defaultString(dto.getPhoneNumber()));
+        row.add(StringUtils.defaultString(dto.getFaxNumber()));
+        return row;
+    }
+
+    /**
+     * Writes a JSON array of specialist rows to the response.
+     *
+     * @param specialists List&lt;SpecialistListDTO&gt; the specialist data
+     * @param assignedIds Set&lt;String&gt; specialist IDs assigned to a service, or null if not applicable
+     * @throws IOException if writing to response fails
+     */
+    private void writeSpecialistRows(List<SpecialistListDTO> specialists,
+                                     Set<String> assignedIds) throws IOException {
+        ArrayNode array = MAPPER.createArrayNode();
+        for (SpecialistListDTO dto : specialists) {
+            ArrayNode row = buildRow(dto);
+            if (assignedIds != null) {
+                row.add(assignedIds.contains(dto.getId().toString()));
+            }
+            array.add(row);
+        }
+        writeJsonResponse(array);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
@@ -72,7 +72,6 @@ public class SpecialistList2Action extends ActionSupport {
             return getSpecialistsForService();
         }
 
-        MiscUtils.getLogger().warn("SpecialistList2Action: invalid method parameter: " + method);
         try {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid or missing method parameter");
         } catch (IOException e) {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
@@ -33,7 +33,7 @@ import ca.openosp.openo.utility.SpringUtils;
  * shell first, then fetch data via {@code fetch()} POST. This decouples the page shell
  * from the data payload, reducing perceived load time and keeping the HTML response small.</p>
  *
- * <p>Endpoints (all POST):</p>
+ * <p>Endpoints (all POST, CSRF-protected via CsrfGuard token header):</p>
  * <ul>
  *   <li>{@code method=getSpecialists} - Returns all specialists for the EditSpecialists page.
  *       Each row: {@code [id, "name", "address", "phone", "fax"]}</li>
@@ -73,7 +73,12 @@ public class SpecialistList2Action extends ActionSupport {
         }
 
         MiscUtils.getLogger().warn("SpecialistList2Action: invalid method parameter: " + method);
-        return NONE;
+        try {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid or missing method parameter");
+        } catch (IOException e) {
+            MiscUtils.getLogger().error("Error sending 400 response", e);
+        }
+        return null;
     }
 
     /**
@@ -173,7 +178,12 @@ public class SpecialistList2Action extends ActionSupport {
         String lName = StringUtils.defaultString(dto.getLastName());
         String fName = StringUtils.defaultString(dto.getFirstName());
         String proLetters = dto.getProfessionalLetters();
-        return lName + " " + fName + (proLetters == null ? "" : " " + proLetters);
+        StringBuilder name = new StringBuilder();
+        name.append(lName).append(" ").append(fName);
+        if (StringUtils.isNotBlank(proLetters)) {
+            name.append(" ").append(proLetters);
+        }
+        return name.toString();
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
@@ -1,0 +1,207 @@
+//CHECKSTYLE:OFF
+package ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.struts2.ServletActionContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.opensymphony.xwork2.ActionSupport;
+
+import ca.openosp.openo.commn.dao.ProfessionalSpecialistDao;
+import ca.openosp.openo.commn.dao.ServiceSpecialistsDao;
+import ca.openosp.openo.commn.model.ServiceSpecialists;
+import ca.openosp.openo.consultation.dto.SpecialistListDTO;
+import ca.openosp.openo.managers.SecurityInfoManager;
+import ca.openosp.openo.util.ConversionUtils;
+import ca.openosp.openo.utility.LoggedInInfo;
+import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.SpringUtils;
+
+/**
+ * Struts2 action providing JSON endpoints for specialist list data.
+ *
+ * <p>Serves specialist data as a separate AJAX endpoint so JSP pages load a lightweight
+ * shell first, then fetch data via {@code fetch()} POST. This decouples the page shell
+ * from the data payload, reducing perceived load time and keeping the HTML response small.</p>
+ *
+ * <p>Endpoints (all POST):</p>
+ * <ul>
+ *   <li>{@code method=getSpecialists} - Returns all specialists for the EditSpecialists page.
+ *       Each row: {@code [id, "name", "address", "phone", "fax"]}</li>
+ *   <li>{@code method=getSpecialistsForService} - Returns all specialists with checked state
+ *       for the DisplayService page. Each row: {@code [id, "name", "address", "phone", "fax", checked]}</li>
+ * </ul>
+ *
+ * @since 2026-03-10
+ */
+public class SpecialistList2Action extends ActionSupport {
+
+    private HttpServletRequest request = ServletActionContext.getRequest();
+    private HttpServletResponse response = ServletActionContext.getResponse();
+
+    private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+    private ProfessionalSpecialistDao professionalSpecialistDao = SpringUtils.getBean(ProfessionalSpecialistDao.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Main dispatcher that routes to the appropriate method based on 'method' parameter.
+     *
+     * @return String action result (null when response is written directly)
+     */
+    @Override
+    public String execute() {
+        if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_con", "r", null)) {
+            throw new SecurityException("missing required security object (_con)");
+        }
+
+        String method = request.getParameter("method");
+
+        if ("getSpecialists".equals(method)) {
+            return getSpecialists();
+        } else if ("getSpecialistsForService".equals(method)) {
+            return getSpecialistsForService();
+        }
+
+        MiscUtils.getLogger().warn("SpecialistList2Action: invalid method parameter: " + method);
+        return NONE;
+    }
+
+    /**
+     * Returns all specialists as a JSON array for the EditSpecialists page.
+     *
+     * <p>Each row is {@code [id, "name", "address", "phone", "fax"]}.</p>
+     *
+     * @return null (response written directly to output stream)
+     */
+    private String getSpecialists() {
+        try {
+            List<SpecialistListDTO> specialists = professionalSpecialistDao.findAllListDTOs();
+
+            ArrayNode array = MAPPER.createArrayNode();
+            for (SpecialistListDTO dto : specialists) {
+                ArrayNode row = MAPPER.createArrayNode();
+                row.add(dto.getId());
+                row.add(buildDisplayName(dto));
+                row.add(StringUtils.defaultString(dto.getStreetAddress()));
+                row.add(StringUtils.defaultString(dto.getPhoneNumber()));
+                row.add(StringUtils.defaultString(dto.getFaxNumber()));
+                array.add(row);
+            }
+
+            writeJsonResponse(array);
+            return null;
+
+        } catch (Exception e) {
+            return handleServerError("Error loading specialist list", e);
+        }
+    }
+
+    /**
+     * Returns all specialists with checked state for the DisplayService page.
+     *
+     * <p>Each row is {@code [id, "name", "address", "phone", "fax", checked]}.
+     * The {@code checked} boolean indicates whether the specialist is assigned to
+     * the given service.</p>
+     *
+     * @return null (response written directly to output stream)
+     */
+    private String getSpecialistsForService() {
+        try {
+            String serviceIdParam = request.getParameter("serviceId");
+            Integer serviceId = ConversionUtils.fromIntString(serviceIdParam);
+
+            if (serviceId == null) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid serviceId parameter");
+                return null;
+            }
+
+            List<SpecialistListDTO> specialists = professionalSpecialistDao.findAllListDTOs();
+            Set<String> assignedIds = loadAssignedSpecialistIds(serviceId);
+
+            ArrayNode array = MAPPER.createArrayNode();
+            for (SpecialistListDTO dto : specialists) {
+                ArrayNode row = MAPPER.createArrayNode();
+                row.add(dto.getId());
+                row.add(buildDisplayName(dto));
+                row.add(StringUtils.defaultString(dto.getStreetAddress()));
+                row.add(StringUtils.defaultString(dto.getPhoneNumber()));
+                row.add(StringUtils.defaultString(dto.getFaxNumber()));
+                row.add(assignedIds.contains(dto.getId().toString()));
+                array.add(row);
+            }
+
+            writeJsonResponse(array);
+            return null;
+
+        } catch (Exception e) {
+            return handleServerError("Error loading specialist list for service", e);
+        }
+    }
+
+    /**
+     * Loads the set of specialist IDs assigned to a given service.
+     *
+     * @param serviceId Integer the consultation service ID
+     * @return Set&lt;String&gt; specialist IDs assigned to the service
+     */
+    private Set<String> loadAssignedSpecialistIds(Integer serviceId) {
+        ServiceSpecialistsDao dao = SpringUtils.getBean(ServiceSpecialistsDao.class);
+        Set<String> ids = new HashSet<>();
+        for (ServiceSpecialists ss : dao.findByServiceId(serviceId)) {
+            ids.add(String.valueOf(ss.getId().getSpecId()));
+        }
+        return ids;
+    }
+
+    /**
+     * Formats a specialist name for display: "LastName FirstName ProLetters".
+     *
+     * @param dto SpecialistListDTO the specialist data
+     * @return String the formatted display name
+     */
+    private static String buildDisplayName(SpecialistListDTO dto) {
+        String lName = StringUtils.defaultString(dto.getLastName());
+        String fName = StringUtils.defaultString(dto.getFirstName());
+        String proLetters = dto.getProfessionalLetters();
+        return lName + " " + fName + (proLetters == null ? "" : " " + proLetters);
+    }
+
+    /**
+     * Writes a JSON response to the output stream.
+     *
+     * @param data ArrayNode the JSON data to write
+     * @throws IOException if writing to response fails
+     */
+    private void writeJsonResponse(ArrayNode data) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        MAPPER.writeValue(response.getWriter(), data);
+    }
+
+    /**
+     * Handles server errors by logging and sending an HTTP 500 response.
+     *
+     * @param logMessage String message to log
+     * @param e Exception that occurred
+     * @return null (response written directly)
+     */
+    private String handleServerError(String logMessage, Exception e) {
+        MiscUtils.getLogger().error(logMessage, e);
+        try {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "An error occurred loading specialist data");
+        } catch (IOException ioException) {
+            MiscUtils.getLogger().error("Error sending error response", ioException);
+        }
+        return null;
+    }
+}

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
@@ -120,7 +120,13 @@ public class EctConsultationFormRequestUtil {
 
     public boolean estPatient(LoggedInInfo loggedInInfo, String demographicNo) {
 
-        int demographic_number = Integer.parseInt(demographicNo);
+        int demographic_number;
+        try {
+            demographic_number = Integer.parseInt(demographicNo);
+        } catch (NumberFormatException e) {
+            MiscUtils.getLogger().error("Invalid demographic number: non-numeric value provided", e);
+            return false;
+        }
         Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographic_number);
         boolean estPatient = false;
         DemographicExt demographicExt = demographicManager.getDemographicExt(loggedInInfo, demographic_number, DemographicProperty.demo_cell);
@@ -217,7 +223,15 @@ public class EctConsultationFormRequestUtil {
 
         boolean verdict = true;
 
-		ConsultationRequest cr = consultationRequestDao.find(Integer.parseInt(id));
+        int requestId;
+        try {
+            requestId = Integer.parseInt(id);
+        } catch (NumberFormatException e) {
+            MiscUtils.getLogger().error("Invalid consultation request ID: non-numeric value provided", e);
+            return false;
+        }
+
+		ConsultationRequest cr = consultationRequestDao.find(requestId);
 		
 		if (cr != null) {
 			fdid = cr.getFdid();
@@ -289,6 +303,11 @@ public class EctConsultationFormRequestUtil {
                 if (specFax.equals("null")) { specFax = ""; }
                 if (specAddr.equals("null")) { specAddr = ""; }
                 if (specEmail.equalsIgnoreCase("null")) { specEmail = ""; }
+            } else {
+                specPhone = "";
+                specFax = "";
+                specAddr = "";
+                specEmail = "";
             }
 
 			Date appointmentTime = cr.getAppointmentTime();
@@ -303,7 +322,7 @@ public class EctConsultationFormRequestUtil {
 			setAppointmentInstructionsLabel( cr.getAppointmentInstructionsLabel() );
 			letterheadName = cr.getLetterheadName();
 
-			List<ConsultationRequestExt> allExts = consultationRequestExtDao.getConsultationRequestExts(Integer.parseInt(id));
+			List<ConsultationRequestExt> allExts = consultationRequestExtDao.getConsultationRequestExts(requestId);
 			Map<String, String> extMap = new HashMap<>();
 			for (ConsultationRequestExt ext : allExts) {
 				extMap.put(ext.getKey(), ext.getValue());

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
@@ -42,6 +42,8 @@ import ca.openosp.openo.util.ConversionUtils;
 import ca.openosp.openo.util.StringUtils;
 
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class EctConsultationFormRequestUtil {
 
@@ -214,8 +216,6 @@ public class EctConsultationFormRequestUtil {
     public boolean estRequestFromId(LoggedInInfo loggedInInfo, String id) {
 
         boolean verdict = true;
-        getSpecailistsName(id);
-
 
 		ConsultationRequest cr = consultationRequestDao.find(Integer.parseInt(id));
 		
@@ -280,6 +280,16 @@ public class EctConsultationFormRequestUtil {
             // be available. This model is used in the Fax and PDF printing methods.
             professionalSpecialist = cr.getProfessionalSpecialist();
 
+            if (professionalSpecialist != null) {
+                specPhone = StringUtils.noNull(professionalSpecialist.getPhoneNumber());
+                specFax = StringUtils.noNull(professionalSpecialist.getFaxNumber());
+                specAddr = StringUtils.noNull(professionalSpecialist.getStreetAddress());
+                specEmail = StringUtils.noNull(professionalSpecialist.getEmailAddress());
+                if (specPhone.equals("null")) { specPhone = ""; }
+                if (specFax.equals("null")) { specFax = ""; }
+                if (specAddr.equals("null")) { specAddr = ""; }
+                if (specEmail.equalsIgnoreCase("null")) { specEmail = ""; }
+            }
 
 			Date appointmentTime = cr.getAppointmentTime();
 			reasonForConsultation = cr.getReasonForReferral();
@@ -292,7 +302,14 @@ public class EctConsultationFormRequestUtil {
 			setAppointmentInstructions( cr.getAppointmentInstructions() );
 			setAppointmentInstructionsLabel( cr.getAppointmentInstructionsLabel() );
 			letterheadName = cr.getLetterheadName();
-			letterheadTitle = consultationRequestExtDao.getConsultationRequestExtsByKey(Integer.parseInt(id),"letterheadTitle");
+
+			List<ConsultationRequestExt> allExts = consultationRequestExtDao.getConsultationRequestExts(Integer.parseInt(id));
+			Map<String, String> extMap = new HashMap<>();
+			for (ConsultationRequestExt ext : allExts) {
+				extMap.put(ext.getKey(), ext.getValue());
+			}
+
+			letterheadTitle = extMap.get("letterheadTitle");
 			letterheadAddress = cr.getLetterheadAddress();
 			letterheadPhone = cr.getLetterheadPhone();
 			letterheadFax = cr.getLetterheadFax();
@@ -346,7 +363,7 @@ public class EctConsultationFormRequestUtil {
                 }
             }
 
-			isEReferral = consultationRequestExtDao.getConsultationRequestExtsByKey(Integer.parseInt(id),ConsultationRequestExtKey.EREFERRAL_REF.getKey()) != null;
+			isEReferral = extMap.get(ConsultationRequestExtKey.EREFERRAL_REF.getKey()) != null;
         }
 
         getFaxLogs(id);
@@ -357,23 +374,30 @@ public class EctConsultationFormRequestUtil {
     private void getFaxLogs(String requestId) {
 
         List<FaxClientLog> faxClientLogs = faxClientLogDao.findClientLogbyRequestId(Integer.parseInt(requestId));
+        if (faxClientLogs.isEmpty()) {
+            return;
+        }
+
+        List<Integer> faxIds = faxClientLogs.stream()
+                .map(FaxClientLog::getFaxId)
+                .collect(Collectors.toList());
+        Map<Integer, FaxJob> faxJobMap = faxJobDao.findByIds(faxIds).stream()
+                .collect(Collectors.toMap(FaxJob::getId, Function.identity()));
+
+        String specialistFax = "";
+        if (this.professionalSpecialist != null) {
+            specialistFax = this.professionalSpecialist.getFaxNumber();
+        }
+        if (specialistFax == null) {
+            specialistFax = "";
+        }
+        if (!specialistFax.isEmpty()) {
+            specialistFax = specialistFax.trim().replaceAll("\\D", "");
+        }
+
         for (FaxClientLog faxClientLog : faxClientLogs) {
-            FaxJob faxJob = faxJobDao.find(faxClientLog.getFaxId());
+            FaxJob faxJob = faxJobMap.get(faxClientLog.getFaxId());
             FaxRecipient faxRecipient = null;
-            String specialistFax = "";
-
-            if (this.professionalSpecialist != null) {
-                specialistFax = this.professionalSpecialist.getFaxNumber();
-            }
-
-            // overcome those silly default nulls in the database.
-            if (specialistFax == null) {
-                specialistFax = "";
-            }
-
-            if (!specialistFax.isEmpty()) {
-                specialistFax = specialistFax.trim().replaceAll("\\D", "");
-            }
 
             if (faxJob != null) {
                 faxRecipient = new FaxRecipient();
@@ -384,7 +408,6 @@ public class EctConsultationFormRequestUtil {
 
                 MiscUtils.getLogger().debug("Does this fax number " + specialistFax + " equal this fax number " + faxRecipient.getFax());
             }
-
 
             // isolate the main specialist fax log
             if (faxRecipient != null && specialistFax.equals(faxRecipient.getFax())) {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
@@ -523,13 +523,8 @@ public class EctConsultationFormRequestUtil {
     }
 
     public String getServiceName(String id) {
-        String retval = new String();
-        ConsultationServices cs = consultationServiceDao.find(Integer.parseInt(id));
-        if (cs != null) {
-            retval = cs.getServiceDesc();
-        }
-
-        return retval;
+        String desc = consultationServiceDao.getServiceDescription(Integer.parseInt(id));
+        return desc != null ? desc : "";
     }
 
     public String getClinicName() {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
@@ -523,8 +523,16 @@ public class EctConsultationFormRequestUtil {
     }
 
     public String getServiceName(String id) {
-        String desc = consultationServiceDao.getServiceDescription(Integer.parseInt(id));
-        return desc != null ? desc : "";
+        if (id == null || id.isEmpty()) {
+            return "";
+        }
+        try {
+            String desc = consultationServiceDao.getServiceDescription(Integer.parseInt(id));
+            return desc != null ? desc : "";
+        } catch (NumberFormatException e) {
+            MiscUtils.getLogger().warn("Invalid service ID: non-numeric value provided");
+            return "";
+        }
     }
 
     public String getClinicName() {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
@@ -121,7 +121,7 @@ public class EctViewConsultationRequestsUtil {
           List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOs(team, showCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit);
 
           for (ConsultationListDTO dto : dtos) {
-              ids.add(dto.getId().toString());
+              ids.add(dto.getId() != null ? dto.getId().toString() : "");
               status.add(dto.getStatus());
               patient.add(dto.getPatientFormattedName());
               provider.add(dto.getMrpFormattedName());
@@ -130,7 +130,7 @@ public class EctViewConsultationRequestsUtil {
               vSpecialist.add(dto.getSpecialistFormattedName());
               urgency.add(dto.getUrgency());
               date.add(dto.getReferralDateFormatted());
-              demographicNo.add(dto.getDemographicNo().toString());
+              demographicNo.add(dto.getDemographicNo() != null ? dto.getDemographicNo().toString() : "0");
               siteName.add(dto.getSiteName());
               teams.add(dto.getSendTo());
               eReferral.add(dto.isEReferral());
@@ -143,6 +143,7 @@ public class EctViewConsultationRequestsUtil {
               cProv.setFirstName(dto.getConsultProviderFirstName());
               consultProvider.add(cProv);
           }
+
       } catch(Exception e) {
          MiscUtils.getLogger().error("Error", e);
          verdict = false;
@@ -167,11 +168,12 @@ public class EctViewConsultationRequestsUtil {
 
       boolean verdict = true;
       try {
+          int demographicId = Integer.parseInt(demoNo);
           ConsultationRequestDao consultReqDao = SpringUtils.getBean(ConsultationRequestDao.class);
-          List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOsByDemographic(Integer.parseInt(demoNo));
+          List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOsByDemographic(demographicId);
 
           for (ConsultationListDTO dto : dtos) {
-              ids.add(dto.getId().toString());
+              ids.add(dto.getId() != null ? dto.getId().toString() : "");
               status.add(dto.getStatus());
               patient.add(dto.getPatientFormattedName());
               provider.add(dto.getMrpFormattedName());
@@ -186,6 +188,10 @@ public class EctViewConsultationRequestsUtil {
               cProv.setFirstName(dto.getConsultProviderFirstName());
               consultProvider.add(cProv);
           }
+
+      } catch (NumberFormatException e) {
+         MiscUtils.getLogger().error("Invalid demographic number: non-numeric value provided", e);
+         verdict = false;
       } catch(Exception e) {
          MiscUtils.getLogger().error("Error", e);
          verdict = false;

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
@@ -125,7 +125,7 @@ public class EctViewConsultationRequestsUtil {
               status.add(dto.getStatus());
               patient.add(dto.getPatientFormattedName());
               provider.add(dto.getMrpFormattedName());
-              providerNo.add(dto.getDemographicProviderNo() != null ? dto.getDemographicProviderNo() : "-1");
+              providerNo.add(isBlank(dto.getDemographicProviderNo()) ? "-1" : dto.getDemographicProviderNo());
               service.add(dto.getEffectiveServiceDescription());
               vSpecialist.add(dto.getSpecialistFormattedName());
               urgency.add(dto.getUrgency());
@@ -138,14 +138,11 @@ public class EctViewConsultationRequestsUtil {
               patientWillBook.add(String.valueOf(dto.isPatientWillBook()));
               followUpDate.add(dto.getFollowUpDateFormatted());
 
-              Provider cProv = new Provider();
-              cProv.setLastName(dto.getConsultProviderLastName());
-              cProv.setFirstName(dto.getConsultProviderFirstName());
-              consultProvider.add(cProv);
+              consultProvider.add(buildConsultProvider(dto));
           }
 
       } catch(Exception e) {
-         MiscUtils.getLogger().error("Error", e);
+         MiscUtils.getLogger().error("Error loading consultation list for team: " + (team != null ? team : "all"), e);
          verdict = false;
       }
       return verdict;
@@ -177,26 +174,48 @@ public class EctViewConsultationRequestsUtil {
               status.add(dto.getStatus());
               patient.add(dto.getPatientFormattedName());
               provider.add(dto.getMrpFormattedName());
+              providerNo.add(isBlank(dto.getDemographicProviderNo()) ? "-1" : dto.getDemographicProviderNo());
               service.add(dto.getEffectiveServiceDescription());
               vSpecialist.add(dto.getSpecialistFormattedName());
               urgency.add(dto.getUrgency());
               patientWillBook.add(String.valueOf(dto.isPatientWillBook()));
               date.add(dto.getReferralDateFormatted());
+              demographicNo.add(dto.getDemographicNo() != null ? dto.getDemographicNo().toString() : "0");
+              siteName.add(dto.getSiteName());
+              teams.add(dto.getSendTo());
+              eReferral.add(dto.isEReferral());
+              apptDate.add(dto.getAppointmentDateFormatted());
+              followUpDate.add(dto.getFollowUpDateFormatted());
 
-              Provider cProv = new Provider();
-              cProv.setLastName(dto.getConsultProviderLastName());
-              cProv.setFirstName(dto.getConsultProviderFirstName());
-              consultProvider.add(cProv);
+              consultProvider.add(buildConsultProvider(dto));
           }
 
       } catch (NumberFormatException e) {
          MiscUtils.getLogger().error("Invalid demographic number: non-numeric value provided", e);
          verdict = false;
       } catch(Exception e) {
-         MiscUtils.getLogger().error("Error", e);
+         MiscUtils.getLogger().error("Error loading consultations for demographic: " + demoNo, e);
          verdict = false;
       }
       return verdict;
+   }
+
+   /**
+    * Builds a Provider object from DTO consulting provider fields, returning null when no provider data exists
+    * so JSPs can render blank instead of "null, null".
+    */
+   private Provider buildConsultProvider(ConsultationListDTO dto) {
+      if (dto.getConsultProviderLastName() == null && dto.getConsultProviderFirstName() == null) {
+         return null;
+      }
+      Provider cProv = new Provider();
+      cProv.setLastName(dto.getConsultProviderLastName() != null ? dto.getConsultProviderLastName() : "");
+      cProv.setFirstName(dto.getConsultProviderFirstName() != null ? dto.getConsultProviderFirstName() : "");
+      return cProv;
+   }
+
+   private boolean isBlank(String value) {
+      return value == null || value.trim().isEmpty();
    }
 
    /**

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
@@ -82,15 +82,15 @@ public class EctViewConsultationRequestsUtil {
    }
    /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
    public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate) {
-      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null);
+      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,startDate,endDate,null);
    }
    /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
    public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby) {
-      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null,null);
+      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,startDate,endDate,orderby,null);
    }
    /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
    public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc) {
-      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null,null,null,null,null);
+      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,startDate,endDate,orderby,desc,null,null,null);
    }
 
    /**

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
@@ -4,7 +4,7 @@
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version. 
+ * of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -25,26 +25,29 @@
 
 package ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
-import ca.openosp.openo.PMmodule.dao.ProviderDao;
 import ca.openosp.openo.commn.dao.ConsultationRequestDao;
-import ca.openosp.openo.commn.dao.ConsultationRequestExtDao;
-import ca.openosp.openo.commn.dao.ConsultationServiceDao;
-import ca.openosp.openo.commn.model.*;
-import ca.openosp.openo.commn.model.enumerator.ConsultationRequestExtKey;
-import ca.openosp.openo.managers.ConsultationManager;
-import ca.openosp.openo.managers.DemographicManager;
+import ca.openosp.openo.commn.model.Provider;
+import ca.openosp.openo.consultation.dto.ConsultationListDTO;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.SpringUtils;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
-public class EctViewConsultationRequestsUtil {  
+/**
+ * Utility class that populates parallel lists of consultation request data for JSP display.
+ * <p>
+ * Uses {@link ConsultationRequestDao#getConsultationDTOs} and
+ * {@link ConsultationRequestDao#getConsultationDTOsByDemographic} to fetch all display fields
+ * via a single JPQL constructor projection with batch-loaded extensions, replacing the previous
+ * N+1 pattern that individually queried Demographics, Providers, Services, and Extensions per row.
+ * </p>
+ *
+ * @since 2001-08-17
+ */
+public class EctViewConsultationRequestsUtil {
    public List<String> ids;
    public List<String> status;
    public List<String> patient;
@@ -58,28 +61,142 @@ public class EctViewConsultationRequestsUtil {
    public List<String> patientWillBook;
    public List<String> urgency;
    public List<String> followUpDate;
-   public List<String> providerNo;   
+   public List<String> providerNo;
    public List<String> siteName;
    public List<Provider> consultProvider;
-   public List<Boolean> eReferral; 
-   
-   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo,String team) {   
+   public List<Boolean> eReferral;
+
+   /**
+    * Populates consultation list data filtered by team with default parameters.
+    *
+    * @param loggedInInfo LoggedInInfo the current user session
+    * @param team String the team/sendTo filter value
+    * @return boolean true if data was loaded successfully, false on error
+    */
+   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo,String team) {
       return estConsultationVecByTeam(loggedInInfo,team,false,null,null);
    }
-   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo,String team,boolean showCompleted) {   
+   /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
+   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo,String team,boolean showCompleted) {
       return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null);
-   }   
+   }
+   /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
    public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate) {
       return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null);
-   }   
-   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby) {   
+   }
+   /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
+   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby) {
       return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null,null);
-   }   
-   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc) { 
+   }
+   /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
+   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc) {
       return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null,null,null,null,null);
-   }  
-            
-   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc,String searchDate, Integer offset, Integer limit) {       
+   }
+
+   /**
+    * Populates parallel lists of consultation request data filtered by team and optional criteria.
+    * <p>
+    * Delegates to {@link ConsultationRequestDao#getConsultationDTOs} which executes a single JPQL
+    * constructor projection query with LEFT JOINs, followed by one batch extension query.
+    * </p>
+    *
+    * @param loggedInInfo LoggedInInfo the current user session
+    * @param team String the team/sendTo filter value (empty string for all teams)
+    * @param showCompleted boolean whether to include completed (status 4) consultations
+    * @param startDate Date the start date filter (null for no lower bound)
+    * @param endDate Date the end date filter (null for no upper bound)
+    * @param orderby String the sort column identifier (1-9), null for default referral date desc
+    * @param desc String "1" for descending sort, null/other for ascending
+    * @param searchDate String "1" to filter on appointment date instead of referral date
+    * @param offset Integer the pagination offset (null defaults to 0)
+    * @param limit Integer the page size (null defaults to {@link ConsultationRequestDao#DEFAULT_CONSULT_REQUEST_RESULTS_LIMIT})
+    * @return boolean true if data was loaded successfully, false on error
+    */
+   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc,String searchDate, Integer offset, Integer limit) {
+      initLists();
+
+      boolean verdict = true;
+      try {
+          ConsultationRequestDao consultReqDao = SpringUtils.getBean(ConsultationRequestDao.class);
+          List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOs(team, showCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit);
+
+          for (ConsultationListDTO dto : dtos) {
+              ids.add(dto.getId().toString());
+              status.add(dto.getStatus());
+              patient.add(dto.getPatientFormattedName());
+              provider.add(dto.getMrpFormattedName());
+              providerNo.add(dto.getDemographicProviderNo() != null ? dto.getDemographicProviderNo() : "-1");
+              service.add(dto.getEffectiveServiceDescription());
+              vSpecialist.add(dto.getSpecialistFormattedName());
+              urgency.add(dto.getUrgency());
+              date.add(dto.getReferralDateFormatted());
+              demographicNo.add(dto.getDemographicNo().toString());
+              siteName.add(dto.getSiteName());
+              teams.add(dto.getSendTo());
+              eReferral.add(dto.isEReferral());
+              apptDate.add(dto.getAppointmentDateFormatted());
+              patientWillBook.add(String.valueOf(dto.isPatientWillBook()));
+              followUpDate.add(dto.getFollowUpDateFormatted());
+
+              Provider cProv = new Provider();
+              cProv.setLastName(dto.getConsultProviderLastName());
+              cProv.setFirstName(dto.getConsultProviderFirstName());
+              consultProvider.add(cProv);
+          }
+      } catch(Exception e) {
+         MiscUtils.getLogger().error("Error", e);
+         verdict = false;
+      }
+      return verdict;
+   }
+
+
+   /**
+    * Populates parallel lists of consultation request data for a specific patient.
+    * <p>
+    * Delegates to {@link ConsultationRequestDao#getConsultationDTOsByDemographic} which executes
+    * a single JPQL constructor projection query with batch-loaded extensions.
+    * </p>
+    *
+    * @param loggedInInfo LoggedInInfo the current user session
+    * @param demoNo String the demographic number of the patient
+    * @return boolean true if data was loaded successfully, false on error
+    */
+   public boolean estConsultationVecByDemographic(LoggedInInfo loggedInInfo, String demoNo) {
+      initLists();
+
+      boolean verdict = true;
+      try {
+          ConsultationRequestDao consultReqDao = SpringUtils.getBean(ConsultationRequestDao.class);
+          List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOsByDemographic(Integer.parseInt(demoNo));
+
+          for (ConsultationListDTO dto : dtos) {
+              ids.add(dto.getId().toString());
+              status.add(dto.getStatus());
+              patient.add(dto.getPatientFormattedName());
+              provider.add(dto.getMrpFormattedName());
+              service.add(dto.getEffectiveServiceDescription());
+              vSpecialist.add(dto.getSpecialistFormattedName());
+              urgency.add(dto.getUrgency());
+              patientWillBook.add(String.valueOf(dto.isPatientWillBook()));
+              date.add(dto.getReferralDateFormatted());
+
+              Provider cProv = new Provider();
+              cProv.setLastName(dto.getConsultProviderLastName());
+              cProv.setFirstName(dto.getConsultProviderFirstName());
+              consultProvider.add(cProv);
+          }
+      } catch(Exception e) {
+         MiscUtils.getLogger().error("Error", e);
+         verdict = false;
+      }
+      return verdict;
+   }
+
+   /**
+    * Initializes all parallel lists to empty ArrayLists.
+    */
+   private void initLists() {
       ids = new ArrayList<>();
       status = new ArrayList<>();
       patient = new ArrayList<>();
@@ -97,184 +214,5 @@ public class EctViewConsultationRequestsUtil {
       followUpDate = new ArrayList<>();
       consultProvider = new ArrayList<>();
       eReferral = new ArrayList<>();
-      
-      boolean verdict = true;
-      try {
-          ConsultationRequestDao consultReqDao = (ConsultationRequestDao) SpringUtils.getBean(ConsultationRequestDao.class);
-          ConsultationRequestExtDao consultationRequestExtDao = SpringUtils.getBean(ConsultationRequestExtDao.class);
-          DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
-          ConsultationManager consultationManager = SpringUtils.getBean(ConsultationManager.class);
-          ProviderDao providerDao = (ProviderDao) SpringUtils.getBean(ProviderDao.class);
-          ConsultationServiceDao serviceDao = (ConsultationServiceDao) SpringUtils.getBean(ConsultationServiceDao.class);
-          ConsultationRequest consult;
-          Demographic demo;
-          Provider prov;
-          ProfessionalSpecialist specialist;
-          ConsultationServices services;
-          Calendar cal = Calendar.getInstance();
-          Date date1, date2;
-          String providerId, providerName, specialistName;
-          List<ConsultationRequest> consultList = consultReqDao.getConsults(team, showCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit);
-
-          for( int idx = 0; idx < consultList.size(); ++idx ) {
-              consult = (ConsultationRequest)consultList.get(idx);
-              demo = demographicManager.getDemographic(loggedInInfo, consult.getDemographicId());
-
-              List<ConsultationRequestExt> extras = consultationRequestExtDao.getConsultationRequestExts(consult.getId());
-              Map<String, String> extraMap = consultationManager.getExtValuesAsMap(extras);
-              
-              String serviceDescription = "";
-              // If service id is 0, check the extensions table
-              if (consult.getServiceId() == 0) {
-                 serviceDescription = extraMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_SERVICE.getKey(), "");
-              } else {
-                 services = serviceDao.find(consult.getServiceId());
-                 if (services != null) {
-                    serviceDescription = services.getServiceDesc();
-                 }
-              }
-
-              providerId = demo.getProviderNo();
-              if( providerId != null && !providerId.equals("")) {
-                  prov = providerDao.getProvider(demo.getProviderNo());
-                  providerName = prov.getFormattedName();
-                  providerNo.add(prov.getProviderNo());
-              }
-              else {
-                  providerName = "N/A";
-                  providerNo.add("-1");
-              }
-
-              if( consult.getProfessionalSpecialist() == null ) {
-                  specialistName = "N/A";
-                  if (consult.getServiceId() == 0) {
-                     specialistName = extraMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_DOCTOR.getKey(), "N/A");
-                  }
-              }
-              else {
-                  specialist = consult.getProfessionalSpecialist();
-                  specialistName = specialist.getLastName() + ", " + specialist.getFirstName();
-              }
-
-              boolean isEReferral = extraMap.containsKey(ConsultationRequestExtKey.EREFERRAL_REF.getKey());
-
-              demographicNo.add(consult.getDemographicId().toString());
-              date.add(DateFormatUtils.ISO_DATE_FORMAT.format(consult.getReferralDate()));
-              ids.add(consult.getId().toString());
-              status.add(consult.getStatus());
-              patient.add(demo.getFormattedName());
-              provider.add(providerName);
-              service.add(serviceDescription);
-              vSpecialist.add(specialistName);
-              urgency.add(consult.getUrgency());
-              siteName.add(consult.getSiteName());
-              teams.add(consult.getSendTo());
-              eReferral.add(isEReferral);
-              
-              date1 = consult.getAppointmentDate();
-              date2 = consult.getAppointmentTime();
-              
-              String apptDateStr = "";
-              if( date1 == null ) {
-            	  apptDateStr = "N/A";
-              } else if( date1 != null && date2 == null ) {
-            	  apptDateStr = DateFormatUtils.ISO_DATE_FORMAT.format(date1) + " T00:00:00";
-              } else {
-            	  apptDateStr = DateFormatUtils.ISO_DATE_FORMAT.format(date1) + " " +  DateFormatUtils.ISO_TIME_FORMAT.format(date2);
-              }
-              
-              apptDate.add(apptDateStr);
-              patientWillBook.add(""+consult.isPatientWillBook());
-              
-              date1 = consult.getFollowUpDate();
-              if( date1 == null ) {
-                  followUpDate.add("N/A");
-              }
-              else {
-                followUpDate.add(DateFormatUtils.ISO_DATE_FORMAT.format(date1));
-              }
-              
-              Provider cProv = providerDao.getProvider(consult.getProviderNo());
-              consultProvider.add(cProv);
-          }
-      } catch(Exception e) {            
-         MiscUtils.getLogger().error("Error", e);            
-         verdict = false;            
-      }                     
-      return verdict;      
-   }      
-   
-      
-   public boolean estConsultationVecByDemographic(LoggedInInfo loggedInInfo, String demoNo) {      
-      ids = new ArrayList<>();
-      status = new ArrayList<>();
-      patient = new ArrayList<>();
-      provider = new ArrayList<>();
-      service = new ArrayList<>();
-      vSpecialist = new ArrayList<>();
-      date = new ArrayList<>();
-      patientWillBook = new ArrayList<>();
-      urgency = new ArrayList<>();
-      apptDate = new ArrayList<>();
-      consultProvider = new ArrayList<>();
-      
-      boolean verdict = true;      
-      try {                           
-
-          ConsultationRequestDao consultReqDao = (ConsultationRequestDao) SpringUtils.getBean(ConsultationRequestDao.class);
-          ConsultationRequestExtDao consultationRequestExtDao = SpringUtils.getBean(ConsultationRequestExtDao.class);
-          ProviderDao providerDao = (ProviderDao) SpringUtils.getBean(ProviderDao.class);
-          DemographicManager demoManager = SpringUtils.getBean(DemographicManager.class);
-          ConsultationServiceDao serviceDao = (ConsultationServiceDao) SpringUtils.getBean(ConsultationServiceDao.class);
-
-          ProfessionalSpecialist specialist;
-          String specialistName = "";
-
-          List <ConsultationRequest> consultList = consultReqDao.getConsults(Integer.parseInt(demoNo));
-          for( ConsultationRequest consult : consultList ) {
-              String serviceDescription = "unknown";
-              // If service id is 0, check the extensions table
-              if (consult.getServiceId() == 0) {
-                 serviceDescription = consultationRequestExtDao.getConsultationRequestExtsByKey(consult.getId(), ConsultationRequestExtKey.EREFERRAL_SERVICE.getKey());
-              } else {
-                 ConsultationServices services = serviceDao.find(consult.getServiceId());
-                 if (services != null) {
-                    serviceDescription = services.getServiceDesc();
-                 }
-              }
-
-               if(consult.getProfessionalSpecialist() == null) {
-                  specialistName = "N/A";
-                  if (consult.getServiceId() == 0) {
-                     specialistName = consultationRequestExtDao.getConsultationRequestExtsByKey(consult.getId(), ConsultationRequestExtKey.EREFERRAL_DOCTOR.getKey());
-                  }
-               }
-               else {
-                  specialist = consult.getProfessionalSpecialist();
-                  specialistName = specialist.getLastName() + ", " + specialist.getFirstName();
-               }
-
-              Demographic demo = demoManager.getDemographic(loggedInInfo, consult.getDemographicId());
-              String providerId = demo.getProviderNo();
-              String providerName = (providerId != null && !providerId.isEmpty()) ? providerDao.getProvider(providerId).getFormattedName() : "N/A";
-
-              ids.add(consult.getId().toString());
-              status.add(consult.getStatus());
-              patient.add(demo.getFormattedName());
-              provider.add(providerName);
-              service.add(serviceDescription);
-              vSpecialist.add(specialistName);
-              urgency.add(consult.getUrgency());
-              patientWillBook.add(""+consult.isPatientWillBook());
-              date.add(DateFormatUtils.ISO_DATE_FORMAT.format(consult.getReferralDate()));
-              
-              Provider cProv = providerDao.getProvider(consult.getProviderNo());
-              consultProvider.add(cProv);
-          }
-      } catch(Exception e) {         
-         MiscUtils.getLogger().error("Error", e);         
-         verdict = false;         
-      }      
-      return verdict;      
    }
 }

--- a/src/main/java/ca/openosp/openo/managers/ConsultationManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/ConsultationManagerImpl.java
@@ -52,6 +52,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.itextpdf.text.DocumentException;
 import org.apache.logging.log4j.Logger;
+import org.owasp.encoder.Encode;
 import ca.openosp.openo.commn.dao.ClinicDAO;
 import ca.openosp.openo.commn.dao.ConsultDocsDao;
 import ca.openosp.openo.commn.dao.ConsultRequestDao;
@@ -727,7 +728,7 @@ public class ConsultationManagerImpl implements ConsultationManager {
                     result.add(map);
                 }
             } catch (Exception e) {
-                MiscUtils.getLogger().warn("Failed to load HRM document " + attachedDoc.getDocumentNo() + " attached to consultation request " + requestId, e);
+                MiscUtils.getLogger().warn("Failed to load HRM document " + attachedDoc.getDocumentNo() + " attached to consultation request " + Encode.forJava(requestId), e);
             }
         }
         return result;

--- a/src/main/java/ca/openosp/openo/managers/ConsultationManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/ConsultationManagerImpl.java
@@ -96,6 +96,7 @@ import ca.openosp.openo.consultations.ConsultationRequestSearchFilter;
 import ca.openosp.openo.consultations.ConsultationRequestSearchFilter.SORTDIR;
 import ca.openosp.openo.consultations.ConsultationResponseSearchFilter;
 import ca.openosp.openo.hospitalReportManager.HRMUtil;
+import ca.openosp.openo.hospitalReportManager.model.HRMDocument;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.PDFGenerationException;
@@ -715,20 +716,21 @@ public class ConsultationManagerImpl implements ConsultationManager {
     @Override
     public ArrayList<HashMap<String, ? extends Object>> getAttachedHRMDocuments(LoggedInInfo loggedInInfo, String demographicNo, String requestId) {
         List<ConsultDocs> attachedHRMDocuments = getAttachedDocumentsByType(loggedInInfo, Integer.parseInt(requestId), ConsultDocs.DOCTYPE_HRM);
-        //TODO: refactor HRMUtil so that it's possible to call a function, pass in a particular HRM ID, and return the same information for that HRM that listHRMDocuments does
-        //		once this is done, would be possible to simply iterate over attachedHRMDocuments
-        //		In the absence of the above refactoring, the following gets the full listHRMDocuments and then filters for only the items that are actually attached to the consult
-        ArrayList<HashMap<String, ? extends Object>> allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicNo, false);
-        ArrayList<HashMap<String, ? extends Object>> filteredHRMDocuments = new ArrayList<>(attachedHRMDocuments.size());
-        for (ConsultDocs attachedHRMDocument : attachedHRMDocuments) {
-            for (HashMap<String, ? extends Object> hrmDocument : allHRMDocuments) {
-                if (((Integer) hrmDocument.get("id")) == attachedHRMDocument.getDocumentNo()) {
-                    filteredHRMDocuments.add(hrmDocument);
+        ArrayList<HashMap<String, ? extends Object>> result = new ArrayList<>(attachedHRMDocuments.size());
+        for (ConsultDocs attachedDoc : attachedHRMDocuments) {
+            try {
+                HRMDocument hrmDoc = HRMUtil.getHRMDocumentById(loggedInInfo, attachedDoc.getDocumentNo());
+                if (hrmDoc != null) {
+                    HashMap<String, Object> map = new HashMap<>();
+                    map.put("id", hrmDoc.getId());
+                    map.put("name", hrmDoc.getDisplayName());
+                    result.add(map);
                 }
+            } catch (Exception e) {
+                MiscUtils.getLogger().warn("Failed to load HRM document " + attachedDoc.getDocumentNo() + " attached to consultation request " + requestId, e);
             }
         }
-        //return the subset of listHRMDocuments that is attached
-        return filteredHRMDocuments;
+        return result;
     }
 
     @Override

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -21,6 +21,7 @@ import com.opensymphony.xwork2.ActionSupport;
 
 import ca.openosp.OscarProperties;
 import ca.openosp.openo.commn.model.CustomFilter;
+import ca.openosp.openo.log.LogAction;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.managers.TicklerManager;
 import ca.openosp.openo.tickler.dto.TicklerCommentDTO;
@@ -38,10 +39,8 @@ import ca.openosp.openo.utility.SpringUtils;
  */
 public class TicklerList2Action extends ActionSupport {
 
-    HttpServletRequest request = ServletActionContext.getRequest();
-    HttpServletResponse response = ServletActionContext.getResponse();
-
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final int MAX_PAGE_SIZE = 500;
 
     private TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
@@ -56,35 +55,47 @@ public class TicklerList2Action extends ActionSupport {
      */
     @Override
     public String execute() throws IOException {
+        HttpServletRequest request = ServletActionContext.getRequest();
+        HttpServletResponse response = ServletActionContext.getResponse();
+
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", "r", null)) {
-            throw new SecurityException("missing required sec object (_tickler)");
+            writeJsonError(response, HttpServletResponse.SC_FORBIDDEN, "Access denied");
+            return null;
         }
 
-        int draw = parseIntParam("draw", 1);
-        int start = Math.max(0, parseIntParam("start", 0));
-        int length = parseIntParam("length", 50);
+        int draw = parseIntParam(request, "draw", 1);
+        int start = Math.max(0, parseIntParam(request, "start", 0));
+        int length = parseIntParam(request, "length", 50);
         if (length > 0) {
-            length = Math.min(length, 500);
+            length = Math.min(length, MAX_PAGE_SIZE);
         }
-        boolean showAll = (length <= 0);
 
         Locale locale = request.getLocale();
 
-        CustomFilter filter = buildFilterFromRequest();
+        CustomFilter filter;
+        try {
+            filter = buildFilterFromRequest(request);
+        } catch (IllegalArgumentException e) {
+            writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST,
+                    "Invalid date format, use yyyy-MM-dd");
+            return null;
+        }
 
         int totalRecords = ticklerManager.getNumTicklers(loggedInInfo, filter);
+
         List<TicklerListDTO> ticklers;
-        if (showAll) {
-            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter);
+        if (length <= 0) {
+            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, 0, totalRecords);
         } else {
             ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, start, length);
         }
 
-        long ticklerWarnDays = getTicklerWarnDays();
-        boolean ignoreWarning = (ticklerWarnDays <= 0);
+        LogAction.addLogSynchronous(loggedInInfo, "TicklerList2Action.execute",
+                "ticklers=" + ticklers.size() + ",total=" + totalRecords);
 
+        long ticklerWarnDays = getTicklerWarnDays();
         DateFormat datetimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", locale);
         DateFormat dateOnlyFormat = new SimpleDateFormat("yyyy-MM-dd", locale);
         DateFormat timeOnlyFormat = new SimpleDateFormat("HH:mm:ss", locale);
@@ -93,59 +104,13 @@ public class TicklerList2Action extends ActionSupport {
         ObjectNode commentsMap = objectMapper.createObjectNode();
 
         for (TicklerListDTO tickler : ticklers) {
-            boolean warning = false;
-            if (!ignoreWarning && tickler.getServiceDate() != null) {
-                LocalDateTime serviceDate = tickler.getServiceDate().toInstant()
-                        .atZone(ZoneId.systemDefault()).toLocalDateTime();
-                long daysDifference = Duration.between(serviceDate, LocalDateTime.now()).toDays();
-                warning = (daysDifference >= ticklerWarnDays);
-            }
-
-            ObjectNode row = objectMapper.createObjectNode();
-            row.put("id", tickler.getId());
-            row.put("demoNo", tickler.getDemographicNo());
-            row.put("demoLastName", tickler.getDemographicLastName());
-            row.put("demoFirstName", tickler.getDemographicFirstName());
-            row.put("creator", tickler.getCreatorFormattedName());
-            row.put("serviceDate", tickler.getServiceDate() != null ? dateOnlyFormat.format(tickler.getServiceDate()) : "");
-            row.put("createDate", tickler.getCreateDate() != null ? datetimeFormat.format(tickler.getCreateDate()) : "");
-            row.put("priority", String.valueOf(tickler.getPriority()));
-            row.put("assignee", tickler.getAssigneeFormattedName());
-            row.put("status", tickler.getStatusDesc(locale));
-            row.put("message", tickler.getMessage());
-            row.put("warning", warning);
-
-            ArrayNode linksArray = objectMapper.createArrayNode();
-            List<TicklerLinkDTO> linkList = tickler.getLinks();
-            if (linkList != null) {
-                for (TicklerLinkDTO tl : linkList) {
-                    ObjectNode linkNode = objectMapper.createObjectNode();
-                    linkNode.put("tableName", tl.getTableName());
-                    linkNode.put("tableId", tl.getTableId());
-                    linksArray.add(linkNode);
-                }
-            }
-            row.set("links", linksArray);
-
-            dataArray.add(row);
+            boolean warning = isWarning(tickler.getServiceDate(), ticklerWarnDays);
+            dataArray.add(buildTicklerRow(tickler, warning, datetimeFormat, dateOnlyFormat, locale));
 
             List<TicklerCommentDTO> tcomments = tickler.getComments();
             if (tcomments != null && !tcomments.isEmpty()) {
-                ArrayNode commentArray = objectMapper.createArrayNode();
-                for (TicklerCommentDTO tc : tcomments) {
-                    ObjectNode commentObj = objectMapper.createObjectNode();
-                    commentObj.put("creator", tc.getProviderFormattedName());
-                    if (tc.getUpdateDate() == null) {
-                        commentObj.put("createDate", "");
-                    } else if (tc.isUpdateDateToday()) {
-                        commentObj.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
-                    } else {
-                        commentObj.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
-                    }
-                    commentObj.put("message", tc.getMessage());
-                    commentArray.add(commentObj);
-                }
-                commentsMap.set(String.valueOf(tickler.getId()), commentArray);
+                commentsMap.set(String.valueOf(tickler.getId()),
+                        buildCommentsArray(tcomments, datetimeFormat, timeOnlyFormat));
             }
         }
 
@@ -164,19 +129,109 @@ public class TicklerList2Action extends ActionSupport {
     }
 
     /**
+     * Checks whether a tickler's service date exceeds the configured warning period.
+     *
+     * @param serviceDate Date the tickler service date
+     * @param warnDays long the warning threshold in days, 0 or negative disables warnings
+     * @return boolean true if the service date is past the warning threshold
+     */
+    private boolean isWarning(java.util.Date serviceDate, long warnDays) {
+        if (serviceDate == null || warnDays <= 0) {
+            return false;
+        }
+        LocalDateTime service = serviceDate.toInstant()
+                .atZone(ZoneId.systemDefault()).toLocalDateTime();
+        long daysDifference = Duration.between(service, LocalDateTime.now()).toDays();
+        return daysDifference >= warnDays;
+    }
+
+    /**
+     * Builds a JSON object node representing a single tickler data row.
+     *
+     * @param tickler TicklerListDTO the tickler data
+     * @param warning boolean whether this tickler has triggered a warning
+     * @param datetimeFormat DateFormat for full datetime display
+     * @param dateOnlyFormat DateFormat for date-only display
+     * @param locale Locale for localized status text
+     * @return ObjectNode the JSON row
+     */
+    private ObjectNode buildTicklerRow(TicklerListDTO tickler, boolean warning,
+                                       DateFormat datetimeFormat, DateFormat dateOnlyFormat,
+                                       Locale locale) {
+        ObjectNode row = objectMapper.createObjectNode();
+        row.put("id", tickler.getId());
+        row.put("demoNo", tickler.getDemographicNo());
+        row.put("demoLastName", tickler.getDemographicLastName());
+        row.put("demoFirstName", tickler.getDemographicFirstName());
+        row.put("creator", tickler.getCreatorFormattedName());
+        row.put("serviceDate",
+                tickler.getServiceDate() != null ? dateOnlyFormat.format(tickler.getServiceDate()) : "");
+        row.put("createDate",
+                tickler.getCreateDate() != null ? datetimeFormat.format(tickler.getCreateDate()) : "");
+        row.put("priority", String.valueOf(tickler.getPriority()));
+        row.put("assignee", tickler.getAssigneeFormattedName());
+        row.put("status", tickler.getStatusDesc(locale));
+        row.put("message", tickler.getMessage());
+        row.put("warning", warning);
+
+        ArrayNode linksArray = objectMapper.createArrayNode();
+        List<TicklerLinkDTO> linkList = tickler.getLinks();
+        if (linkList != null) {
+            for (TicklerLinkDTO tl : linkList) {
+                ObjectNode linkNode = objectMapper.createObjectNode();
+                linkNode.put("tableName", tl.getTableName());
+                linkNode.put("tableId", tl.getTableId());
+                linksArray.add(linkNode);
+            }
+        }
+        row.set("links", linksArray);
+
+        return row;
+    }
+
+    /**
+     * Builds a JSON array of comment objects for a tickler.
+     *
+     * @param comments List of TicklerCommentDTO the comments to serialize
+     * @param datetimeFormat DateFormat for full datetime display
+     * @param timeOnlyFormat DateFormat for time-only display (used for today's comments)
+     * @return ArrayNode the JSON array of comments
+     */
+    private ArrayNode buildCommentsArray(List<TicklerCommentDTO> comments,
+                                         DateFormat datetimeFormat, DateFormat timeOnlyFormat) {
+        ArrayNode commentArray = objectMapper.createArrayNode();
+        for (TicklerCommentDTO tc : comments) {
+            ObjectNode commentObj = objectMapper.createObjectNode();
+            commentObj.put("creator", tc.getProviderFormattedName());
+            if (tc.getUpdateDate() == null) {
+                commentObj.put("createDate", "");
+            } else if (tc.isUpdateDateToday()) {
+                commentObj.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
+            } else {
+                commentObj.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
+            }
+            commentObj.put("message", tc.getMessage());
+            commentArray.add(commentObj);
+        }
+        return commentArray;
+    }
+
+    /**
      * Parses request parameters and constructs a CustomFilter for the tickler query.
      * Handles both general and demographic-specific filtering through a single path.
      *
+     * @param request HttpServletRequest the current request
      * @return CustomFilter populated from request parameters
+     * @throws IllegalArgumentException if date parameters are in an invalid format
      */
-    private CustomFilter buildFilterFromRequest() {
-        String ticklerview = getStringParam("ticklerview", "A");
-        String providerview = getStringParam("providerview", "all");
-        String assignedTo = getStringParam("assignedTo", "all");
-        String mrpview = getStringParam("mrpview", "all");
-        String dateBegin = getStringParam("xml_vdate", "1950-01-01");
-        String dateEnd = getStringParam("xml_appointment_date", "");
-        int targetDemographic = parseIntParam("demographic_no", 0);
+    private CustomFilter buildFilterFromRequest(HttpServletRequest request) {
+        String ticklerview = getStringParam(request, "ticklerview", "A");
+        String providerview = getStringParam(request, "providerview", "all");
+        String assignedTo = getStringParam(request, "assignedTo", "all");
+        String mrpview = getStringParam(request, "mrpview", "all");
+        String dateBegin = getStringParam(request, "xml_vdate", "1950-01-01");
+        String dateEnd = getStringParam(request, "xml_appointment_date", "");
+        int targetDemographic = parseIntParam(request, "demographic_no", 0);
 
         if (targetDemographic > 0) {
             if (dateEnd.isEmpty()) {
@@ -196,8 +251,6 @@ public class TicklerList2Action extends ActionSupport {
 
         if (targetDemographic > 0) {
             filter.setDemographicNo(String.valueOf(targetDemographic));
-            // When viewing a specific demographic's ticklers, only filter by
-            // demographic, status, and date range (matches old search_tickler_bydemo behavior)
             filter.setMrp(null);
             filter.setProvider(null);
             filter.setAssignee(null);
@@ -213,12 +266,30 @@ public class TicklerList2Action extends ActionSupport {
             }
         }
 
-        String sortDir = getStringParam("order[0][dir]", "desc");
+        String sortDir = getStringParam(request, "order[0][dir]", "desc");
         if (!"asc".equalsIgnoreCase(sortDir)) {
             sortDir = "desc";
         }
         filter.setSort_order(sortDir);
         return filter;
+    }
+
+    /**
+     * Writes a JSON error response with the given HTTP status code.
+     *
+     * @param response HttpServletResponse the response to write to
+     * @param statusCode int the HTTP status code
+     * @param message String the error message
+     * @throws IOException if writing fails
+     */
+    private void writeJsonError(HttpServletResponse response, int statusCode,
+                                String message) throws IOException {
+        response.setStatus(statusCode);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        ObjectNode error = objectMapper.createObjectNode();
+        error.put("error", message);
+        response.getWriter().write(error.toString());
     }
 
     /**
@@ -238,7 +309,7 @@ public class TicklerList2Action extends ActionSupport {
         }
     }
 
-    private int parseIntParam(String name, int defaultValue) {
+    private int parseIntParam(HttpServletRequest request, String name, int defaultValue) {
         String val = request.getParameter(name);
         if (val == null || val.isEmpty()) {
             return defaultValue;
@@ -250,7 +321,7 @@ public class TicklerList2Action extends ActionSupport {
         }
     }
 
-    private String getStringParam(String name, String defaultValue) {
+    private String getStringParam(HttpServletRequest request, String name, String defaultValue) {
         String val = request.getParameter(name);
         if (val == null || val.isEmpty()) {
             return defaultValue;

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -228,7 +228,11 @@ public class TicklerList2Action extends ActionSupport {
             }
         }
 
-        filter.setSort_order("desc");
+        String sortDir = getStringParam("order[0][dir]", "desc");
+        if (!"asc".equalsIgnoreCase(sortDir)) {
+            sortDir = "desc";
+        }
+        filter.setSort_order(sortDir);
         return filter;
     }
 

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -90,6 +90,7 @@ public class TicklerList2Action extends ActionSupport {
         DateFormat timeOnlyFormat = new SimpleDateFormat("HH:mm:ss", locale);
 
         ArrayNode dataArray = objectMapper.createArrayNode();
+        ObjectNode commentsMap = objectMapper.createObjectNode();
 
         for (TicklerListDTO tickler : ticklers) {
             boolean warning = false;
@@ -113,7 +114,6 @@ public class TicklerList2Action extends ActionSupport {
             row.put("status", tickler.getStatusDesc(locale));
             row.put("message", tickler.getMessage());
             row.put("warning", warning);
-            row.put("rowType", "tickler");
 
             ArrayNode linksArray = objectMapper.createArrayNode();
             List<TicklerLinkDTO> linkList = tickler.getLinks();
@@ -130,31 +130,22 @@ public class TicklerList2Action extends ActionSupport {
             dataArray.add(row);
 
             List<TicklerCommentDTO> tcomments = tickler.getComments();
-            if (tcomments != null) {
+            if (tcomments != null && !tcomments.isEmpty()) {
+                ArrayNode commentArray = objectMapper.createArrayNode();
                 for (TicklerCommentDTO tc : tcomments) {
-                    ObjectNode commentRow = objectMapper.createObjectNode();
-                    commentRow.put("id", tickler.getId());
-                    commentRow.put("demoNo", tickler.getDemographicNo());
-                    commentRow.put("demoLastName", tickler.getDemographicLastName());
-                    commentRow.put("demoFirstName", tickler.getDemographicFirstName());
-                    commentRow.put("creator", tc.getProviderFormattedName());
-                    commentRow.put("serviceDate", tickler.getServiceDate() != null ? dateOnlyFormat.format(tickler.getServiceDate()) : "");
+                    ObjectNode commentObj = objectMapper.createObjectNode();
+                    commentObj.put("creator", tc.getProviderFormattedName());
                     if (tc.getUpdateDate() == null) {
-                        commentRow.put("createDate", "");
+                        commentObj.put("createDate", "");
                     } else if (tc.isUpdateDateToday()) {
-                        commentRow.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
+                        commentObj.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
                     } else {
-                        commentRow.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
+                        commentObj.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
                     }
-                    commentRow.put("priority", String.valueOf(tickler.getPriority()));
-                    commentRow.put("assignee", "");
-                    commentRow.put("status", "");
-                    commentRow.put("message", tc.getMessage());
-                    commentRow.put("warning", false);
-                    commentRow.put("rowType", "comment");
-
-                    dataArray.add(commentRow);
+                    commentObj.put("message", tc.getMessage());
+                    commentArray.add(commentObj);
                 }
+                commentsMap.set(String.valueOf(tickler.getId()), commentArray);
             }
         }
 
@@ -163,6 +154,7 @@ public class TicklerList2Action extends ActionSupport {
         result.put("recordsTotal", totalRecords);
         result.put("recordsFiltered", totalRecords);
         result.set("data", dataArray);
+        result.set("comments", commentsMap);
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -54,6 +54,7 @@ public class TicklerList2Action extends ActionSupport {
      * @return null since the response is written directly
      * @throws IOException if writing the JSON response fails
      */
+    @Override
     public String execute() throws IOException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
@@ -62,8 +63,11 @@ public class TicklerList2Action extends ActionSupport {
         }
 
         int draw = parseIntParam("draw", 1);
-        int start = parseIntParam("start", 0);
+        int start = Math.max(0, parseIntParam("start", 0));
         int length = parseIntParam("length", 50);
+        if (length > 0) {
+            length = Math.min(length, 500);
+        }
         boolean showAll = (length <= 0);
 
         Locale locale = request.getLocale();
@@ -88,10 +92,13 @@ public class TicklerList2Action extends ActionSupport {
         ArrayNode dataArray = objectMapper.createArrayNode();
 
         for (TicklerListDTO tickler : ticklers) {
-            LocalDateTime serviceDate = tickler.getServiceDate().toInstant()
-                    .atZone(ZoneId.systemDefault()).toLocalDateTime();
-            long daysDifference = Duration.between(serviceDate, LocalDateTime.now()).toDays();
-            boolean warning = !ignoreWarning && (daysDifference >= ticklerWarnDays);
+            boolean warning = false;
+            if (!ignoreWarning && tickler.getServiceDate() != null) {
+                LocalDateTime serviceDate = tickler.getServiceDate().toInstant()
+                        .atZone(ZoneId.systemDefault()).toLocalDateTime();
+                long daysDifference = Duration.between(serviceDate, LocalDateTime.now()).toDays();
+                warning = (daysDifference >= ticklerWarnDays);
+            }
 
             ObjectNode row = objectMapper.createObjectNode();
             row.put("id", tickler.getId());
@@ -99,8 +106,8 @@ public class TicklerList2Action extends ActionSupport {
             row.put("demoLastName", tickler.getDemographicLastName());
             row.put("demoFirstName", tickler.getDemographicFirstName());
             row.put("creator", tickler.getCreatorFormattedName());
-            row.put("serviceDate", dateOnlyFormat.format(tickler.getServiceDate()));
-            row.put("createDate", datetimeFormat.format(tickler.getCreateDate()));
+            row.put("serviceDate", tickler.getServiceDate() != null ? dateOnlyFormat.format(tickler.getServiceDate()) : "");
+            row.put("createDate", tickler.getCreateDate() != null ? datetimeFormat.format(tickler.getCreateDate()) : "");
             row.put("priority", String.valueOf(tickler.getPriority()));
             row.put("assignee", tickler.getAssigneeFormattedName());
             row.put("status", tickler.getStatusDesc(locale));
@@ -131,8 +138,10 @@ public class TicklerList2Action extends ActionSupport {
                     commentRow.put("demoLastName", tickler.getDemographicLastName());
                     commentRow.put("demoFirstName", tickler.getDemographicFirstName());
                     commentRow.put("creator", tc.getProviderFormattedName());
-                    commentRow.put("serviceDate", dateOnlyFormat.format(tickler.getServiceDate()));
-                    if (tc.isUpdateDateToday()) {
+                    commentRow.put("serviceDate", tickler.getServiceDate() != null ? dateOnlyFormat.format(tickler.getServiceDate()) : "");
+                    if (tc.getUpdateDate() == null) {
+                        commentRow.put("createDate", "");
+                    } else if (tc.isUpdateDateToday()) {
                         commentRow.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
                     } else {
                         commentRow.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
@@ -177,6 +186,16 @@ public class TicklerList2Action extends ActionSupport {
         String dateEnd = getStringParam("xml_appointment_date", "");
         int targetDemographic = parseIntParam("demographic_no", 0);
 
+        if (targetDemographic > 0) {
+            if (dateEnd.isEmpty()) {
+                dateEnd = "8888-12-31";
+            }
+        } else {
+            if (dateEnd.isEmpty()) {
+                dateEnd = new SimpleDateFormat("yyyy-MM-dd").format(new java.util.Date());
+            }
+        }
+
         CustomFilter filter = new CustomFilter();
         filter.setPriority(null);
         filter.setStatus(ticklerview);
@@ -190,9 +209,6 @@ public class TicklerList2Action extends ActionSupport {
             filter.setMrp(null);
             filter.setProvider(null);
             filter.setAssignee(null);
-            if (dateEnd.isEmpty()) {
-                filter.setEndDateWeb("8888-12-31");
-            }
         } else {
             if (!mrpview.isEmpty() && !"all".equals(mrpview)) {
                 filter.setMrp(mrpview);
@@ -221,9 +237,13 @@ public class TicklerList2Action extends ActionSupport {
     private long getTicklerWarnDays() {
         String numDaysUntilWarn = OscarProperties.getInstance().getProperty("tickler_warn_period");
         if (numDaysUntilWarn == null || numDaysUntilWarn.isEmpty()) {
-            numDaysUntilWarn = "0";
+            return 0;
         }
-        return Long.parseLong(numDaysUntilWarn);
+        try {
+            return Long.parseLong(numDaysUntilWarn);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     private int parseIntParam(String name, int defaultValue) {

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -1,26 +1,3 @@
-/**
- * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
- * This software is published under the GPL GNU General Public License.
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * <p>
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * <p>
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- * <p>
- * This software was written for the
- * Department of Family Medicine
- * McMaster University
- * Hamilton
- * Ontario, Canada
- */
 package ca.openosp.openo.tickler.pageUtil;
 
 import java.io.IOException;

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -1,0 +1,267 @@
+/**
+ * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for the
+ * Department of Family Medicine
+ * McMaster University
+ * Hamilton
+ * Ontario, Canada
+ */
+package ca.openosp.openo.tickler.pageUtil;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.struts2.ServletActionContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.opensymphony.xwork2.ActionSupport;
+
+import ca.openosp.OscarProperties;
+import ca.openosp.openo.commn.model.CustomFilter;
+import ca.openosp.openo.managers.SecurityInfoManager;
+import ca.openosp.openo.managers.TicklerManager;
+import ca.openosp.openo.tickler.dto.TicklerCommentDTO;
+import ca.openosp.openo.tickler.dto.TicklerLinkDTO;
+import ca.openosp.openo.tickler.dto.TicklerListDTO;
+import ca.openosp.openo.utility.LoggedInInfo;
+import ca.openosp.openo.utility.SpringUtils;
+
+/**
+ * Struts2 action that returns paginated tickler data as JSON for DataTables
+ * server-side processing. Returns raw data objects; HTML rendering is handled
+ * by client-side DataTables column render functions.
+ *
+ * @since 2026-02-05
+ */
+public class TicklerList2Action extends ActionSupport {
+
+    HttpServletRequest request = ServletActionContext.getRequest();
+    HttpServletResponse response = ServletActionContext.getResponse();
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
+    private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+
+    /**
+     * Handles DataTables server-side processing requests. Accepts standard
+     * DataTables parameters (draw, start, length) plus tickler filter parameters.
+     * Returns JSON with raw data fields for client-side rendering.
+     *
+     * @return null since the response is written directly
+     * @throws IOException if writing the JSON response fails
+     */
+    public String execute() throws IOException {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", "r", null)) {
+            throw new SecurityException("missing required sec object (_tickler)");
+        }
+
+        int draw = parseIntParam("draw", 1);
+        int start = parseIntParam("start", 0);
+        int length = parseIntParam("length", 50);
+        boolean showAll = (length <= 0);
+
+        Locale locale = request.getLocale();
+
+        CustomFilter filter = buildFilterFromRequest();
+
+        int totalRecords = ticklerManager.getNumTicklers(loggedInInfo, filter);
+        List<TicklerListDTO> ticklers;
+        if (showAll) {
+            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter);
+        } else {
+            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, start, length);
+        }
+
+        long ticklerWarnDays = getTicklerWarnDays();
+        boolean ignoreWarning = (ticklerWarnDays <= 0);
+
+        DateFormat datetimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", locale);
+        DateFormat dateOnlyFormat = new SimpleDateFormat("yyyy-MM-dd", locale);
+        DateFormat timeOnlyFormat = new SimpleDateFormat("HH:mm:ss", locale);
+
+        ArrayNode dataArray = objectMapper.createArrayNode();
+
+        for (TicklerListDTO tickler : ticklers) {
+            LocalDateTime serviceDate = tickler.getServiceDate().toInstant()
+                    .atZone(ZoneId.systemDefault()).toLocalDateTime();
+            long daysDifference = Duration.between(serviceDate, LocalDateTime.now()).toDays();
+            boolean warning = !ignoreWarning && (daysDifference >= ticklerWarnDays);
+
+            ObjectNode row = objectMapper.createObjectNode();
+            row.put("id", tickler.getId());
+            row.put("demoNo", tickler.getDemographicNo());
+            row.put("demoLastName", tickler.getDemographicLastName());
+            row.put("demoFirstName", tickler.getDemographicFirstName());
+            row.put("creator", tickler.getCreatorFormattedName());
+            row.put("serviceDate", dateOnlyFormat.format(tickler.getServiceDate()));
+            row.put("createDate", datetimeFormat.format(tickler.getCreateDate()));
+            row.put("priority", String.valueOf(tickler.getPriority()));
+            row.put("assignee", tickler.getAssigneeFormattedName());
+            row.put("status", tickler.getStatusDesc(locale));
+            row.put("message", tickler.getMessage());
+            row.put("warning", warning);
+            row.put("rowType", "tickler");
+
+            ArrayNode linksArray = objectMapper.createArrayNode();
+            List<TicklerLinkDTO> linkList = tickler.getLinks();
+            if (linkList != null) {
+                for (TicklerLinkDTO tl : linkList) {
+                    ObjectNode linkNode = objectMapper.createObjectNode();
+                    linkNode.put("tableName", tl.getTableName());
+                    linkNode.put("tableId", tl.getTableId());
+                    linksArray.add(linkNode);
+                }
+            }
+            row.set("links", linksArray);
+
+            dataArray.add(row);
+
+            List<TicklerCommentDTO> tcomments = tickler.getComments();
+            if (tcomments != null) {
+                for (TicklerCommentDTO tc : tcomments) {
+                    ObjectNode commentRow = objectMapper.createObjectNode();
+                    commentRow.put("id", tickler.getId());
+                    commentRow.put("demoNo", tickler.getDemographicNo());
+                    commentRow.put("demoLastName", tickler.getDemographicLastName());
+                    commentRow.put("demoFirstName", tickler.getDemographicFirstName());
+                    commentRow.put("creator", tc.getProviderFormattedName());
+                    commentRow.put("serviceDate", dateOnlyFormat.format(tickler.getServiceDate()));
+                    if (tc.isUpdateDateToday()) {
+                        commentRow.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
+                    } else {
+                        commentRow.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
+                    }
+                    commentRow.put("priority", String.valueOf(tickler.getPriority()));
+                    commentRow.put("assignee", "");
+                    commentRow.put("status", "");
+                    commentRow.put("message", tc.getMessage());
+                    commentRow.put("warning", false);
+                    commentRow.put("rowType", "comment");
+
+                    dataArray.add(commentRow);
+                }
+            }
+        }
+
+        ObjectNode result = objectMapper.createObjectNode();
+        result.put("draw", draw);
+        result.put("recordsTotal", totalRecords);
+        result.put("recordsFiltered", totalRecords);
+        result.set("data", dataArray);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(result.toString());
+
+        return null;
+    }
+
+    /**
+     * Parses request parameters and constructs a CustomFilter for the tickler query.
+     * Handles both general and demographic-specific filtering through a single path.
+     *
+     * @return CustomFilter populated from request parameters
+     */
+    private CustomFilter buildFilterFromRequest() {
+        String ticklerview = getStringParam("ticklerview", "A");
+        String providerview = getStringParam("providerview", "all");
+        String assignedTo = getStringParam("assignedTo", "all");
+        String mrpview = getStringParam("mrpview", "all");
+        String dateBegin = getStringParam("xml_vdate", "1950-01-01");
+        String dateEnd = getStringParam("xml_appointment_date", "");
+        int targetDemographic = parseIntParam("demographic_no", 0);
+
+        CustomFilter filter = new CustomFilter();
+        filter.setPriority(null);
+        filter.setStatus(ticklerview);
+        filter.setStartDateWeb(dateBegin);
+        filter.setEndDateWeb(dateEnd);
+
+        if (targetDemographic > 0) {
+            filter.setDemographicNo(String.valueOf(targetDemographic));
+            // When viewing a specific demographic's ticklers, only filter by
+            // demographic, status, and date range (matches old search_tickler_bydemo behavior)
+            filter.setMrp(null);
+            filter.setProvider(null);
+            filter.setAssignee(null);
+            if (dateEnd.isEmpty()) {
+                filter.setEndDateWeb("8888-12-31");
+            }
+        } else {
+            if (!mrpview.isEmpty() && !"all".equals(mrpview)) {
+                filter.setMrp(mrpview);
+            }
+            if (!providerview.isEmpty() && !"all".equals(providerview)) {
+                filter.setProvider(providerview);
+            }
+            if (!assignedTo.isEmpty() && !"all".equals(assignedTo)) {
+                filter.setAssignee(assignedTo);
+            }
+        }
+
+        filter.setSort_order("desc");
+        return filter;
+    }
+
+    /**
+     * Reads the tickler warning period from application properties.
+     *
+     * @return the number of days after which a tickler triggers a warning, or 0 if not configured
+     */
+    private long getTicklerWarnDays() {
+        String numDaysUntilWarn = OscarProperties.getInstance().getProperty("tickler_warn_period");
+        if (numDaysUntilWarn == null || numDaysUntilWarn.isEmpty()) {
+            numDaysUntilWarn = "0";
+        }
+        return Long.parseLong(numDaysUntilWarn);
+    }
+
+    private int parseIntParam(String name, int defaultValue) {
+        String val = request.getParameter(name);
+        if (val == null || val.isEmpty()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(val);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private String getStringParam(String name, String defaultValue) {
+        String val = request.getParameter(name);
+        if (val == null || val.isEmpty()) {
+            return defaultValue;
+        }
+        return val;
+    }
+}

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -87,7 +87,7 @@ public class TicklerList2Action extends ActionSupport {
 
         List<TicklerListDTO> ticklers;
         if (length <= 0) {
-            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, 0, totalRecords);
+            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, 0, 0);
         } else {
             ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, start, length);
         }

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/AllergyTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/AllergyTo1.java
@@ -68,6 +68,7 @@ public class AllergyTo1 {
 
     private int position = 0;
 
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date lastUpdateDate;
 
     private String providerNo;

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/AppointmentTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/AppointmentTo1.java
@@ -27,6 +27,8 @@ package ca.openosp.openo.webserv.rest.to.model;
 import java.io.Serializable;
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import ca.openosp.openo.commn.model.Appointment.BookingSource;
 import ca.openosp.openo.commn.model.Demographic;
 import ca.openosp.openo.commn.model.Provider;
@@ -62,8 +64,10 @@ public class AppointmentTo1 implements Serializable {
 
     private String importedStatus;
 
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date createDateTime = new Date();
 
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date updateDateTime = new Date();
 
     private String creator;

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/CaseManagementIssueTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/CaseManagementIssueTo1.java
@@ -26,6 +26,8 @@ package ca.openosp.openo.webserv.rest.to.model;
 
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 public class CaseManagementIssueTo1 {
 
     protected Long id;
@@ -36,7 +38,10 @@ public class CaseManagementIssueTo1 {
     protected boolean major;
     protected boolean resolved;
     protected String type;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     protected Date update_date = new Date();
+    
     protected IssueTo1 issue;
     protected Integer program_id = null;
     private boolean unsaved;

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/DemographicTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/DemographicTo1.java
@@ -32,6 +32,8 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 @XmlRootElement
 public class DemographicTo1 implements Serializable {
 
@@ -81,7 +83,10 @@ public class DemographicTo1 implements Serializable {
     private String displayName;
     private ProviderTo1 provider;
     private String lastUpdateUser;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date lastUpdateDate;
+
     private String title;
     private String officialLanguage;
     private String countryOfOrigin;

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/IssueTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/IssueTo1.java
@@ -29,6 +29,8 @@ import java.util.Date;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 
 @XmlRootElement(name = "issue")
 public class IssueTo1 implements Serializable {
@@ -44,7 +46,10 @@ public class IssueTo1 implements Serializable {
     private String code;
     private String description;
     private String role;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date update_date;
+    
     private String priority;
     private String type;
     private Integer sortOrderId;

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/MeasurementTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/MeasurementTo1.java
@@ -45,6 +45,8 @@ public class MeasurementTo1 {
     private Date dateObserved;
     
     private Integer appointmentNo;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date createDate = new Date();
 
     public Integer getId() {

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/NoteTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/NoteTo1.java
@@ -34,6 +34,9 @@ import java.util.Set;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import ca.openosp.openo.casemgmt.model.CaseManagementIssue;
 
 @XmlRootElement(name = "encounterNote")
@@ -43,9 +46,15 @@ public class NoteTo1 implements Serializable {
     private Boolean isSigned;
     private Boolean isVerified;
     private Boolean isEditable;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date observationDate;
+
     private String revision;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date updateDate;
+    
     private String providerName;
     private String providerNo;
     private String status;

--- a/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/omdAsthmaFlowsheet.xml
+++ b/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/omdAsthmaFlowsheet.xml
@@ -109,7 +109,7 @@
 			</rule>
 		</ruleset>
 	</item>	
-	<item measurement_type="AACP" display_name="Action Plan" guideline="" graphable="yes" value_name="Provided/Revised/Reviewed" />
+	<item measurement_type="AACP" display_name="Action Plan" guideline="" graphable="yes" value_name="Plan" />
 	<item measurement_type="ARMA" display_name="Medication Adherence" guideline="" graphable="yes" value_name="Reviewed" />
 	<item measurement_type="SMCS" display_name="Smoking Cessation" guideline="" graphable="yes" value_name="Reviewed" />
 	<item measurement_type="ARDT" display_name="Device Technique Optimal" guideline="" graphable="no" value_name="Reviewed" />

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -1530,6 +1530,8 @@
         <action name="tickler/AddTickler" class="ca.openosp.openo.tickler.pageUtil.AddTickler2Action">
             <result name="close">/close.html</result>
         </action>
+        <action name="tickler/ListTicklers" class="ca.openosp.openo.tickler.pageUtil.TicklerList2Action">
+        </action>
         <action name="eform/uploadHtml" class="ca.openosp.openo.eform.upload.HtmlUpload2Action">
             <result name="success">/eform/partials/upload.jsp</result>
             <result name="fail">/eform/partials/upload.jsp</result>

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -981,6 +981,7 @@
             <result name="success">/oscarEncounter/oscarConsultationRequest/config/EnableRequestResponse.jsp</result>
         </action>
         <action name="oscarEncounter/ConsultationLookup2Action" class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.ConsultationLookup2Action"/>
+        <action name="oscarEncounter/SpecialistList" class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.SpecialistList2Action"/>
         <action name="oscarEncounter/AddService" class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConAddService2Action">
             <result name="success">/oscarEncounter/oscarConsultationRequest/config/AddService.jsp</result>
         </action>

--- a/src/main/webapp/js/specialistListRenderer.js
+++ b/src/main/webapp/js/specialistListRenderer.js
@@ -1,0 +1,64 @@
+/**
+ * Shared batch renderer for specialist list pages (EditSpecialists, DisplayService).
+ *
+ * Fetches specialist JSON from SpecialistList2Action via POST and renders rows
+ * in batches using requestAnimationFrame for non-blocking DOM updates.
+ * Includes OWASP CsrfGuard token in the request header for CSRF protection.
+ *
+ * @param {Object} options
+ * @param {string} options.url - The fetch URL for the specialist data endpoint
+ * @param {string} options.tbodyId - The ID of the tbody element to render into
+ * @param {Function} options.buildRow - Function that receives a data row array and returns a tr element
+ * @param {string} options.csrfTokenName - The CSRF token header name from CsrfGuard
+ * @param {string} options.csrfTokenValue - The CSRF token value from CsrfGuard
+ * @since 2026-03-10
+ */
+function renderSpecialistList(options) {
+    var BATCH_SIZE = 1000;
+    var tbody = document.getElementById(options.tbodyId);
+    var firstBatchRendered = false;
+
+    function renderBatch(data, idx) {
+        var end = Math.min(idx + BATCH_SIZE, data.length);
+        var fragment = document.createDocumentFragment();
+        for (; idx < end; idx++) {
+            fragment.appendChild(options.buildRow(data[idx]));
+        }
+        tbody.appendChild(fragment);
+        if (!firstBatchRendered) {
+            firstBatchRendered = true;
+            HideSpin();
+        }
+        if (idx < data.length) {
+            requestAnimationFrame(function() { renderBatch(data, idx); });
+        }
+    }
+
+    var headers = {};
+    if (options.csrfTokenName) {
+        headers[options.csrfTokenName] = options.csrfTokenValue;
+    }
+
+    fetch(options.url, {
+        method: "POST",
+        headers: headers,
+        credentials: "same-origin"
+    })
+    .then(function(resp) {
+        if (!resp.ok) {
+            throw new Error("HTTP " + resp.status);
+        }
+        return resp.json();
+    })
+    .then(function(data) {
+        if (data.length === 0) {
+            HideSpin();
+        } else {
+            renderBatch(data, 0);
+        }
+    })
+    .catch(function(err) {
+        HideSpin();
+        console.error("Error loading specialists:", err);
+    });
+}

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -104,8 +104,6 @@
     <%
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
-        displayServiceUtil.estSpecialist();
-
         //multi-site support
         String appNo = request.getParameter("appNo");
         appNo = (appNo == null ? "" : appNo);

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
@@ -40,8 +40,6 @@
 %>
 
 <%@ page import="java.util.ResourceBundle" %>
-<%@ page import="org.owasp.encoder.Encode" %>
-<%@ page import="ca.openosp.openo.consultation.dto.SpecialistListDTO" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -53,7 +51,6 @@
     <jsp:useBean id="displayServiceUtil" scope="request"
                  class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConDisplayServiceUtil"/>
     <%
-        displayServiceUtil.loadSpecialists();
         String serviceId = (String) request.getAttribute("serviceId");
         String serviceDesc = displayServiceUtil.getServiceDesc(serviceId);
     %>
@@ -74,15 +71,8 @@
     </head>
     <body class="BodyStyle" vlink="#0000FF">
     <jsp:include page="/images/spinner.jsp" flush="true"/>
-    <script>
-        ShowSpin(true);
-        document.onreadystatechange = function () {
-            if (document.readyState === "interactive") {
-                HideSpin();
-            }
-        }
-    </script>
-    <% 
+    <script>ShowSpin(true);</script>
+    <%
     java.util.List<String> actionErrors = (java.util.List<String>) request.getAttribute("actionErrors");
     if (actionErrors != null && !actionErrors.isEmpty()) {
 %>
@@ -144,37 +134,7 @@
                                         </th>
 
                                     </tr>
-                                    <%
-                                        java.util.Vector specialistInField = displayServiceUtil.getSpecialistInField(serviceId);
-                                        for (SpecialistListDTO dto : displayServiceUtil.getSpecialists()) {
-                                            String specId = dto.getId().toString();
-                                            String fName = dto.getFirstName();
-                                            String lName = dto.getLastName();
-                                            String proLetters = dto.getProfessionalLetters();
-                                            String address = dto.getStreetAddress();
-                                            String phone = dto.getPhoneNumber();
-                                            String fax = dto.getFaxNumber();
-                                    %>
-                                    <tr>
-                                        <td>
-                                            <%if (specialistInField.contains(specId)) { %> <input type=checkbox
-                                                                                                  name="specialists"
-                                                                                                  value=<%=specId%> checked> <%} else {%>
-                                            <input type=checkbox name="specialists" value=<%=specId%>>
-                                            <%}%>
-                                        </td>
-                                        <td>
-                                            <%=Encode.forHtmlContent(lName + " " + fName + (proLetters == null ? "" : " " + proLetters))%>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(address) %>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(phone)%>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(fax)%>
-                                        </td>
-                                    </tr>
-                                    <%}%>
-
+                                    <tbody id="specialistBody"></tbody>
                                 </table>
 
                             </form></td>
@@ -188,5 +148,65 @@
             </tr>
         </table>
     </div>
+    <script>
+        (function() {
+            var BATCH_SIZE = 1000;
+            var tbody = document.getElementById("specialistBody");
+
+            function createCell(text) {
+                var td = document.createElement("td");
+                td.textContent = text;
+                return td;
+            }
+
+            function renderBatch(data, idx) {
+                var end = Math.min(idx + BATCH_SIZE, data.length);
+                var fragment = document.createDocumentFragment();
+                for (; idx < end; idx++) {
+                    var s = data[idx];
+                    var tr = document.createElement("tr");
+
+                    var cbTd = document.createElement("td");
+                    var cb = document.createElement("input");
+                    cb.type = "checkbox";
+                    cb.name = "specialists";
+                    cb.value = s[0];
+                    if (s[5]) cb.checked = true;
+                    cbTd.appendChild(cb);
+                    tr.appendChild(cbTd);
+
+                    tr.appendChild(createCell(s[1]));
+                    tr.appendChild(createCell(s[2]));
+                    tr.appendChild(createCell(s[3]));
+                    tr.appendChild(createCell(s[4]));
+
+                    fragment.appendChild(tr);
+                }
+                tbody.appendChild(fragment);
+                if (idx === Math.min(BATCH_SIZE, data.length)) {
+                    HideSpin();
+                }
+                if (idx < data.length) {
+                    requestAnimationFrame(function() { renderBatch(data, idx); });
+                }
+            }
+
+            fetch("<%= request.getContextPath() %>/oscarEncounter/SpecialistList.do?method=getSpecialistsForService&serviceId=<%=serviceId %>", {
+                method: "POST"
+            })
+            .then(function(resp) { return resp.json(); })
+            .then(function(data) {
+                if (data.length === 0) {
+                    HideSpin();
+                } else {
+                    renderBatch(data, 0);
+                }
+            })
+            .catch(function(err) {
+                HideSpin();
+                console.error("Error loading specialists:", err);
+            });
+        })();
+    </script>
     </body>
 </html>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
@@ -26,6 +26,7 @@
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib prefix="csrf" uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
@@ -152,6 +153,9 @@
     </div>
     <script>
         (function() {
+            var ctxPath = "<%= Encode.forJavaScript(request.getContextPath()) %>";
+            var serviceId = "<%= Encode.forJavaScript(serviceId) %>";
+
             function createCell(text) {
                 var td = document.createElement("td");
                 td.textContent = text;
@@ -159,7 +163,7 @@
             }
 
             renderSpecialistList({
-                url: "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/SpecialistList.do?method=getSpecialistsForService&serviceId=" + encodeURIComponent("<%= org.owasp.encoder.Encode.forJavaScript(serviceId) %>"),
+                url: ctxPath + "/oscarEncounter/SpecialistList.do?method=getSpecialistsForService&serviceId=" + encodeURIComponent(serviceId),
                 tbodyId: "specialistBody",
                 csrfTokenName: "<csrf:tokenname/>",
                 csrfTokenValue: "<csrf:tokenvalue/>",

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
@@ -41,6 +41,7 @@
 
 <%@ page import="java.util.ResourceBundle" %>
 <%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="ca.openosp.openo.consultation.dto.SpecialistListDTO" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -52,7 +53,7 @@
     <jsp:useBean id="displayServiceUtil" scope="request"
                  class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConDisplayServiceUtil"/>
     <%
-        displayServiceUtil.estSpecialistVector();
+        displayServiceUtil.loadSpecialists();
         String serviceId = (String) request.getAttribute("serviceId");
         String serviceDesc = displayServiceUtil.getServiceDesc(serviceId);
     %>
@@ -145,15 +146,14 @@
                                     </tr>
                                     <%
                                         java.util.Vector specialistInField = displayServiceUtil.getSpecialistInField(serviceId);
-                                        for (int i = 0; i < displayServiceUtil.specIdVec.size(); i++) {
-                                            String specId = displayServiceUtil.specIdVec.elementAt(i);
-                                            String fName = displayServiceUtil.fNameVec.elementAt(i);
-                                            String lName = displayServiceUtil.lNameVec.elementAt(i);
-                                            String proLetters = displayServiceUtil.proLettersVec.elementAt(i);
-                                            String address = displayServiceUtil.addressVec.elementAt(i);
-                                            String phone = displayServiceUtil.phoneVec.elementAt(i);
-                                            String fax = displayServiceUtil.faxVec.elementAt(i);
-
+                                        for (SpecialistListDTO dto : displayServiceUtil.getSpecialists()) {
+                                            String specId = dto.getId().toString();
+                                            String fName = dto.getFirstName();
+                                            String lName = dto.getLastName();
+                                            String proLetters = dto.getProfessionalLetters();
+                                            String address = dto.getStreetAddress();
+                                            String phone = dto.getPhoneNumber();
+                                            String fax = dto.getFaxNumber();
                                     %>
                                     <tr>
                                         <td>
@@ -164,8 +164,7 @@
                                             <%}%>
                                         </td>
                                         <td>
-                                            <%
-                                                out.print(Encode.forHtmlContent(lName + " " + fName + (proLetters == null ? "" : " " + proLetters))); %>
+                                            <%=Encode.forHtmlContent(lName + " " + fName + (proLetters == null ? "" : " " + proLetters))%>
                                         </td>
                                         <td><%=Encode.forHtmlContent(address) %>
                                         </td>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
@@ -25,6 +25,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib prefix="csrf" uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
@@ -68,6 +69,7 @@
         </script>
 
         <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/css/encounterStyles.css">
+        <script type="text/javascript" src="<%= request.getContextPath() %>/js/specialistListRenderer.js"></script>
     </head>
     <body class="BodyStyle" vlink="#0000FF">
     <jsp:include page="/images/spinner.jsp" flush="true"/>
@@ -150,20 +152,18 @@
     </div>
     <script>
         (function() {
-            var BATCH_SIZE = 1000;
-            var tbody = document.getElementById("specialistBody");
-
             function createCell(text) {
                 var td = document.createElement("td");
                 td.textContent = text;
                 return td;
             }
 
-            function renderBatch(data, idx) {
-                var end = Math.min(idx + BATCH_SIZE, data.length);
-                var fragment = document.createDocumentFragment();
-                for (; idx < end; idx++) {
-                    var s = data[idx];
+            renderSpecialistList({
+                url: "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/SpecialistList.do?method=getSpecialistsForService&serviceId=" + encodeURIComponent("<%= org.owasp.encoder.Encode.forJavaScript(serviceId) %>"),
+                tbodyId: "specialistBody",
+                csrfTokenName: "<csrf:tokenname/>",
+                csrfTokenValue: "<csrf:tokenvalue/>",
+                buildRow: function(s) {
                     var tr = document.createElement("tr");
 
                     var cbTd = document.createElement("td");
@@ -180,31 +180,8 @@
                     tr.appendChild(createCell(s[3]));
                     tr.appendChild(createCell(s[4]));
 
-                    fragment.appendChild(tr);
+                    return tr;
                 }
-                tbody.appendChild(fragment);
-                if (idx === Math.min(BATCH_SIZE, data.length)) {
-                    HideSpin();
-                }
-                if (idx < data.length) {
-                    requestAnimationFrame(function() { renderBatch(data, idx); });
-                }
-            }
-
-            fetch("<%= request.getContextPath() %>/oscarEncounter/SpecialistList.do?method=getSpecialistsForService&serviceId=<%=serviceId %>", {
-                method: "POST"
-            })
-            .then(function(resp) { return resp.json(); })
-            .then(function(data) {
-                if (data.length === 0) {
-                    HideSpin();
-                } else {
-                    renderBatch(data, 0);
-                }
-            })
-            .catch(function(err) {
-                HideSpin();
-                console.error("Error loading specialists:", err);
             });
         })();
     </script>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
@@ -26,6 +26,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ page import="java.util.List" %>
+<%@ page import="ca.openosp.openo.consultation.dto.SpecialistListDTO" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -45,7 +46,7 @@
     <jsp:useBean id="displayServiceUtil" scope="request"
                  class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConDisplayServiceUtil"/>
     <%
-        displayServiceUtil.estSpecialistVector();
+        displayServiceUtil.loadSpecialists();
     %>
     <head>
 
@@ -132,28 +133,22 @@
 
                                     </tr>
                                     <%
-
-                                        for (int i = 0; i < displayServiceUtil.specIdVec.size(); i++) {
-                                            String specId = displayServiceUtil.specIdVec.elementAt(i);
-                                            String fName = displayServiceUtil.fNameVec.elementAt(i);
-                                            String lName = displayServiceUtil.lNameVec.elementAt(i);
-                                            String proLetters = displayServiceUtil.proLettersVec.elementAt(i);
-                                            String address = displayServiceUtil.addressVec.elementAt(i);
-                                            String phone = displayServiceUtil.phoneVec.elementAt(i);
-                                            String fax = displayServiceUtil.faxVec.elementAt(i);
+                                        String contextPath = request.getContextPath();
+                                        for (SpecialistListDTO dto : displayServiceUtil.getSpecialists()) {
+                                            String specId = dto.getId().toString();
+                                            String fName = dto.getFirstName();
+                                            String lName = dto.getLastName();
+                                            String proLetters = dto.getProfessionalLetters();
+                                            String address = dto.getStreetAddress();
+                                            String phone = dto.getPhoneNumber();
+                                            String fax = dto.getFaxNumber();
                                     %>
 
                                     <tr>
                                         <td><input type="checkbox" name="specialists"
                                                    value="<%=specId%>"></td>
                                         <td>
-                                            <%
-                                                String contextPath = request.getContextPath();
-                                                String url = contextPath + "/oscarEncounter/EditSpecialists.do?specId=" + specId;
-                                                out.print("<a href=\"" + url + "\">");
-                                                out.print(Encode.forHtmlContent(lName + " " + fName + " " + (proLetters == null ? "" : proLetters)));
-                                                out.print("</a>");
-                                            %>
+                                            <a href="<%=contextPath%>/oscarEncounter/EditSpecialists.do?specId=<%=specId%>"><%=Encode.forHtmlContent(lName + " " + fName + " " + (proLetters == null ? "" : proLetters))%></a>
                                         </td>
                                         <td><%=Encode.forHtmlContent(address) %>
                                         </td>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
@@ -27,6 +27,7 @@
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib prefix="csrf" uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" %>
 <%@ page import="java.util.List" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -140,7 +141,8 @@
     </div>
     <script>
         (function() {
-            var editUrlPrefix = "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/EditSpecialists.do?specId=";
+            var ctxPath = "<%= Encode.forJavaScript(request.getContextPath()) %>";
+            var editUrlPrefix = ctxPath + "/oscarEncounter/EditSpecialists.do?specId=";
 
             function createCell(text) {
                 var td = document.createElement("td");
@@ -149,7 +151,7 @@
             }
 
             renderSpecialistList({
-                url: "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/SpecialistList.do?method=getSpecialists",
+                url: ctxPath + "/oscarEncounter/SpecialistList.do?method=getSpecialists",
                 tbodyId: "specialistBody",
                 csrfTokenName: "<csrf:tokenname/>",
                 csrfTokenValue: "<csrf:tokenvalue/>",

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
@@ -1,4 +1,4 @@
-<%@ page import="org.owasp.encoder.Encode" %><%--
+<%--
 
     Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
     This software is published under the GPL GNU General Public License.
@@ -26,7 +26,6 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ page import="java.util.List" %>
-<%@ page import="ca.openosp.openo.consultation.dto.SpecialistListDTO" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -45,9 +44,6 @@
 <html>
     <jsp:useBean id="displayServiceUtil" scope="request"
                  class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConDisplayServiceUtil"/>
-    <%
-        displayServiceUtil.loadSpecialists();
-    %>
     <head>
 
         <title><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.config.EditSpecialists.title"/>
@@ -65,15 +61,8 @@
 
     <body class="BodyStyle" vlink="#0000FF">
     <jsp:include page="/images/spinner.jsp" flush="true"/>
-    <script>
-        ShowSpin(true);
-        document.onreadystatechange = function () {
-            if (document.readyState === "interactive") {
-                HideSpin();
-            }
-        }
-    </script>
-    <% 
+    <script>ShowSpin(true);</script>
+    <%
     java.util.List<String> actionErrors = (java.util.List<String>) request.getAttribute("actionErrors");
     if (actionErrors != null && !actionErrors.isEmpty()) {
 %>
@@ -132,33 +121,7 @@
                                         </th>
 
                                     </tr>
-                                    <%
-                                        String contextPath = request.getContextPath();
-                                        for (SpecialistListDTO dto : displayServiceUtil.getSpecialists()) {
-                                            String specId = dto.getId().toString();
-                                            String fName = dto.getFirstName();
-                                            String lName = dto.getLastName();
-                                            String proLetters = dto.getProfessionalLetters();
-                                            String address = dto.getStreetAddress();
-                                            String phone = dto.getPhoneNumber();
-                                            String fax = dto.getFaxNumber();
-                                    %>
-
-                                    <tr>
-                                        <td><input type="checkbox" name="specialists"
-                                                   value="<%=specId%>"></td>
-                                        <td>
-                                            <a href="<%=contextPath%>/oscarEncounter/EditSpecialists.do?specId=<%=specId%>"><%=Encode.forHtmlContent(lName + " " + fName + " " + (proLetters == null ? "" : proLetters))%></a>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(address) %>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(phone)%>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(fax)%>
-                                        </td>
-                                    </tr>
-                                    <% }%>
-
+                                    <tbody id="specialistBody"></tbody>
                                 </table>
 
                             </form></td>
@@ -173,5 +136,71 @@
             </tr>
         </table>
     </div>
+    <script>
+        (function() {
+            var BATCH_SIZE = 1000;
+            var tbody = document.getElementById("specialistBody");
+            var editUrlPrefix = "<%= request.getContextPath() %>/oscarEncounter/EditSpecialists.do?specId=";
+
+            function createCell(text) {
+                var td = document.createElement("td");
+                td.textContent = text;
+                return td;
+            }
+
+            function renderBatch(data, idx) {
+                var end = Math.min(idx + BATCH_SIZE, data.length);
+                var fragment = document.createDocumentFragment();
+                for (; idx < end; idx++) {
+                    var s = data[idx];
+                    var tr = document.createElement("tr");
+
+                    var cbTd = document.createElement("td");
+                    var cb = document.createElement("input");
+                    cb.type = "checkbox";
+                    cb.name = "specialists";
+                    cb.value = s[0];
+                    cbTd.appendChild(cb);
+                    tr.appendChild(cbTd);
+
+                    var nameTd = document.createElement("td");
+                    var link = document.createElement("a");
+                    link.href = editUrlPrefix + s[0];
+                    link.textContent = s[1];
+                    nameTd.appendChild(link);
+                    tr.appendChild(nameTd);
+
+                    tr.appendChild(createCell(s[2]));
+                    tr.appendChild(createCell(s[3]));
+                    tr.appendChild(createCell(s[4]));
+
+                    fragment.appendChild(tr);
+                }
+                tbody.appendChild(fragment);
+                if (idx === Math.min(BATCH_SIZE, data.length)) {
+                    HideSpin();
+                }
+                if (idx < data.length) {
+                    requestAnimationFrame(function() { renderBatch(data, idx); });
+                }
+            }
+
+            fetch("<%= request.getContextPath() %>/oscarEncounter/SpecialistList.do?method=getSpecialists", {
+                method: "POST"
+            })
+            .then(function(resp) { return resp.json(); })
+            .then(function(data) {
+                if (data.length === 0) {
+                    HideSpin();
+                } else {
+                    renderBatch(data, 0);
+                }
+            })
+            .catch(function(err) {
+                HideSpin();
+                console.error("Error loading specialists:", err);
+            });
+        })();
+    </script>
     </body>
 </html>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
@@ -25,6 +25,7 @@
 --%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib prefix="csrf" uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" %>
 <%@ page import="java.util.List" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 <%
@@ -56,6 +57,7 @@
             }
         </script>
         <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/css/encounterStyles.css">
+        <script type="text/javascript" src="<%= request.getContextPath() %>/js/specialistListRenderer.js"></script>
 
     </head>
 
@@ -138,9 +140,7 @@
     </div>
     <script>
         (function() {
-            var BATCH_SIZE = 1000;
-            var tbody = document.getElementById("specialistBody");
-            var editUrlPrefix = "<%= request.getContextPath() %>/oscarEncounter/EditSpecialists.do?specId=";
+            var editUrlPrefix = "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/EditSpecialists.do?specId=";
 
             function createCell(text) {
                 var td = document.createElement("td");
@@ -148,11 +148,12 @@
                 return td;
             }
 
-            function renderBatch(data, idx) {
-                var end = Math.min(idx + BATCH_SIZE, data.length);
-                var fragment = document.createDocumentFragment();
-                for (; idx < end; idx++) {
-                    var s = data[idx];
+            renderSpecialistList({
+                url: "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/SpecialistList.do?method=getSpecialists",
+                tbodyId: "specialistBody",
+                csrfTokenName: "<csrf:tokenname/>",
+                csrfTokenValue: "<csrf:tokenvalue/>",
+                buildRow: function(s) {
                     var tr = document.createElement("tr");
 
                     var cbTd = document.createElement("td");
@@ -174,31 +175,8 @@
                     tr.appendChild(createCell(s[3]));
                     tr.appendChild(createCell(s[4]));
 
-                    fragment.appendChild(tr);
+                    return tr;
                 }
-                tbody.appendChild(fragment);
-                if (idx === Math.min(BATCH_SIZE, data.length)) {
-                    HideSpin();
-                }
-                if (idx < data.length) {
-                    requestAnimationFrame(function() { renderBatch(data, idx); });
-                }
-            }
-
-            fetch("<%= request.getContextPath() %>/oscarEncounter/SpecialistList.do?method=getSpecialists", {
-                method: "POST"
-            })
-            .then(function(resp) { return resp.json(); })
-            .then(function(data) {
-                if (data.length === 0) {
-                    HideSpin();
-                } else {
-                    renderBatch(data, 0);
-                }
-            })
-            .catch(function(err) {
-                HideSpin();
-                console.error("Error loading specialists:", err);
             });
         })();
     </script>

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
@@ -488,7 +488,7 @@
                                     <% String[] opts = validations.getName().contains("/") ? validations.getName().split("/") : validations.getRegularExp().split("\\|");
                                         boolean valFoundInOpts = false;
                                         for (String opt : opts) {
-                                            if (opt.equals(val)) valFoundInOpts = true;%>
+                                            if (val != null && opt.equals(val)) valFoundInOpts = true;%>
                                     <option value="<%=Encode.forHtmlAttribute(opt)%>"  <%=sel(opt, val)%>><%=Encode.forHtmlContent(opt)%>
                                     </option>
                                     <% }

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
@@ -489,7 +489,7 @@
                                         boolean valFoundInOpts = false;
                                         for (String opt : opts) {
                                             if (opt.equals(val)) valFoundInOpts = true;%>
-                                    <option value="<%=opt%>"  <%=sel(opt, val)%>><%=opt%>
+                                    <option value="<%=Encode.forHtmlAttribute(opt)%>"  <%=sel(opt, val)%>><%=Encode.forHtmlContent(opt)%>
                                     </option>
                                     <% }
                                         if (val != null && !val.isEmpty() && !valFoundInOpts) { %>

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
@@ -486,10 +486,16 @@
                                         name="<%= "inputValue-" + ctr %>">
                                     <option value=""></option>
                                     <% String[] opts = validations.getName().contains("/") ? validations.getName().split("/") : validations.getRegularExp().split("\\|");
-                                        for (String opt : opts) {%>
+                                        boolean valFoundInOpts = false;
+                                        for (String opt : opts) {
+                                            if (opt.equals(val)) valFoundInOpts = true;%>
                                     <option value="<%=opt%>"  <%=sel(opt, val)%>><%=opt%>
                                     </option>
-                                    <% }%>
+                                    <% }
+                                        if (val != null && !val.isEmpty() && !valFoundInOpts) { %>
+                                    <option value="<%=Encode.forHtmlAttribute(val)%>" selected disabled><%=Encode.forHtmlContent(val)%>
+                                    </option>
+                                    <% } %>
                                 </select>
                                 <%} else if (validations != null && validations.getName().startsWith("Integer")) { %>
                                 <select id="<%= "inputValue-" + ctr %>"

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -261,7 +261,7 @@
                 var safeTableId = encodeURIComponent(tableId);
                 var href;
                 if (type === 'MDS') {
-                    href = "javascript:reportWindow('SegmentDisplay.jsp?segmentID=" + safeTableId +
+                    href = "javascript:reportWindow('" + ctx + "/oscarMDS/SegmentDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 } else if (type === 'CML') {
                     href = "javascript:reportWindow('" + ctx + "/lab/CA/ON/CMLDisplay.jsp?segmentID=" + safeTableId +

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -36,6 +36,7 @@
 <%@ page import="ca.openosp.openo.commn.model.Site" %>
 <%@ page import="ca.openosp.openo.commn.dao.SiteDao" %>
 <%@ page import="java.util.*" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -205,7 +206,7 @@
 
 
             const ctx = '${pageContext.request.contextPath}';
-            const userNo = '<%=user_no%>';
+            const userNo = '<%=Encode.forJavaScript(user_no)%>';
 
             function escapeHtml(text) {
                 if (!text) return '';
@@ -687,12 +688,12 @@
                     <div class="form-group">
                         <label for="xml_vdate">From</label>
                         <input type="date" class="form-control" name="xml_vdate" id="xml_vdate"
-                               value="<%=xml_vdate%>">
+                               value="<%=Encode.forHtmlAttribute(xml_vdate)%>">
                     </div>
                     <div class="form-group">
                         <label for="xml_appointment_date">To</label>
                         <input type="date" class="form-control" name="xml_appointment_date" id="xml_appointment_date"
-                               value="<%=xml_appointment_date%>">
+                               value="<%=Encode.forHtmlAttribute(xml_appointment_date)%>">
                     </div>
 
                     <div class="form-group">
@@ -704,8 +705,8 @@
                                 List<Provider> providers = providerDao.getActiveProviders();
                                 for (Provider p : providers) {
                             %>
-                            <option value="<%=p.getProviderNo()%>" <%=mrpview.equals(p.getProviderNo()) ? "selected" : ""%>><%=p.getLastName()%>
-                                ,<%=p.getFirstName()%>
+                            <option value="<%=Encode.forHtmlAttribute(p.getProviderNo())%>" <%=mrpview.equals(p.getProviderNo()) ? "selected" : ""%>><%=Encode.forHtml(p.getLastName())%>
+                                ,<%=Encode.forHtml(p.getFirstName())%>
                             </option>
                             <%
                                 }
@@ -720,8 +721,8 @@
                             <%
                                 for (Provider p : providers) {
                             %>
-                            <option value="<%=p.getProviderNo()%>" <%=providerview.equals(p.getProviderNo()) ? "selected" : ""%>><%=p.getLastName()%>
-                                ,<%=p.getFirstName()%>
+                            <option value="<%=Encode.forHtmlAttribute(p.getProviderNo())%>" <%=providerview.equals(p.getProviderNo()) ? "selected" : ""%>><%=Encode.forHtml(p.getLastName())%>
+                                ,<%=Encode.forHtml(p.getFirstName())%>
                             </option>
                             <%
                                 }
@@ -738,10 +739,10 @@
                         <script>
                             let _providers = [];
                             <%for (int i=0; i<sites.size(); i++) {%>
-                            _providers["<%=sites.get(i).getSiteId()%>"] = "<%Iterator<Provider> iter = sites.get(i).getProviders().iterator();
+                            _providers["<%=Encode.forJavaScript(sites.get(i).getSiteId().toString())%>"] = "<%Iterator<Provider> iter = sites.get(i).getProviders().iterator();
 							while (iter.hasNext()) {
 								Provider p=iter.next();
-								if ("1".equals(p.getStatus())) {%><option value='<%=p.getProviderNo()%>'><%=p.getLastName()%>, <%=p.getFirstName()%></option><%}%>";
+								if ("1".equals(p.getStatus())) {%><option value='<%=Encode.forJavaScript(p.getProviderNo())%>'><%=Encode.forJavaScript(p.getLastName())%>, <%=Encode.forJavaScript(p.getFirstName())%><\/option><%}%>";
                             <%}}%>
 
                             function changeSite(sel) {
@@ -753,7 +754,7 @@
                             <%
                                 for (int i = 0; i < sites.size(); i++) {
                             %>
-                            <option value="<%=sites.get(i).getSiteId()%>" <%=sites.get(i).getSiteId().toString().equals(request.getParameter("site")) ? "selected" : ""%>><%=sites.get(i).getName()%>
+                            <option value="<%=Encode.forHtmlAttribute(sites.get(i).getSiteId().toString())%>" <%=sites.get(i).getSiteId().toString().equals(request.getParameter("site")) ? "selected" : ""%>><%=Encode.forHtml(sites.get(i).getName())%>
                             </option>
                             <%
                                 }
@@ -765,7 +766,7 @@
                         %>
                         <script>
                             changeSite(document.getElementById("site"));
-                            document.getElementById("assignedTo").value = '<%=request.getParameter("assignedTo")%>';
+                            document.getElementById("assignedTo").value = '<%=Encode.forJavaScript(request.getParameter("assignedTo"))%>';
                         </script>
                         <%
                             }
@@ -786,8 +787,8 @@
                                 List<Provider> providersActive = providerDao.getActiveProviders();
                                 for (Provider p : providersActive) {
                             %>
-                            <option value="<%=p.getProviderNo()%>" <%=assignedTo.equals(p.getProviderNo()) ? "selected" : ""%>><%=p.getLastName()%>
-                                , <%=p.getFirstName()%>
+                            <option value="<%=Encode.forHtmlAttribute(p.getProviderNo())%>" <%=assignedTo.equals(p.getProviderNo()) ? "selected" : ""%>><%=Encode.forHtml(p.getLastName())%>
+                                , <%=Encode.forHtml(p.getFirstName())%>
                             </option>
                             <%
                                 }

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -258,24 +258,25 @@
 
             function buildAttachmentLink(type, tableId) {
                 var uNo = encodeURIComponent(userNo);
+                var safeTableId = encodeURIComponent(tableId);
                 var href;
                 if (type === 'MDS') {
-                    href = "javascript:reportWindow('SegmentDisplay.jsp?segmentID=" + tableId +
+                    href = "javascript:reportWindow('SegmentDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 } else if (type === 'CML') {
-                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ON/CMLDisplay.jsp?segmentID=" + tableId +
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ON/CMLDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 } else if (type === 'HL7') {
-                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ALL/labDisplay.jsp?segmentID=" + tableId +
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ALL/labDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 } else if (type === 'DOC') {
-                    href = "javascript:reportWindow('" + ctx + "/documentManager/ManageDocument.do?method=display&doc_no=" + tableId +
+                    href = "javascript:reportWindow('" + ctx + "/documentManager/ManageDocument.do?method=display&doc_no=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 } else if (type === 'HRM') {
-                    href = "javascript:reportWindow('" + ctx + "/hospitalReportManager/Display.do?id=" + tableId +
-                        "&segmentID=" + tableId + "')";
+                    href = "javascript:reportWindow('" + ctx + "/hospitalReportManager/Display.do?id=" + safeTableId +
+                        "&segmentID=" + safeTableId + "')";
                 } else {
-                    href = "javascript:reportWindow('" + ctx + "/lab/CA/BC/labDisplay.jsp?segmentID=" + tableId +
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/BC/labDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 }
                 return ' <a title="View attachment" href="' + href +
@@ -350,6 +351,8 @@
                         let api = this.api();
                         let rows = api.rows({page: 'current'}).nodes();
                         let numCols = jQuery('#ticklerResults thead th').length;
+
+                        jQuery('#ticklerResults tbody tr.comment-row').remove();
 
                         api.column(idColumn, {page: 'current'})
                             .data()
@@ -751,8 +754,8 @@
                             _providers["<%=Encode.forJavaScript(sites.get(i).getSiteId().toString())%>"] = "<%Iterator<Provider> iter = sites.get(i).getProviders().iterator();
 							while (iter.hasNext()) {
 								Provider p=iter.next();
-								if ("1".equals(p.getStatus())) {%><option value='<%=Encode.forJavaScript(p.getProviderNo())%>'><%=Encode.forJavaScript(p.getLastName())%>, <%=Encode.forJavaScript(p.getFirstName())%><\/option><%}%>";
-                            <%}}%>
+								if ("1".equals(p.getStatus())) {%><option value='<%=Encode.forJavaScript(Encode.forHtmlAttribute(p.getProviderNo()))%>'><%=Encode.forJavaScript(Encode.forHtml(p.getLastName()))%>, <%=Encode.forJavaScript(Encode.forHtml(p.getFirstName()))%><\/option><%}}%>";
+                            <%}%>
 
                             function changeSite(sel) {
                                 sel.form.assignedTo.innerHTML = sel.value == "none" ? "" : _providers[sel.value];

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -685,7 +685,8 @@
                             href="javascript:void(0)" id="dateRange" onClick="allYear()"><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.btnViewAll"/></a></label>
                     <div class="form-group">
                         <label for="xml_vdate">From</label>
-                        <input type="date" class="form-control" name="xml_vdate" id="xml_vdate">
+                        <input type="date" class="form-control" name="xml_vdate" id="xml_vdate"
+                               value="<%=xml_vdate%>">
                     </div>
                     <div class="form-group">
                         <label for="xml_appointment_date">To</label>

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -24,12 +24,10 @@
 
 --%>
 <!DOCTYPE html>
-<%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.*" %>
-<%@ page import="ca.openosp.openo.lab.ca.on.*" %>
 <%@ page import="ca.openosp.openo.PMmodule.dao.ProviderDao" %>
 <%@ page import="ca.openosp.openo.commn.dao.ViewDao" %>
 <%@ page import="ca.openosp.openo.commn.model.View" %>
@@ -37,19 +35,7 @@
 <%@ page import="ca.openosp.OscarProperties" %>
 <%@ page import="ca.openosp.openo.commn.model.Site" %>
 <%@ page import="ca.openosp.openo.commn.dao.SiteDao" %>
-<%@ page import="ca.openosp.openo.commn.model.CustomFilter" %>
-<%@ page import="ca.openosp.openo.managers.TicklerManager" %>
-<%@ page import="ca.openosp.openo.tickler.dto.TicklerListDTO" %>
-<%@ page import="ca.openosp.openo.tickler.dto.TicklerCommentDTO" %>
-<%@ page import="ca.openosp.openo.tickler.dto.TicklerLinkDTO" %>
-<%@ page import="java.text.DateFormat" %>
-<%@ page import="java.text.SimpleDateFormat" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.util.*" %>
-<%@ page import="java.time.ZoneId" %>
-<%@ page import="java.time.LocalDateTime" %>
-<%@ page import="java.time.Duration" %>
-<%@ page import="ca.openosp.openo.lab.ca.on.LabResultData" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -69,7 +55,6 @@
     }
 %>
 <%!
-    TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     ViewDao viewDao = SpringUtils.getBean(ViewDao.class);
 %>
 
@@ -79,7 +64,6 @@
         labReqVer = "07";
     }
 
-    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
     String user_no = (String) session.getAttribute("user");
     String createReport = request.getParameter("Submit");
     boolean doCreateReport = createReport != null && createReport.equals("Create Report");
@@ -221,6 +205,86 @@
 
 
             const ctx = '${pageContext.request.contextPath}';
+            const userNo = '<%=user_no%>';
+
+            function escapeHtml(text) {
+                if (!text) return '';
+                var div = document.createElement('div');
+                div.appendChild(document.createTextNode(text));
+                return div.innerHTML;
+            }
+
+            function renderCheckbox(data, type, row) {
+                if (row.rowType === 'comment') return '';
+                return '<input type="checkbox" name="checkbox" value="' + row.id + '" class="noprint">';
+            }
+
+            function renderEditIcon(data, type, row) {
+                if (row.rowType === 'comment') return '';
+                return '<a href="javascript:void(0)" title="Edit Tickler" ' +
+                    'onClick="window.open(\'' + ctx + '/tickler/ticklerEdit.jsp?tickler_no=' + row.id +
+                    '\', \'edit_tickler\', \'width=800, height=650\')">' +
+                    '<span class="glyphicon glyphicon-pencil"></span></a>';
+            }
+
+            function renderDemoName(data, type, row) {
+                var name = escapeHtml(row.demoLastName) + ',' + escapeHtml(row.demoFirstName);
+                if (row.rowType === 'comment') return name;
+                return '<a href="javascript:void(0)" ' +
+                    'onClick="popupPage(600,800,\'' + ctx +
+                    '/demographic/demographiccontrol.jsp?demographic_no=' +
+                    encodeURIComponent(row.demoNo) +
+                    '&displaymode=edit&dboperation=search_detail\')">' + name + '</a>';
+            }
+
+            function renderText(data) {
+                return escapeHtml(data);
+            }
+
+            function renderMessage(data, type, row) {
+                var html = '<span style="white-space:pre-wrap">' + escapeHtml(row.message) + '</span>';
+                if (row.rowType === 'tickler' && row.links) {
+                    for (var i = 0; i < row.links.length; i++) {
+                        html += buildAttachmentLink(row.links[i].tableName, row.links[i].tableId);
+                    }
+                }
+                return html;
+            }
+
+            function renderNoteIcon(data, type, row) {
+                if (row.rowType === 'comment') return '';
+                return '<a href="javascript:void(0)" class="noteDialogLink noprint" ' +
+                    'onClick="openNoteDialog(\'' + row.demoNo + '\',\'' + row.id + '\')" ' +
+                    'title="Add Encounter Note">' +
+                    '<span class="glyphicon glyphicon-comment"></span></a>';
+            }
+
+            function buildAttachmentLink(type, tableId) {
+                var uNo = encodeURIComponent(userNo);
+                var href;
+                if (type === 'MDS') {
+                    href = "javascript:reportWindow('SegmentDisplay.jsp?segmentID=" + tableId +
+                        "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
+                } else if (type === 'CML') {
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ON/CMLDisplay.jsp?segmentID=" + tableId +
+                        "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
+                } else if (type === 'HL7') {
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ALL/labDisplay.jsp?segmentID=" + tableId +
+                        "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
+                } else if (type === 'DOC') {
+                    href = "javascript:reportWindow('" + ctx + "/documentManager/ManageDocument.do?method=display&doc_no=" + tableId +
+                        "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
+                } else if (type === 'HRM') {
+                    href = "javascript:reportWindow('" + ctx + "/hospitalReportManager/Display.do?id=" + tableId +
+                        "&segmentID=" + tableId + "')";
+                } else {
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/BC/labDisplay.jsp?segmentID=" + tableId +
+                        "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
+                }
+                return ' <a title="View attachment" href="' + href +
+                    '"><i class="glyphicon glyphicon-paperclip"></i></a>';
+            }
+
             let ticklerResultsTable;
             jQuery(document).ready(function () {
                 jQuery("#note-form").dialog({
@@ -241,45 +305,63 @@
                 //     }
                 // });
                 let groupColumn = 11;
+                let warningColumn = 12;
                 ticklerResultsTable = jQuery("#ticklerResults").dataTable({
-                    // cache the datatable state to persist through page refreshes
-                    bStateSave: true,
-                    fnStateSave: function (oSettings, oData) {
+                    "bStateSave": true,
+                    "fnStateSave": function (oSettings, oData) {
                         localStorage.setItem('ticklerDataTable', JSON.stringify(oData));
                     },
-                    fnStateLoad: function () {
+                    "fnStateLoad": function () {
                         return JSON.parse(localStorage.getItem('ticklerDataTable'));
                     },
                     "searching": false,
                     "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],
                     "iDisplayLength": 50,
-                    columns: [
-                        {orderable: false}, //checkbox column, so shouldn't be orderable
-                        {orderable: false}, //edit icon column, so shouldn't be orderable
-                        {orderable: false}, //demographic name column. should not be made orderable until row group is refactored, otherwise tickler comments are not grouped properly
-                        {orderable: false}, //creator column. should not be made orderable until row group is refactored, otherwise tickler comments are not grouped properly
-                        {}, //service date column
-                        {orderable: false}, //update date column
-                        {}, //priority column
-                        {orderable: false}, //assigned to column. should not be made orderable until row group is refactored, otherwise tickler comments are not grouped properly
-                        {orderable: false}, //status column. should not be made orderable until row group is refactored, otherwise tickler comments are not grouped properly
-                        {orderable: false}, //comment column.
-                        {orderable: false}, //note icon column, so shouldn't be orderable
-                        {orderable: false} //hidden group id column, so shouldn't be orderable
+                    "serverSide": true,
+                    "ajax": {
+                        "url": ctx + "/tickler/ListTicklers.do",
+                        "data": function (d) {
+                            d.ticklerview = jQuery("#ticklerview").val();
+                            d.providerview = jQuery("#providerview").val() || "all";
+                            d.assignedTo = jQuery("#assignedTo").val() || "all";
+                            d.mrpview = jQuery("#mrpview").val() || "all";
+                            d.xml_vdate = jQuery("#xml_vdate").val() || "";
+                            d.xml_appointment_date = jQuery("#xml_appointment_date").val() || "";
+                            d.demographic_no = jQuery("input[name='demoview']").val() || "0";
+                        }
+                    },
+                    "columns": [
+                        {data: null, orderable: false, render: renderCheckbox},
+                        {data: null, orderable: false, render: renderEditIcon},
+                        {data: null, orderable: false, render: renderDemoName},
+                        {data: "creator", orderable: false, render: renderText},
+                        {data: "serviceDate", orderable: false},
+                        {data: "createDate", orderable: false},
+                        {data: "priority", orderable: false},
+                        {data: "assignee", orderable: false, render: renderText},
+                        {data: "status", orderable: false, render: renderText},
+                        {data: null, orderable: false, render: renderMessage},
+                        {data: null, orderable: false, render: renderNoteIcon},
+                        {data: "id", orderable: false},
+                        {data: "rowType", orderable: false}
                     ],
-                    columnDefs: [
-                        {visible: false, targets: groupColumn}
+                    "columnDefs": [
+                        {visible: false, targets: groupColumn},
+                        {visible: false, targets: warningColumn}
                     ],
-                    drawCallback: function (settings) {
+                    "createdRow": function (row, data, dataIndex) {
+                        if (data.warning === true) {
+                            jQuery(row).addClass('error');
+                        } else if (data.rowType === 'comment') {
+                            jQuery(row).addClass('followup-comment-' + data.id + ' comment-row no-sort');
+                        }
+                    },
+                    "drawCallback": function (settings) {
                         let api = this.api();
                         let rows = api.rows({page: 'current'}).nodes();
                         let last = null;
 
-                        api.column(groupColumn, {page: 'current'}) //TODO: this code reorders the rows on the current page, the global order based on the current sort.
-                            //      this means if a global sort is done that results in the tickler comments to NOT be on the current page
-                            //      they will not be visible.  A workaround has been implemented by adding the service date and priority
-                            //      into the tickler comment rows as well.  The datatables row group plugin might be a better approach,
-                            //      but will require refactoring of this code
+                        api.column(groupColumn, {page: 'current'})
                             .data()
                             .each(function (group, i) {
                                 if (last !== group) {
@@ -290,16 +372,14 @@
                                 }
                             });
                     },
-                    order: [[4, 'desc']]
-
+                    "order": [[4, 'desc']]
                 })
 
                 /*
-                 * Reload the search results with the Tickler status is changed.
+                 * Reload the search results when the Tickler status is changed.
                  */
                 jQuery("#ticklerview").change(function () {
-                    document.forms['serviceform'].Submit.value = 'Create Report';
-                    document.forms['serviceform'].submit();
+                    ticklerResultsTable.api().ajax.reload();
                 })
 
             });
@@ -741,6 +821,7 @@
                 </div>
 
             </c:if>
+            <c:if test="${not empty param.demoview}">
             <div class="pull-left" style="margin-bottom:10px;">
                 <label for="ticklerview">Filter</label>
                 <select id="ticklerview" class="form-control" name="ticklerview">
@@ -749,10 +830,10 @@
                     <option value="D" <%=ticklerview.equals("D") ? "selected" : ""%>><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.formDeleted"/></option>
                 </select>
             </div>
+            </c:if>
         </form>
 
         <form name="ticklerform" method="post" action="dbTicklerMain.jsp">
-            <% Locale locale = request.getLocale();%>
             <input type="hidden" name="parentAjaxId" value="<c:out value='${param.parentAjaxId}' />"/>
             <table id="ticklerResults" class="table table-striped table-compact" style="width:100%">
                 <thead>
@@ -788,217 +869,10 @@
                     </th>
                     <th></th>
                     <th></th>
+                    <th></th>
                 </tr>
                 </thead>
                 <tbody>
-                <%
-                    String dateBegin = xml_vdate;
-                    String dateEnd = xml_appointment_date;
-
-                    String vGrantdate = "1980-01-07 00:00:00.0";
-                    DateFormat datetimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", locale);
-                    DateFormat dateOnlyFormat = new SimpleDateFormat("yyyy-MM-dd", locale);
-                    DateFormat timeOnlyFormat = new SimpleDateFormat("HH:mm:ss", locale);
-
-                    if (dateEnd.compareTo("") == 0) {
-                        dateEnd = MyDateFormat.getMysqlStandardDate(curYear, curMonth, curDay);
-                    }
-
-                    if (dateBegin.compareTo("") == 0) {
-                        dateBegin = "1950-01-01"; // any early start date should suffice for selecting since the beginning
-                    }
-
-                    CustomFilter filter = new CustomFilter();
-                    filter.setPriority(null);
-
-                    filter.setStatus(ticklerview);
-
-                    filter.setStartDateWeb(dateBegin);
-                    filter.setEndDateWeb(dateEnd);
-                    filter.setPriority(null);
-
-                    if (!mrpview.isEmpty() && !mrpview.equals("all")) {
-                        filter.setMrp(mrpview);
-                    }
-
-                    if (!providerview.isEmpty() && !providerview.equals("all")) {
-                        filter.setProvider(providerview);
-                    }
-
-                    if (!assignedTo.isEmpty() && !assignedTo.equals("all")) {
-                        filter.setAssignee(assignedTo);
-                    }
-
-                    filter.setSort_order("desc");
-
-                    int targetDemographic = Integer.parseInt(demographic_no);
-                    if (targetDemographic > 0) {
-                        filter.setDemographicNo(String.valueOf(targetDemographic));
-                        // Preserve old search_tickler_bydemo behavior: when viewing a specific
-                        // demographic's ticklers, only filter by demographic, status, and date range
-                        filter.setMrp(null);
-                        filter.setProvider(null);
-                        filter.setAssignee(null);
-                        filter.setPriority(null);
-                        filter.setProgramId(null);
-                        filter.setMessage(null);
-                        filter.setClient(null);
-                    }
-
-                    // Use DTO projection for optimized list view (reduces queries from ~25 to 3)
-                    List<TicklerListDTO> ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter);
-
-                    String numDaysUntilWarn = OscarProperties.getInstance().getProperty("tickler_warn_period");
-                    if (numDaysUntilWarn == null || numDaysUntilWarn.isEmpty()) {
-                        numDaysUntilWarn = "0";
-                    }
-
-                    // Single rendering path using DTOs
-                    for (TicklerListDTO tickler : ticklers) {
-                            LocalDateTime serviceDate = tickler.getServiceDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-                            LocalDateTime currentDate = LocalDateTime.now();
-
-                            long daysDifference = Duration.between(serviceDate, currentDate).toDays();
-                            long ticklerWarnDays = Long.parseLong(numDaysUntilWarn);
-                            boolean ignoreWarning = (ticklerWarnDays <= 0);
-                            boolean warning = false;
-
-                            String warnColour = "";
-                            if (!ignoreWarning && (daysDifference >= ticklerWarnDays)) {
-                                warnColour = "Red";
-                                warning = true;
-                            }
-
-                            String cellColour = warnColour;
-                %>
-
-                <tr <%=warning ? "class='error'" : ""%> >
-                    <td class="<%=cellColour%>"><input type="checkbox" name="checkbox" value="<%=tickler.getId()%>"
-                                                       class="noprint"></td>
-                    <td class="<%=cellColour%>">
-                        <a href="javascript:void(0)" title="<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.editTickler"/>"
-                           onClick="window.open('<%= request.getContextPath() %>/tickler/ticklerEdit.jsp?tickler_no=<%=tickler.getId()%>', 'edit_tickler', 'width=800, height=650')">
-                            <span class="glyphicon glyphicon-pencil"></span>
-                        </a>
-                    </td>
-                    <td class="<%=cellColour%>"><a href="javascript:void(0)"
-                                                   onClick="popupPage(600,800,'<%= request.getContextPath() %>/demographic/demographiccontrol.jsp?demographic_no=<%=Encode.forUriComponent(String.valueOf(tickler.getDemographicNo()))%>&displaymode=edit&dboperation=search_detail')">
-                        <%=Encode.forHtmlContent(tickler.getDemographicLastName())%>,<%=Encode.forHtmlContent(tickler.getDemographicFirstName())%>
-                    </a></td>
-                    <td class="<%=cellColour%>"><%=Encode.forHtmlContent(tickler.getCreatorFormattedName())%>
-                    </td>
-                    <td class="<%=cellColour%>"><%=dateOnlyFormat.format(tickler.getServiceDate())%>
-                    </td>
-                    <td class="<%=cellColour%>"><%=datetimeFormat.format(tickler.getCreateDate())%>
-                    </td>
-                    <td class="<%=cellColour%>"><%=tickler.getPriority()%>
-                    </td>
-                    <td class="<%=cellColour%>"><%=Encode.forHtmlContent(tickler.getAssigneeFormattedName())%>
-                    </td>
-                    <td class="<%=cellColour%>"><%=tickler.getStatusDesc(locale)%>
-                    </td>
-                    <td class="<%=cellColour%>"><span
-                            style="white-space:pre-wrap"><%=Encode.forHtmlContent(tickler.getMessage())%></span>
-
-                        <%
-                            List<TicklerLinkDTO> linkList = tickler.getLinks();
-                            if (linkList != null) {
-                                for (TicklerLinkDTO tl : linkList) {
-                                    String type = tl.getTableName();
-                        %>
-
-                        <%
-                            if (LabResultData.isMDS(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('SegmentDisplay.jsp?segmentID=<%=tl.getTableId()%>&providerNo=<%=user_no%>&searchProviderNo=<%=user_no%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else if (LabResultData.isCML(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/ON/CMLDisplay.jsp?segmentID=<%=tl.getTableId()%>&providerNo=<%=user_no%>&searchProviderNo=<%=user_no%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else if (LabResultData.isHL7TEXT(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/ALL/labDisplay.jsp?segmentID=<%=tl.getTableId()%>&providerNo=<%=user_no%>&searchProviderNo=<%=user_no%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else if (LabResultData.isDocument(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%=request.getContextPath()%>/documentManager/ManageDocument.do?method=display&doc_no=<%=tl.getTableId()%>&providerNo=<%=user_no%>&searchProviderNo=<%=user_no%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else if (LabResultData.isHRM(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%=request.getContextPath()%>/hospitalReportManager/Display.do?id=<%=tl.getTableId()%>&segmentID=<%=tl.getTableId()%>')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/BC/labDisplay.jsp?segmentID=<%=tl.getTableId()%>&providerNo=<%=user_no%>&searchProviderNo=<%=user_no%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                            }
-                        %>
-                        <%
-                                }
-                            }
-                        %>
-
-                    </td>
-                    <td class="<%=cellColour%> noprint">
-                        <a href="javascript:void(0)" class="noteDialogLink"
-                           onClick="openNoteDialog('<%=Encode.forJavaScriptAttribute(String.valueOf(tickler.getDemographicNo()))%>','<%=Encode.forJavaScriptAttribute(String.valueOf(tickler.getId()))%>')"
-                           title="Add Encounter Note">
-                            <span class="glyphicon glyphicon-comment"></span>
-                        </a>
-                    </td>
-                    <td><%=tickler.getId()%>
-                    </td>
-                </tr>
-                <% List<TicklerCommentDTO> tcomments = tickler.getComments();
-                    for (TicklerCommentDTO tc : tcomments) {
-                        String formattedName = tc.getProviderFormattedName();
-                %>
-
-
-                <tr class="followup-comment-<%=tickler.getId()%> comment-row no-sort">
-                    <td></td>
-                    <td></td>
-                    <td><%=Encode.forHtmlContent(tickler.getDemographicLastName())%>,<%=Encode.forHtmlContent(tickler.getDemographicFirstName())%>
-                    </td>
-                    <td class="no-sort"><%=Encode.forHtmlContent(formattedName)%>
-                    </td>
-                    <td><%=dateOnlyFormat.format(tickler.getServiceDate())%>
-                    </td>
-
-                    <td class="no-sort">
-                        <% if (tc.isUpdateDateToday()) { %>
-                        <%=timeOnlyFormat.format(tc.getUpdateDate())%>
-                        <% } else { %>
-                        <%=datetimeFormat.format(tc.getUpdateDate())%>
-                        <% } %>
-                    </td>
-
-                    <td><%=tickler.getPriority()%>
-                    </td>
-                    <td></td>
-                    <td></td>
-                    <td class="no-sort" style="white-space:pre-wrap"><%=Encode.forHtmlContent(tc.getMessage())%>
-                    </td>
-                    <td></td>
-                    <td><%=tickler.getId()%>
-                    </td>
-                </tr>
-                <% }
-                }
-                %>
                 </tbody>
             </table>
 

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -306,7 +306,7 @@
                 //     }
                 // });
                 let groupColumn = 11;
-                let warningColumn = 12;
+                let rowTypeColumn = 12;
                 ticklerResultsTable = jQuery("#ticklerResults").dataTable({
                     "searching": false,
                     "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],
@@ -341,7 +341,7 @@
                     ],
                     "columnDefs": [
                         {visible: false, targets: groupColumn},
-                        {visible: false, targets: warningColumn}
+                        {visible: false, targets: rowTypeColumn}
                     ],
                     "createdRow": function (row, data, dataIndex) {
                         if (data.warning === true) {
@@ -366,7 +366,7 @@
                                 }
                             });
                     },
-                    "order": JSON.parse(localStorage.getItem('ticklerSortOrder')) || [[4, 'desc']]
+                    "order": (function() { try { return JSON.parse(localStorage.getItem('ticklerSortOrder')) || [[4, 'desc']]; } catch(e) { return [[4, 'desc']]; } })()
                 })
 
                 ticklerResultsTable.api().on('length.dt', function (e, settings, len) {

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -216,12 +216,10 @@
             }
 
             function renderCheckbox(data, type, row) {
-                if (row.rowType === 'comment') return '';
                 return '<input type="checkbox" name="checkbox" value="' + row.id + '" class="noprint">';
             }
 
             function renderEditIcon(data, type, row) {
-                if (row.rowType === 'comment') return '';
                 return '<a href="javascript:void(0)" title="Edit Tickler" ' +
                     'onClick="window.open(\'' + ctx + '/tickler/ticklerEdit.jsp?tickler_no=' + row.id +
                     '\', \'edit_tickler\', \'width=800, height=650\')">' +
@@ -230,7 +228,6 @@
 
             function renderDemoName(data, type, row) {
                 var name = escapeHtml(row.demoLastName) + ',' + escapeHtml(row.demoFirstName);
-                if (row.rowType === 'comment') return name;
                 return '<a href="javascript:void(0)" ' +
                     'onClick="popupPage(600,800,\'' + ctx +
                     '/demographic/demographiccontrol.jsp?demographic_no=' +
@@ -244,7 +241,7 @@
 
             function renderMessage(data, type, row) {
                 var html = '<span style="white-space:pre-wrap">' + escapeHtml(row.message) + '</span>';
-                if (row.rowType === 'tickler' && row.links) {
+                if (row.links) {
                     for (var i = 0; i < row.links.length; i++) {
                         html += buildAttachmentLink(row.links[i].tableName, row.links[i].tableId);
                     }
@@ -253,7 +250,6 @@
             }
 
             function renderNoteIcon(data, type, row) {
-                if (row.rowType === 'comment') return '';
                 return '<a href="javascript:void(0)" class="noteDialogLink noprint" ' +
                     'onClick="openNoteDialog(\'' + row.demoNo + '\',\'' + row.id + '\')" ' +
                     'title="Add Encounter Note">' +
@@ -305,8 +301,8 @@
                 //
                 //     }
                 // });
-                let groupColumn = 11;
-                let rowTypeColumn = 12;
+                let idColumn = 11;
+                let lastComments = {};
                 ticklerResultsTable = jQuery("#ticklerResults").dataTable({
                     "searching": false,
                     "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],
@@ -322,6 +318,10 @@
                             d.xml_vdate = jQuery("#xml_vdate").val() || "";
                             d.xml_appointment_date = jQuery("#xml_appointment_date").val() || "";
                             d.demographic_no = jQuery("input[name='demoview']").val() || "0";
+                        },
+                        "dataSrc": function (json) {
+                            lastComments = json.comments || {};
+                            return json.data;
                         }
                     },
                     "columns": [
@@ -336,33 +336,42 @@
                         {data: "status", orderable: false, render: renderText},
                         {data: null, orderable: false, render: renderMessage},
                         {data: null, orderable: false, render: renderNoteIcon},
-                        {data: "id", orderable: false},
-                        {data: "rowType", orderable: false}
+                        {data: "id", orderable: false}
                     ],
                     "columnDefs": [
-                        {visible: false, targets: groupColumn},
-                        {visible: false, targets: rowTypeColumn}
+                        {visible: false, targets: idColumn}
                     ],
                     "createdRow": function (row, data, dataIndex) {
                         if (data.warning === true) {
                             jQuery(row).addClass('error');
-                        } else if (data.rowType === 'comment') {
-                            jQuery(row).addClass('followup-comment-' + data.id + ' comment-row no-sort');
                         }
                     },
                     "drawCallback": function (settings) {
                         let api = this.api();
                         let rows = api.rows({page: 'current'}).nodes();
-                        let last = null;
+                        let numCols = jQuery('#ticklerResults thead th').length;
 
-                        api.column(groupColumn, {page: 'current'})
+                        api.column(idColumn, {page: 'current'})
                             .data()
-                            .each(function (group, i) {
-                                if (last !== group) {
-                                    jQuery(rows)
-                                        .eq(i)
-                                        .after(jQuery(".followup-comment-" + group))
-                                    last = group;
+                            .each(function (ticklerId, i) {
+                                let comments = lastComments[String(ticklerId)];
+                                if (comments) {
+                                    for (var c = comments.length - 1; c >= 0; c--) {
+                                        var tc = comments[c];
+                                        var commentTr = jQuery('<tr class="comment-row no-sort"></tr>');
+                                        commentTr.append('<td></td>');
+                                        commentTr.append('<td></td>');
+                                        commentTr.append('<td>' + escapeHtml(api.row(i).data().demoLastName) + ',' + escapeHtml(api.row(i).data().demoFirstName) + '</td>');
+                                        commentTr.append('<td>' + escapeHtml(tc.creator) + '</td>');
+                                        commentTr.append('<td>' + escapeHtml(api.row(i).data().serviceDate) + '</td>');
+                                        commentTr.append('<td>' + escapeHtml(tc.createDate) + '</td>');
+                                        commentTr.append('<td>' + escapeHtml(api.row(i).data().priority) + '</td>');
+                                        commentTr.append('<td></td>');
+                                        commentTr.append('<td></td>');
+                                        commentTr.append('<td style="white-space:pre-wrap">' + escapeHtml(tc.message) + '</td>');
+                                        commentTr.append('<td></td>');
+                                        jQuery(rows).eq(i).after(commentTr);
+                                    }
                                 }
                             });
                     },
@@ -870,7 +879,6 @@
                     <th>
                         <fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.msgMessage"/>
                     </th>
-                    <th></th>
                     <th></th>
                     <th></th>
                 </tr>

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -307,16 +307,9 @@
                 let groupColumn = 11;
                 let warningColumn = 12;
                 ticklerResultsTable = jQuery("#ticklerResults").dataTable({
-                    "bStateSave": true,
-                    "fnStateSave": function (oSettings, oData) {
-                        localStorage.setItem('ticklerDataTable', JSON.stringify(oData));
-                    },
-                    "fnStateLoad": function () {
-                        return JSON.parse(localStorage.getItem('ticklerDataTable'));
-                    },
                     "searching": false,
                     "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],
-                    "iDisplayLength": 50,
+                    "iDisplayLength": parseInt(localStorage.getItem('ticklerPageLength')) || 50,
                     "serverSide": true,
                     "ajax": {
                         "url": ctx + "/tickler/ListTicklers.do",
@@ -335,7 +328,7 @@
                         {data: null, orderable: false, render: renderEditIcon},
                         {data: null, orderable: false, render: renderDemoName},
                         {data: "creator", orderable: false, render: renderText},
-                        {data: "serviceDate", orderable: false},
+                        {data: "serviceDate"},
                         {data: "createDate", orderable: false},
                         {data: "priority", orderable: false},
                         {data: "assignee", orderable: false, render: renderText},
@@ -372,8 +365,16 @@
                                 }
                             });
                     },
-                    "order": [[4, 'desc']]
+                    "order": JSON.parse(localStorage.getItem('ticklerSortOrder')) || [[4, 'desc']]
                 })
+
+                ticklerResultsTable.api().on('length.dt', function (e, settings, len) {
+                    localStorage.setItem('ticklerPageLength', len);
+                });
+
+                ticklerResultsTable.api().on('order.dt', function () {
+                    localStorage.setItem('ticklerSortOrder', JSON.stringify(ticklerResultsTable.api().order()));
+                });
 
                 /*
                  * Reload the search results when the Tickler status is changed.

--- a/src/test-modern/java/ca/openosp/openo/consultation/dao/ProfessionalSpecialistDaoDTOIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/consultation/dao/ProfessionalSpecialistDaoDTOIntegrationTest.java
@@ -1,0 +1,137 @@
+package ca.openosp.openo.consultation.dao;
+
+import ca.openosp.openo.commn.dao.ProfessionalSpecialistDao;
+import ca.openosp.openo.commn.model.ProfessionalSpecialist;
+import ca.openosp.openo.consultation.dto.SpecialistListDTO;
+import ca.openosp.openo.test.base.OpenOTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ProfessionalSpecialistDao#findAllListDTOs()}.
+ *
+ * <p>Validates the JPQL constructor projection that provides lightweight
+ * specialist data for list views, avoiding full entity hydration.</p>
+ *
+ * @since 2026-03-11
+ * @see ProfessionalSpecialistDao
+ * @see SpecialistListDTO
+ */
+@DisplayName("ProfessionalSpecialist DAO DTO Projection Integration Tests")
+@Tag("integration")
+@Tag("database")
+@Tag("dao")
+@Tag("slow")
+@Tag("read")
+@Tag("dto")
+@Transactional
+public class ProfessionalSpecialistDaoDTOIntegrationTest extends OpenOTestBase {
+
+    @Autowired
+    private ProfessionalSpecialistDao professionalSpecialistDao;
+
+    @PersistenceContext(unitName = "entityManagerFactory")
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        ProfessionalSpecialist spec1 = new ProfessionalSpecialist();
+        spec1.setFirstName("Alice");
+        spec1.setLastName("Smith");
+        spec1.setProfessionalLetters("MD, FRCPC");
+        spec1.setStreetAddress("123 Main St");
+        spec1.setPhoneNumber("555-1234");
+        spec1.setFaxNumber("555-5678");
+        entityManager.persist(spec1);
+
+        ProfessionalSpecialist spec2 = new ProfessionalSpecialist();
+        spec2.setFirstName("Bob");
+        spec2.setLastName("Jones");
+        spec2.setStreetAddress("456 Oak Ave");
+        spec2.setPhoneNumber("555-9999");
+        entityManager.persist(spec2);
+
+        ProfessionalSpecialist spec3 = new ProfessionalSpecialist();
+        spec3.setFirstName("Carol");
+        spec3.setLastName("Adams");
+        entityManager.persist(spec3);
+
+        entityManager.flush();
+    }
+
+    @Test
+    @DisplayName("should return all specialists as DTOs")
+    void shouldReturnAllSpecialistsAsDTOs() {
+        List<SpecialistListDTO> results = professionalSpecialistDao.findAllListDTOs();
+
+        assertThat(results).hasSize(3);
+    }
+
+    @Test
+    @Tag("query")
+    @DisplayName("should order by lastName then firstName")
+    void shouldOrderByLastNameThenFirstName() {
+        List<SpecialistListDTO> results = professionalSpecialistDao.findAllListDTOs();
+
+        assertThat(results).extracting(SpecialistListDTO::getLastName)
+                .containsExactly("Adams", "Jones", "Smith");
+    }
+
+    @Test
+    @Tag("query")
+    @DisplayName("should populate all DTO fields correctly")
+    void shouldPopulateAllDTOFields_correctly() {
+        List<SpecialistListDTO> results = professionalSpecialistDao.findAllListDTOs();
+
+        SpecialistListDTO alice = results.stream()
+                .filter(dto -> "Smith".equals(dto.getLastName()))
+                .findFirst().orElse(null);
+
+        assertThat(alice).isNotNull();
+        assertThat(alice.getId()).isNotNull();
+        assertThat(alice.getFirstName()).isEqualTo("Alice");
+        assertThat(alice.getLastName()).isEqualTo("Smith");
+        assertThat(alice.getProfessionalLetters()).isEqualTo("MD, FRCPC");
+        assertThat(alice.getStreetAddress()).isEqualTo("123 Main St");
+        assertThat(alice.getPhoneNumber()).isEqualTo("555-1234");
+        assertThat(alice.getFaxNumber()).isEqualTo("555-5678");
+    }
+
+    @Test
+    @Tag("query")
+    @DisplayName("should handle null optional fields gracefully")
+    void shouldHandleNullOptionalFields_gracefully() {
+        List<SpecialistListDTO> results = professionalSpecialistDao.findAllListDTOs();
+
+        SpecialistListDTO carol = results.stream()
+                .filter(dto -> "Adams".equals(dto.getLastName()))
+                .findFirst().orElse(null);
+
+        assertThat(carol).isNotNull();
+        assertThat(carol.getProfessionalLetters()).isNull();
+        assertThat(carol.getStreetAddress()).isNull();
+        assertThat(carol.getPhoneNumber()).isNull();
+        assertThat(carol.getFaxNumber()).isNull();
+    }
+
+    @Test
+    @DisplayName("should return empty list when no specialists exist")
+    void shouldReturnEmptyList_whenNoSpecialistsExist() {
+        entityManager.createQuery("DELETE FROM ProfessionalSpecialist").executeUpdate();
+        entityManager.flush();
+
+        List<SpecialistListDTO> results = professionalSpecialistDao.findAllListDTOs();
+
+        assertThat(results).isEmpty();
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
+++ b/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
@@ -1,20 +1,3 @@
-/**
- * Copyright (c) 2026. Magenta Health. All Rights Reserved.
- * This software is published under the GPL GNU General Public License.
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * <p>
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * <p>
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package ca.openosp.openo.tickler.web;
 
 import ca.openosp.openo.commn.model.CustomFilter;

--- a/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
+++ b/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
@@ -1,0 +1,500 @@
+/**
+ * Copyright (c) 2026. Magenta Health. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+package ca.openosp.openo.tickler.web;
+
+import ca.openosp.openo.commn.model.CustomFilter;
+import ca.openosp.openo.commn.model.Tickler;
+import ca.openosp.openo.managers.SecurityInfoManager;
+import ca.openosp.openo.managers.TicklerManager;
+import ca.openosp.openo.test.base.OpenOWebTestBase;
+import ca.openosp.openo.tickler.dto.TicklerCommentDTO;
+import ca.openosp.openo.tickler.dto.TicklerLinkDTO;
+import ca.openosp.openo.tickler.dto.TicklerListDTO;
+import ca.openosp.openo.tickler.pageUtil.TicklerList2Action;
+import ca.openosp.openo.utility.LoggedInInfo;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Web layer tests for {@link TicklerList2Action}.
+ *
+ * <p>Validates the DataTables server-side JSON endpoint including privilege
+ * enforcement, paging inputs, filter parameters, and JSON response shape.
+ *
+ * @since 2026-02-06
+ */
+@DisplayName("TicklerList2Action Web Layer Tests")
+@Tag("web")
+class TicklerList2ActionTest extends OpenOWebTestBase {
+
+    @Mock
+    private TicklerManager mockTicklerManager;
+
+    private TicklerList2Action action;
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final String TEST_PROVIDER = "999998";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        replaceSpringUtilsBean(TicklerManager.class, mockTicklerManager);
+        replaceSpringUtilsBean(SecurityInfoManager.class, mockSecurityInfoManager);
+
+        when(mockLoggedInInfo.getLoggedInProviderNo()).thenReturn(TEST_PROVIDER);
+        setSessionAttribute("user", TEST_PROVIDER);
+        String loggedInInfoKey = LoggedInInfo.class.getName() + ".LOGGED_IN_INFO_KEY";
+        setSessionAttribute(loggedInInfoKey, mockLoggedInInfo);
+
+        // Default: return empty results
+        when(mockTicklerManager.getNumTicklers(any(LoggedInInfo.class), any(CustomFilter.class)))
+                .thenReturn(0);
+        when(mockTicklerManager.getTicklerDTOs(any(LoggedInInfo.class), any(CustomFilter.class), anyInt(), anyInt()))
+                .thenReturn(Collections.emptyList());
+        when(mockTicklerManager.getTicklerDTOs(any(LoggedInInfo.class), any(CustomFilter.class)))
+                .thenReturn(Collections.emptyList());
+
+        action = new TicklerList2Action();
+        injectField("ticklerManager", mockTicklerManager);
+        injectField("securityInfoManager", mockSecurityInfoManager);
+    }
+
+    // ── Privilege Enforcement ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should return 403 JSON error when _tickler read privilege denied")
+    void shouldReturn403_whenPrivilegeDenied() throws Exception {
+        denyPrivilege("_tickler", "r");
+
+        executeAction(action);
+
+        assertThat(getMockResponse().getStatus()).isEqualTo(403);
+        JsonNode json = parseResponse();
+        assertThat(json.get("error").asText()).isEqualTo("Access denied");
+        verifySecurityCheck("_tickler", "r");
+    }
+
+    @Test
+    @DisplayName("Should return JSON when _tickler read privilege allowed")
+    void shouldReturnJson_whenPrivilegeAllowed() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        executeAction(action);
+
+        assertThat(getMockResponse().getContentType()).contains("application/json");
+    }
+
+    // ── JSON Response Shape ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should return correct top-level JSON structure")
+    void shouldReturnCorrectJsonStructure_whenEmptyResults() throws Exception {
+        allowPrivilege("_tickler", "r");
+        addRequestParameter("draw", "3");
+
+        executeAction(action);
+
+        JsonNode json = parseResponse();
+        assertThat(json.get("draw").asInt()).isEqualTo(3);
+        assertThat(json.get("recordsTotal").asInt()).isEqualTo(0);
+        assertThat(json.get("recordsFiltered").asInt()).isEqualTo(0);
+        assertThat(json.get("data").isArray()).isTrue();
+        assertThat(json.get("data").size()).isZero();
+        assertThat(json.has("comments")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should include all required fields in data rows")
+    void shouldIncludeAllFields_whenTicklerReturned() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(1, "Follow up on labs");
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode row = parseResponse().get("data").get(0);
+        assertThat(row.get("id").asInt()).isEqualTo(1);
+        assertThat(row.get("demoNo").asInt()).isEqualTo(1001);
+        assertThat(row.get("demoLastName").asText()).isEqualTo("Smith");
+        assertThat(row.get("demoFirstName").asText()).isEqualTo("John");
+        assertThat(row.get("creator").asText()).isEqualTo("Doctor, Jane");
+        assertThat(row.get("serviceDate").asText()).isNotEmpty();
+        assertThat(row.get("createDate").asText()).isNotEmpty();
+        assertThat(row.get("priority").asText()).isEqualTo("Normal");
+        assertThat(row.get("assignee").asText()).isEqualTo("Nurse, Bob");
+        assertThat(row.get("status").asText()).isNotEmpty();
+        assertThat(row.get("message").asText()).isEqualTo("Follow up on labs");
+        assertThat(row.has("warning")).isTrue();
+        assertThat(row.get("links").isArray()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should set recordsTotal and recordsFiltered to total count")
+    void shouldSetRecordCounts_whenResultsExist() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        stubPaginatedResults(42, List.of(createTestTickler(1, "test")));
+        addRequestParameter("draw", "5");
+
+        executeAction(action);
+
+        JsonNode json = parseResponse();
+        assertThat(json.get("recordsTotal").asInt()).isEqualTo(42);
+        assertThat(json.get("recordsFiltered").asInt()).isEqualTo(42);
+        assertThat(json.get("draw").asInt()).isEqualTo(5);
+    }
+
+    // ── Comments in Response ───────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should include comments as separate map keyed by tickler ID")
+    void shouldIncludeCommentsMap_whenTicklerHasComments() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(10, "Needs review");
+        TicklerCommentDTO comment = new TicklerCommentDTO(
+                100, 10, "Reviewed by specialist", new Date(1700000000000L), "Specialist", "Alice");
+        dto.setComments(List.of(comment));
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode json = parseResponse();
+        JsonNode comments = json.get("comments");
+        assertThat(comments.has("10")).isTrue();
+
+        JsonNode commentArray = comments.get("10");
+        assertThat(commentArray.isArray()).isTrue();
+        assertThat(commentArray.size()).isEqualTo(1);
+        assertThat(commentArray.get(0).get("creator").asText()).isEqualTo("Specialist, Alice");
+        assertThat(commentArray.get(0).get("message").asText()).isEqualTo("Reviewed by specialist");
+        assertThat(commentArray.get(0).has("createDate")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should omit tickler from comments map when it has no comments")
+    void shouldOmitFromCommentsMap_whenNoComments() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(20, "No comments here");
+        dto.setComments(Collections.emptyList());
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode comments = parseResponse().get("comments");
+        assertThat(comments.has("20")).isFalse();
+    }
+
+    // ── Links in Response ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should include links array in data rows")
+    void shouldIncludeLinks_whenTicklerHasLinks() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(5, "Lab attached");
+        dto.setLinks(List.of(new TicklerLinkDTO(1, 5, "HL7", 999L)));
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode links = parseResponse().get("data").get(0).get("links");
+        assertThat(links.size()).isEqualTo(1);
+        assertThat(links.get(0).get("tableName").asText()).isEqualTo("HL7");
+        assertThat(links.get(0).get("tableId").asLong()).isEqualTo(999L);
+    }
+
+    // ── Paging Parameters ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should pass start and length to TicklerManager for pagination")
+    void shouldPassPagingParams_whenProvided() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("start", "25");
+        addRequestParameter("length", "50");
+
+        executeAction(action);
+
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), eq(25), eq(50));
+    }
+
+    @Test
+    @DisplayName("Should default to start=0 and length=50")
+    void shouldUseDefaults_whenPagingParamsMissing() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        executeAction(action);
+
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), eq(0), eq(50));
+    }
+
+    @Test
+    @DisplayName("Should clamp negative start to zero")
+    void shouldClampStart_whenNegative() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("start", "-10");
+
+        executeAction(action);
+
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), eq(0), anyInt());
+    }
+
+    @Test
+    @DisplayName("Should cap length at 500")
+    void shouldCapLength_whenExceedsMax() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("length", "1000");
+
+        executeAction(action);
+
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), anyInt(), eq(500));
+    }
+
+    @Test
+    @DisplayName("Should use paginated overload with totalRecords as limit when length is -1")
+    void shouldShowAll_whenLengthIsNegative() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        when(mockTicklerManager.getNumTicklers(any(LoggedInInfo.class), any(CustomFilter.class)))
+                .thenReturn(150);
+        addRequestParameter("length", "-1");
+
+        executeAction(action);
+
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), eq(0), eq(150));
+    }
+
+    @Test
+    @DisplayName("Should default draw to 1 when not provided")
+    void shouldDefaultDraw_whenMissing() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        executeAction(action);
+
+        JsonNode json = parseResponse();
+        assertThat(json.get("draw").asInt()).isEqualTo(1);
+    }
+
+    // ── Filter Parameters ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should pass ticklerview status to filter")
+    void shouldPassStatus_whenTicklerviewProvided() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("ticklerview", "C");
+
+        executeAction(action);
+
+        ArgumentCaptor<CustomFilter> captor = ArgumentCaptor.forClass(CustomFilter.class);
+        verify(mockTicklerManager).getNumTicklers(any(LoggedInInfo.class), captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo("C");
+    }
+
+    @Test
+    @DisplayName("Should default ticklerview to Active")
+    void shouldDefaultToActive_whenTicklerviewMissing() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        executeAction(action);
+
+        ArgumentCaptor<CustomFilter> captor = ArgumentCaptor.forClass(CustomFilter.class);
+        verify(mockTicklerManager).getNumTicklers(any(LoggedInInfo.class), captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo("A");
+    }
+
+    @ParameterizedTest
+    @DisplayName("Should pass sort direction to filter")
+    @CsvSource({"asc, asc", "desc, desc", "invalid, desc", "'', desc"})
+    void shouldPassSortDirection_whenOrderDirProvided(String input, String expected) throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        if (input != null && !input.isEmpty()) {
+            addRequestParameter("order[0][dir]", input);
+        }
+
+        executeAction(action);
+
+        ArgumentCaptor<CustomFilter> captor = ArgumentCaptor.forClass(CustomFilter.class);
+        verify(mockTicklerManager).getNumTicklers(any(LoggedInInfo.class), captor.capture());
+        assertThat(captor.getValue().getSort_order()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Should clear provider filters when demographic_no is set")
+    void shouldClearProviderFilters_whenDemographicSpecified() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("demographic_no", "1001");
+        addRequestParameter("providerview", "999998");
+        addRequestParameter("assignedTo", "999999");
+        addRequestParameter("mrpview", "999997");
+
+        executeAction(action);
+
+        ArgumentCaptor<CustomFilter> captor = ArgumentCaptor.forClass(CustomFilter.class);
+        verify(mockTicklerManager).getNumTicklers(any(LoggedInInfo.class), captor.capture());
+        CustomFilter filter = captor.getValue();
+        assertThat(filter.getDemographicNo()).isEqualTo("1001");
+        assertThat(filter.getMrp()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should handle non-numeric parameter values gracefully")
+    void shouldHandleGracefully_whenParamsAreNonNumeric() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("draw", "abc");
+        addRequestParameter("start", "xyz");
+        addRequestParameter("length", "!!!");
+
+        executeAction(action);
+
+        JsonNode json = parseResponse();
+        // Should fall back to defaults: draw=1, start=0, length=50
+        assertThat(json.get("draw").asInt()).isEqualTo(1);
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), eq(0), eq(50));
+    }
+
+    // ── Invalid Date Handling ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should return 400 JSON error when date format is invalid")
+    void shouldReturn400_whenDateFormatInvalid() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("xml_vdate", "not-a-date");
+
+        executeAction(action);
+
+        assertThat(getMockResponse().getStatus()).isEqualTo(400);
+        JsonNode json = parseResponse();
+        assertThat(json.get("error").asText()).contains("date");
+    }
+
+    // ── Warning Flag ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should set warning=false when service date is in the future")
+    void shouldNotWarn_whenServiceDateIsFuture() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(1, "future tickler");
+        // Service date far in the future — no warn period can trigger
+        dto.setServiceDate(new Date(System.currentTimeMillis() + 365L * 24 * 60 * 60 * 1000));
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode row = parseResponse().get("data").get(0);
+        assertThat(row.get("warning").asBoolean()).isFalse();
+    }
+
+    // ── Null/Empty Dates ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should handle null serviceDate and createDate gracefully")
+    void shouldReturnEmptyStrings_whenDatesAreNull() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(1, "no dates");
+        dto.setServiceDate(null);
+        dto.setCreateDate(null);
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode row = parseResponse().get("data").get(0);
+        assertThat(row.get("serviceDate").asText()).isEmpty();
+        assertThat(row.get("createDate").asText()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should handle null comment updateDate")
+    void shouldReturnEmptyCreateDate_whenCommentUpdateDateIsNull() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(1, "test");
+        TicklerCommentDTO comment = new TicklerCommentDTO(1, 1, "comment", null, "Last", "First");
+        dto.setComments(List.of(comment));
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode commentNode = parseResponse().get("comments").get("1").get(0);
+        assertThat(commentNode.get("createDate").asText()).isEmpty();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private TicklerListDTO createTestTickler(int id, String message) {
+        return new TicklerListDTO(
+                id, message, new Date(), new Date(),
+                Tickler.STATUS.A, Tickler.PRIORITY.Normal,
+                1001, "Smith", "John",
+                "Doctor", "Jane",
+                "Nurse", "Bob");
+    }
+
+    private void stubPaginatedResults(int total, List<TicklerListDTO> ticklers) {
+        when(mockTicklerManager.getNumTicklers(any(LoggedInInfo.class), any(CustomFilter.class)))
+                .thenReturn(total);
+        when(mockTicklerManager.getTicklerDTOs(any(LoggedInInfo.class), any(CustomFilter.class), anyInt(), anyInt()))
+                .thenReturn(ticklers);
+        when(mockTicklerManager.getTicklerDTOs(any(LoggedInInfo.class), any(CustomFilter.class)))
+                .thenReturn(ticklers);
+    }
+
+    private JsonNode parseResponse() throws Exception {
+        return mapper.readTree(getMockResponse().getContentAsString());
+    }
+
+    private void injectField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = TicklerList2Action.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(action, value);
+    }
+}

--- a/src/test-modern/resources/META-INF/persistence.xml
+++ b/src/test-modern/resources/META-INF/persistence.xml
@@ -28,6 +28,7 @@
         <class>ca.openosp.openo.commn.model.Facility</class>
         <class>ca.openosp.openo.commn.model.DemographicMerged</class>
         <class>ca.openosp.openo.PMmodule.model.ProgramQueue</class>
+        <class>ca.openosp.openo.commn.model.ProfessionalSpecialist</class>
         <!-- HBM.XML mapped entities -->
         <mapping-file>ca/openosp/openo/commn/model/Provider.hbm.xml</mapping-file>
         <mapping-file>ca/openosp/openo/commn/model/Demographic.hbm.xml</mapping-file>

--- a/src/test-modern/resources/test-context-full.xml
+++ b/src/test-modern/resources/test-context-full.xml
@@ -191,6 +191,9 @@
     <bean id="customFilterDao" class="ca.openosp.openo.commn.dao.CustomFilterDaoImpl" autowire="byName" />
     <bean id="oscarLogDao" class="ca.openosp.openo.commn.dao.OscarLogDaoImpl" autowire="byName" />
 
+    <!-- Specialist DAOs -->
+    <bean id="professionalSpecialistDao" class="ca.openosp.openo.commn.dao.ProfessionalSpecialistDaoImpl" autowire="byName" />
+
     <!-- Additional DAOs required by TicklerManager -->
     <bean id="programAccessDAO" class="ca.openosp.openo.PMmodule.dao.ProgramAccessDAOImpl" autowire="byName" />
     <bean id="ProgramAccessDAO" class="ca.openosp.openo.PMmodule.dao.ProgramAccessDAOImpl" autowire="byName" />


### PR DESCRIPTION
## Summary

This branch packages 5 fixes and performance improvements.

## Performance Fixes:

### 1. [**PR #2333**](https://github.com/openo-beta/Open-O/pull/2333) - Performance: slow edit specialists page (7 commits)
- The Edit Specialists and Display Service pages were slow because all specialist data was rendered server-side in a single large HTML response
- Data is now loaded asynchronously via a dedicated endpoint and rendered client-side, significantly reducing page load times

**Related Issue:** [#2321](https://github.com/openo-beta/Open-O/issues/2321)

### 2. [**PR #2264**](https://github.com/openo-beta/Open-O/pull/2264) - Fix: slow consultation pages - LEGACY BUG (14 commits)
- Consultation list and form pages were slow due to inefficient database queries loading full entities when only summary data was needed
- Replaced with DTO-based queries, batch fetching, and database indexes to dramatically reduce query count and load times

**Related Issue:** https://github.com/openo-beta/Open-O/issues/2099


### 3. [**PR #2268**](https://github.com/openo-beta/Open-O/pull/2268) - Performance/Improvement: tickler pagination not working correctly - LEGACY BUG (11 commits)
- Tickler pagination was previously only cosmetic — the system was loading up to 5,000 records before applying pagination in the browser
- Pagination is now handled server-side so only the requested page of records is fetched
- Minor UX fixes: the "From" date filter now persists across searches, and the secondary filter dropdown is hidden when not applicable

**Related Issue:** https://github.com/openo-beta/Open-O/issues/2259

---

## Bug Fixes

### 4. [**PR #2332**](https://github.com/openo-beta/Open-O/pull/2332) - Fix: Update instructions/label for Asthma Action Plan measurement (6 commits)
- The AACP flowsheet was using a generic Yes/No/NA dropdown instead of the required Provided/Revised/Reviewed options per OMD DE16.098 conformance requirements
- ⚠️ Includes a required manual database migration step for existing installations

**Related Issue:** [#2319](https://github.com/openo-beta/Open-O/issues/2319)

### 5. [**PR #2334**](https://github.com/openo-beta/Open-O/pull/2334) - fix: restore epoch serialization for date fields across REST TO models to fix Ocean sync (1 commit)
- A dependency upgrade changed how dates were serialized in the REST API, causing date fields to return as formatted strings instead of numeric epoch values
- Epoch serialization has been restored across all affected REST transfer models, fixing Ocean integration sync and potentially other third-party integrations
