### PR TITLE
Bugfixes and Enhancements 20260428

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ __pycache__/
 .editorconfig
 .claude
 CLAUDE.md
+.classpath
+.factorypath
+.project
 
 # Docusaurus
 /website/node_modules/

--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -1221,6 +1221,7 @@ INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `me
 ( 'NERF', 'Neuropathic Features?', 'Neuropathic Features?', 'null', '15', '2013-05-07 00:00:00'),
 ( 'NOSK', 'Number of Cigarettes per day', 'Smoking', 'Cigarettes per day', '5', '2013-02-01 00:00:00'),
 ( 'NOVS', 'Need for nocturnal ventilated support', 'Need for nocturnal ventilated support', 'Yes/No', '7', '2013-02-01 00:00:00'),
+( 'NRTF', 'Neurological exam: 128Hz tuning fork D1', 'Neurological exam: 128Hz tuning fork D1', 'Normal', '7', '2026-03-23 00:00:00'),
 ( 'NtrC', 'Diet/Nutrition Counseling Given', 'Diet/Nutrition Counseling Given', 'Yes/No', '7', '2013-02-01 00:00:00'),
 ( 'NYHA', 'NYHA Functional Capacity Classification', 'NYHA Functional Capacity Classification', 'Class 1-4', '9', '2013-02-01 00:00:00'),
 ( 'OPAE', 'Opioid Adverse Effects', 'Opioid Adverse Effects', 'null', '17', '2014-11-27 13:00:00'),

--- a/database/mysql/oscardata_on.sql
+++ b/database/mysql/oscardata_on.sql
@@ -11547,6 +11547,47 @@ INSERT INTO `billingservice` (`service_code`, `description`, `value`, `percentag
 ('Z944A', '----', '89.75', NULL, '2010-10-01', 'ON', '00');
 
 --
+-- OMA Uninsured Services Fees (OMD Conformance PC13.19)
+-- See: https://github.com/openo-beta/Open-O/issues/2381
+--
+
+INSERT INTO billingservice (service_compositecode,service_code,description,value,percentage,billingservice_date,specialty,region,anaesthesia,termination_date,displaystyle,sliFlag,gstFlag) VALUES
+     ('','_OMA_A003','General Assessment','253.35','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_A007','Intermediate Assessment','110.10','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_A110','Periodic oculo-visual assessment (by a General/Family practitioner)','141.85','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_C01','Patient interview for practice admission','128.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F01','Form completion for physicals for schools, camps, pre-school, daycare, university/educational institutions','37.25','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F02','Form completion for physicals for pre-employment certification of fitness/fitness clubs or hospital/nursing home employee','49.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F03','Children''s Aid Society (CAS) application for prospective foster parent','252.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F04','CRA Disability Tax Credit Certificate (form T2201)','150.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F05','Insurance Certificate OCF- 3 Disability Certificate','262.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F06','Insurance Certificate OCF-18 Treatment Plan','278.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F07','Insurance Certificate OCF-23 Treatment Confirmation','262.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F08','Attending Physician''s Statement','200.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F09','Insurance Medical Examination (assessment and report)','200.00','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F10','Medical Report for a CPP Disability Benefit (SCISP-2519)','85.00','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F11','CPP Narrative Medical Report','150.00','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F12','Medical certificate employment insurance sickness benefits INS5140','52.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F13','Travel cancellation insurance form','164.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F14','Life insurance death certificate','50.00','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F15','Insurance Certificate OCF-19 Determination of Catastrophic Impairment','155.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F16','System-Specific or Disease Specific Questionnaire','125.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F17','System-Specific Examination','152.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F18','Assessments: Clarification Report','300.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F19','Assessments: Full Narrative Report','350.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F20','Assessments: Independent Medical Examination','200.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F21','Terminal Illness Medical Attestation for a Disability Benefit (ISP2530B)','85.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F22','Reassessment Medical Report (ISP2509)','25.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F23','Scannable Impairment Evaluation (IMPAIR)','50.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F24','Medical Report – Recurrence of the Same Medical Problem (ISP2525)','25.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F25','Drivers medical examination (form only)','77.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_G010','Urinalysis – without microscopy','7.65','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_N01','Sick notes (includes return to work/school notes)','26.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_N02','Fitness to work notes','50.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_RECOR','Electronic Transfer of Records','30.00','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_RX','Dispensing service fee','20.75','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0);
+
+--
 -- Dumping data for table 'clinic'
 --
 
@@ -12540,9 +12581,42 @@ INSERT INTO ctl_billingservice (servicetype_name,servicetype,service_code,servic
 INSERT INTO ctl_billingservice (servicetype_name,servicetype,service_code,service_group_name,service_group,status,service_order) VALUES ('General Practice','MFP','B994A','Premium','Group3','A',35);
 INSERT INTO ctl_billingservice (servicetype_name,servicetype,service_code,service_group_name,service_group,status,service_order) VALUES ('Service','TST','A007A',' Description 3','Group3','A',1);
 INSERT INTO ctl_billingservice (servicetype_name,servicetype,service_code,service_group_name,service_group,status,service_order) VALUES ('Service','TST','A008A',' Description 3','Group3','A',2);
-INSERT INTO ctl_billingservice (servicetype_name,servicetype,service_code,service_group_name,service_group,status,service_order) VALUES ('PRIVATE','PRI','A007A',' Group 1 Name','Group1','A',1);
-INSERT INTO ctl_billingservice (servicetype_name,servicetype,service_code,service_group_name,service_group,status,service_order) VALUES ('PRIVATE','PRI','A007A',' Group 2 Name','Group2','A',1);
-INSERT INTO ctl_billingservice (servicetype_name,servicetype,service_code,service_group_name,service_group,status,service_order) VALUES ('PRIVATE','PRI','A007A',' Group 3 Name','Group3','A',1);
+-- OMA Uninsured Services Fees - PRIVATE form mappings (OMD Conformance PC13.19)
+INSERT INTO ctl_billingservice (servicetype_name,servicetype,service_code,service_group_name,service_group,status,service_order) VALUES
+     ('PRIVATE','PRI','_OMA_A003','Assessments','Group2','A',1),
+     ('PRIVATE','PRI','_OMA_A007','Assessments','Group2','A',2),
+     ('PRIVATE','PRI','_OMA_A110','Assessments','Group2','A',3),
+     ('PRIVATE','PRI','_OMA_F01','Forms','Group1','A',2),
+     ('PRIVATE','PRI','_OMA_F02','Forms','Group1','A',3),
+     ('PRIVATE','PRI','_OMA_F03','Forms','Group1','A',4),
+     ('PRIVATE','PRI','_OMA_F04','Forms','Group1','A',5),
+     ('PRIVATE','PRI','_OMA_F05','Forms','Group1','A',6),
+     ('PRIVATE','PRI','_OMA_F06','Forms','Group1','A',7),
+     ('PRIVATE','PRI','_OMA_F07','Forms','Group1','A',8),
+     ('PRIVATE','PRI','_OMA_F08','Assessments','Group2','A',5),
+     ('PRIVATE','PRI','_OMA_F09','Assessments','Group2','A',6),
+     ('PRIVATE','PRI','_OMA_F10','Assessments','Group2','A',7),
+     ('PRIVATE','PRI','_OMA_F11','Assessments','Group2','A',8),
+     ('PRIVATE','PRI','_OMA_F12','Assessments','Group2','A',4),
+     ('PRIVATE','PRI','_OMA_F13','Forms','Group1','A',11),
+     ('PRIVATE','PRI','_OMA_F14','Forms','Group1','A',12),
+     ('PRIVATE','PRI','_OMA_F15','Forms','Group1','A',13),
+     ('PRIVATE','PRI','_OMA_F16','Assessments','Group2','A',10),
+     ('PRIVATE','PRI','_OMA_F17','Assessments','Group2','A',11),
+     ('PRIVATE','PRI','_OMA_F18','Assessments','Group2','A',12),
+     ('PRIVATE','PRI','_OMA_F19','Assessments','Group2','A',13),
+     ('PRIVATE','PRI','_OMA_F20','Assessments','Group2','A',14),
+     ('PRIVATE','PRI','_OMA_F21','Forms','Group1','A',14),
+     ('PRIVATE','PRI','_OMA_F22','Assessments','Group2','A',15),
+     ('PRIVATE','PRI','_OMA_F23','Assessments','Group2','A',16),
+     ('PRIVATE','PRI','_OMA_F24','Assessments','Group2','A',17),
+     ('PRIVATE','PRI','_OMA_F25','Assessments','Group2','A',9),
+     ('PRIVATE','PRI','_OMA_G010','Procedures','Group3','A',2),
+     ('PRIVATE','PRI','_OMA_N01','Forms','Group1','A',9),
+     ('PRIVATE','PRI','_OMA_N02','Forms','Group1','A',10),
+     ('PRIVATE','PRI','_OMA_RECOR','Forms','Group1','A',1),
+     ('PRIVATE','PRI','_OMA_RX','Procedures','Group3','A',1),
+     ('PRIVATE','PRI','_OMA_C01','Assessments','Group2','A',18);
 
 --
 -- Dumping data for table 'ctl_billingservice_premium'

--- a/database/mysql/updates/update-2026-03-23-nrtf-tuning-fork.sql
+++ b/database/mysql/updates/update-2026-03-23-nrtf-tuning-fork.sql
@@ -1,0 +1,13 @@
+--
+-- Add NRTF (Neurological Exam 128Hz Tuning Fork D1) measurement type
+-- for diabetes flowsheet compliance with OMD DE16.066
+-- Fixes: https://github.com/openo-beta/Open-O/issues/2338
+--
+
+INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `measuringInstruction`, `validation`, `createDate`)
+VALUES ('NRTF', 'Neurological exam: 128Hz tuning fork D1', 'Neurological exam: 128Hz tuning fork D1', 'Normal', '7', '2026-03-23 00:00:00')
+ON DUPLICATE KEY UPDATE
+  `typeDisplayName`='Neurological exam: 128Hz tuning fork D1',
+  `typeDescription`='Neurological exam: 128Hz tuning fork D1',
+  `measuringInstruction`='Normal',
+  `validation`='7';

--- a/database/mysql/updates/update-2026-03-24-oma-uninsured-service-fees.sql
+++ b/database/mysql/updates/update-2026-03-24-oma-uninsured-service-fees.sql
@@ -1,0 +1,82 @@
+-- OMA Uninsured Services Fees for Ontario Private Billing
+-- OMD Conformance Requirement PC13.19
+-- Adds 34 OMA fee codes to the billingservice table and maps them to the PRIVATE billing form
+-- See: https://github.com/openo-beta/Open-O/issues/2381
+
+-- Deactivate legacy placeholder PRIVATE form mappings (replaced by OMA codes below)
+UPDATE ctl_billingservice SET status = 'I' WHERE servicetype = 'PRI' AND service_code = 'A007A' AND service_group_name IN (' Group 1 Name', ' Group 2 Name', ' Group 3 Name');
+
+-- Billing service codes (private codes use underscore prefix, region=NULL)
+INSERT INTO billingservice (service_compositecode,service_code,description,value,percentage,billingservice_date,specialty,region,anaesthesia,termination_date,displaystyle,sliFlag,gstFlag) VALUES
+     ('','_OMA_A003','General Assessment','253.35','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_A007','Intermediate Assessment','110.10','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_A110','Periodic oculo-visual assessment (by a General/Family practitioner)','141.85','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_C01','Patient interview for practice admission','128.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F01','Form completion for physicals for schools, camps, pre-school, daycare, university/educational institutions','37.25','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F02','Form completion for physicals for pre-employment certification of fitness/fitness clubs or hospital/nursing home employee','49.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F03','Children''s Aid Society (CAS) application for prospective foster parent','252.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F04','CRA Disability Tax Credit Certificate (form T2201)','150.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F05','Insurance Certificate OCF- 3 Disability Certificate','262.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F06','Insurance Certificate OCF-18 Treatment Plan','278.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F07','Insurance Certificate OCF-23 Treatment Confirmation','262.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F08','Attending Physician''s Statement','200.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F09','Insurance Medical Examination (assessment and report)','200.00','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F10','Medical Report for a CPP Disability Benefit (SCISP-2519)','85.00','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F11','CPP Narrative Medical Report','150.00','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F12','Medical certificate employment insurance sickness benefits INS5140','52.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F13','Travel cancellation insurance form','164.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F14','Life insurance death certificate','50.00','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F15','Insurance Certificate OCF-19 Determination of Catastrophic Impairment','155.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F16','System-Specific or Disease Specific Questionnaire','125.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F17','System-Specific Examination','152.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F18','Assessments: Clarification Report','300.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F19','Assessments: Full Narrative Report','350.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F20','Assessments: Independent Medical Examination','200.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F21','Terminal Illness Medical Attestation for a Disability Benefit (ISP2530B)','85.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F22','Reassessment Medical Report (ISP2509)','25.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F23','Scannable Impairment Evaluation (IMPAIR)','50.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F24','Medical Report – Recurrence of the Same Medical Problem (ISP2525)','25.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_F25','Drivers medical examination (form only)','77.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_G010','Urinalysis – without microscopy','7.65','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_N01','Sick notes (includes return to work/school notes)','26.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_N02','Fitness to work notes','50.00','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_RECOR','Electronic Transfer of Records','30.00','0.00','2026-03-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0),
+     ('','_OMA_RX','Dispensing service fee','20.75','0.00','2026-01-01',NULL,NULL,NULL,'9999-12-31',NULL,0,0);
+
+-- Map billing codes to the PRIVATE billing form with group organization
+-- Group1 = Forms, Group2 = Assessments, Group3 = Procedures
+INSERT INTO ctl_billingservice (servicetype_name,servicetype,service_code,service_group_name,service_group,status,service_order) VALUES
+     ('PRIVATE','PRI','_OMA_A003','Assessments','Group2','A',1),
+     ('PRIVATE','PRI','_OMA_A007','Assessments','Group2','A',2),
+     ('PRIVATE','PRI','_OMA_A110','Assessments','Group2','A',3),
+     ('PRIVATE','PRI','_OMA_F01','Forms','Group1','A',2),
+     ('PRIVATE','PRI','_OMA_F02','Forms','Group1','A',3),
+     ('PRIVATE','PRI','_OMA_F03','Forms','Group1','A',4),
+     ('PRIVATE','PRI','_OMA_F04','Forms','Group1','A',5),
+     ('PRIVATE','PRI','_OMA_F05','Forms','Group1','A',6),
+     ('PRIVATE','PRI','_OMA_F06','Forms','Group1','A',7),
+     ('PRIVATE','PRI','_OMA_F07','Forms','Group1','A',8),
+     ('PRIVATE','PRI','_OMA_F08','Assessments','Group2','A',5),
+     ('PRIVATE','PRI','_OMA_F09','Assessments','Group2','A',6),
+     ('PRIVATE','PRI','_OMA_F10','Assessments','Group2','A',7),
+     ('PRIVATE','PRI','_OMA_F11','Assessments','Group2','A',8),
+     ('PRIVATE','PRI','_OMA_F12','Assessments','Group2','A',4),
+     ('PRIVATE','PRI','_OMA_F13','Forms','Group1','A',11),
+     ('PRIVATE','PRI','_OMA_F14','Forms','Group1','A',12),
+     ('PRIVATE','PRI','_OMA_F15','Forms','Group1','A',13),
+     ('PRIVATE','PRI','_OMA_F16','Assessments','Group2','A',10),
+     ('PRIVATE','PRI','_OMA_F17','Assessments','Group2','A',11),
+     ('PRIVATE','PRI','_OMA_F18','Assessments','Group2','A',12),
+     ('PRIVATE','PRI','_OMA_F19','Assessments','Group2','A',13),
+     ('PRIVATE','PRI','_OMA_F20','Assessments','Group2','A',14),
+     ('PRIVATE','PRI','_OMA_F21','Forms','Group1','A',14),
+     ('PRIVATE','PRI','_OMA_F22','Assessments','Group2','A',15),
+     ('PRIVATE','PRI','_OMA_F23','Assessments','Group2','A',16),
+     ('PRIVATE','PRI','_OMA_F24','Assessments','Group2','A',17),
+     ('PRIVATE','PRI','_OMA_F25','Assessments','Group2','A',9),
+     ('PRIVATE','PRI','_OMA_G010','Procedures','Group3','A',2),
+     ('PRIVATE','PRI','_OMA_N01','Forms','Group1','A',9),
+     ('PRIVATE','PRI','_OMA_N02','Forms','Group1','A',10),
+     ('PRIVATE','PRI','_OMA_RECOR','Forms','Group1','A',1),
+     ('PRIVATE','PRI','_OMA_RX','Procedures','Group3','A',1),
+     ('PRIVATE','PRI','_OMA_C01','Assessments','Group2','A',18);

--- a/pom.xml
+++ b/pom.xml
@@ -58,15 +58,18 @@
             <url>file://${basedir}/local_repo</url>
         </repository>
 
-        <!-- for the com.github.openosp htmltopdf dependency only. Upgrades
-        from this dependency are welcome -->
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
         <repository>
             <id>central</id>
             <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+
+        <!-- Primarily needed for com.github.openosp:ultrabuk-htmltopdf-java.
+        Listed last so Maven Central is queried first — Maven resolves repositories
+        in declaration order and JitPack will be queried for all groupIds, not just
+        com.github.*. Upgrades from this dependency are welcome. -->
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 

--- a/src/main/java/ca/openosp/openo/commn/dao/DocumentDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/DocumentDao.java
@@ -90,4 +90,6 @@ public interface DocumentDao extends AbstractDao<Document> {
     public List<Document> findByDemographicAndDoctype(int demographicId, DocumentType documentType);
 
     public Document findByDemographicAndFilename(int demographicId, String fileName);
+
+    public List<Integer> findDocumentNosForDemographic(Integer demographicNo, List<Integer> docNos);
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
@@ -245,6 +245,19 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
      *
      * @param demoNo
      */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<Integer> findDocumentNosForDemographic(Integer demographicNo, List<Integer> docNos) {
+        if (docNos == null || docNos.isEmpty()) return Collections.emptyList();
+        Query query = entityManager.createQuery(
+                "SELECT c.id.documentNo FROM CtlDocument c " +
+                "WHERE c.id.module = 'demographic' AND c.id.moduleId = :demographicNo " +
+                "AND c.status != 'D' AND c.id.documentNo IN :docNos");
+        query.setParameter("demographicNo", demographicNo);
+        query.setParameter("docNos", docNos);
+        return query.getResultList();
+    }
+
     @Override
     public List<Document> findByDemographicId(String demoNo) {
         Integer id = null;

--- a/src/main/java/ca/openosp/openo/commn/dao/EFormDataDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/EFormDataDao.java
@@ -79,4 +79,6 @@ public interface EFormDataDao extends AbstractDao<EFormData> {
 
     public Date getLatestFormDateAndTimeForEforms(Collection<Integer> fdidList);
 
+    public List<Integer> findFdidsForDemographic(Integer demographicNo, List<Integer> fdids);
+
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/EFormDataDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/EFormDataDaoImpl.java
@@ -6,6 +6,7 @@ package ca.openosp.openo.commn.dao;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -573,5 +574,17 @@ public class EFormDataDaoImpl extends AbstractDaoImpl<EFormData> implements EFor
             return d;
         }
         return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<Integer> findFdidsForDemographic(Integer demographicNo, List<Integer> fdids) {
+        if (fdids == null || fdids.isEmpty()) return Collections.emptyList();
+        Query query = entityManager.createQuery(
+                "SELECT x.id FROM EFormData x " +
+                "WHERE x.demographicId = :demographicNo AND x.id IN :fdids");
+        query.setParameter("demographicNo", demographicNo);
+        query.setParameter("fdids", fdids);
+        return query.getResultList();
     }
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDao.java
@@ -51,4 +51,6 @@ public interface PatientLabRoutingDao extends AbstractDao<PatientLabRouting> {
 
     public List<Integer> findDemographicIdsSince(Date date);
 
+    public List<Integer> findLabNosForDemographic(Integer demographicNo, List<Integer> labNos);
+
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDaoImpl.java
@@ -3,6 +3,7 @@
 
 package ca.openosp.openo.commn.dao;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -342,6 +343,18 @@ public class PatientLabRoutingDaoImpl extends AbstractDaoImpl<PatientLabRouting>
         List<Integer> results = q.getResultList();
 
         return results;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<Integer> findLabNosForDemographic(Integer demographicNo, List<Integer> labNos) {
+        if (labNos == null || labNos.isEmpty()) return Collections.emptyList();
+        Query query = entityManager.createQuery(
+                "SELECT r.labNo FROM PatientLabRouting r " +
+                "WHERE r.demographicNo = :demographicNo AND r.labNo IN :labNos");
+        query.setParameter("demographicNo", demographicNo);
+        query.setParameter("labNos", labNos);
+        return query.getResultList();
     }
 
 }

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
@@ -300,6 +300,18 @@ public interface DocumentAttachmentManager {
      * @throws PDFGenerationException if an error occurs during the PDF flattening process
      */
     public void flattenPDFFormFields(Path pdfPath) throws PDFGenerationException;
+
+    /**
+     * Validates that all documents in the array belong to the specified patient demographic.
+     * Each entry is prefixed with a type letter (D, L, E, H) followed by the document ID
+     * (e.g. "D42", "L7").
+     *
+     * @param loggedInInfo  The logged-in provider context
+     * @param demographicNo The patient's demographic number
+     * @param documents     Array of typed document ID strings
+     * @return {@code true} if every document belongs to the patient; {@code false} otherwise
+     */
+    public boolean validateDocumentsBelongToPatient(LoggedInInfo loggedInInfo, Integer demographicNo, String[] documents);
 }
 
 	

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -69,6 +69,12 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
     private ConsultDocsDao consultDocsDao;
     @Autowired
     private EFormDocsDao eFormDocsDao;
+    @Autowired
+    private ca.openosp.openo.commn.dao.DocumentDao documentDao;
+    @Autowired
+    private ca.openosp.openo.commn.dao.PatientLabRoutingDao patientLabRoutingDao;
+    @Autowired
+    private ca.openosp.openo.commn.dao.EFormDataDao eFormDataDao;
 
     @Autowired
     private ConsultationManager consultationManager;
@@ -662,5 +668,49 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         } catch (IOException e) {
             throw new PDFGenerationException("Error while flattening the " + pdfPath.getFileName() + " file. " + e.getMessage(), e);
         }
+    }
+
+    @Override
+    public boolean validateDocumentsBelongToPatient(LoggedInInfo loggedInInfo, Integer demographicNo, String[] documents) {
+        // Use Set to automatically deduplicate IDs — duplicate entries would cause size-based validation to fail incorrectly
+        Set<Integer> docIds = new HashSet<>();
+        Set<Integer> labIds = new HashSet<>();
+        Set<Integer> eformIds = new HashSet<>();
+        Set<Integer> hrmIds = new HashSet<>();
+
+        for (String doc : documents) {
+            if (doc == null || doc.length() < 2) continue;
+            char type = doc.charAt(0);
+            try {
+                int id = Integer.parseInt(doc.substring(1));
+                switch (type) {
+                    case 'D': docIds.add(id); break;
+                    case 'L': labIds.add(id); break;
+                    case 'E': eformIds.add(id); break;
+                    case 'H': hrmIds.add(id); break;
+                }
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+
+        if (!docIds.isEmpty()) {
+            List<Integer> found = documentDao.findDocumentNosForDemographic(demographicNo, new ArrayList<>(docIds));
+            if (!found.containsAll(docIds)) return false;
+        }
+        if (!labIds.isEmpty()) {
+            List<Integer> found = patientLabRoutingDao.findLabNosForDemographic(demographicNo, new ArrayList<>(labIds));
+            if (!found.containsAll(labIds)) return false;
+        }
+        if (!eformIds.isEmpty()) {
+            List<Integer> found = eFormDataDao.findFdidsForDemographic(demographicNo, new ArrayList<>(eformIds));
+            if (!found.containsAll(eformIds)) return false;
+        }
+        if (!hrmIds.isEmpty()) {
+            List<Integer> found = HRMUtil.findHRMDocumentIdsForPatient(demographicNo, new ArrayList<>(hrmIds));
+            if (!found.containsAll(hrmIds)) return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/ca/openosp/openo/encounter/oceanEReferal/pageUtil/ERefer2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oceanEReferal/pageUtil/ERefer2Action.java
@@ -7,6 +7,7 @@ import ca.openosp.openo.commn.model.EReferAttachment;
 import ca.openosp.openo.commn.model.EReferAttachmentData;
 import ca.openosp.openo.commn.model.enumerator.DocumentType;
 import ca.openosp.openo.documentManager.DocumentAttachmentManager;
+import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.SpringUtils;
@@ -67,6 +68,7 @@ public class ERefer2Action extends ActionSupport {
 
     private static final Logger logger = MiscUtils.getLogger();
     private final DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
+    private final SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     /**
      * Main execution method for this Struts2 action.
@@ -92,9 +94,38 @@ public class ERefer2Action extends ActionSupport {
                 attachOceanEReferralConsult();
             else if (method.equalsIgnoreCase("editOceanEReferralConsult"))
                 editOceanEReferralConsult();
+            else if (method.equalsIgnoreCase("validateDocuments"))
+                validateDocuments();
         }
 
         return SUCCESS;
+    }
+
+    private void writeResponse(boolean valid) {
+        try (PrintWriter writer = response.getWriter()) {
+            response.setContentType("application/json");
+            writer.write(valid ? "{\"valid\":true}" : "{\"valid\":false}");
+        } catch (IOException e) {
+            logger.error("Failed to write validation response", e);
+        }
+    }
+
+    public void validateDocuments() {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.READ, null)) {
+            writeResponse(false);
+            return;
+        }
+        String demographicNo = request.getParameter("demographicNo");
+        String[] documents = request.getParameterValues("documents");
+        if (StringUtils.isNullOrEmpty(demographicNo) || documents == null || documents.length == 0) {
+            // Nothing to validate - return true
+            writeResponse(true);
+            return;
+        }
+        boolean valid = documentAttachmentManager.validateDocumentsBelongToPatient(
+                loggedInInfo, Integer.parseInt(demographicNo), documents);
+        writeResponse(valid);
     }
 
     /**
@@ -137,6 +168,10 @@ public class ERefer2Action extends ActionSupport {
      * </p>
      */
     public void attachOceanEReferralConsult() {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.READ, null)) {
+            throw new SecurityException("missing required sec object (_con)");
+        }
         String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "" : request.getParameter("demographicNo");
         String documents = StringUtils.isNullOrEmpty(request.getParameter("documents")) ? "" : request.getParameter("documents");
         if (documents.isEmpty() || demographicNo.isEmpty()) {

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUtil.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUtil.java
@@ -413,4 +413,15 @@ public class HRMUtil {
             hrmDocumentToProviderDao.remove(existingUnmatched.getId());
         }
     }
+
+    /**
+     * Returns the subset of the given HRM document IDs that are linked to the specified patient.
+     *
+     * @param demographicNo the patient's demographic number
+     * @param hrmIds        the list of HRM document IDs to check
+     * @return List of HRM document IDs that belong to the patient
+     */
+    public static List<Integer> findHRMDocumentIdsForPatient(Integer demographicNo, List<Integer> hrmIds) {
+        return hrmDocumentToDemographicDao.findHrmIdsForDemographic(demographicNo, hrmIds);
+    }
 }

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/dao/HRMDocumentToDemographicDao.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/dao/HRMDocumentToDemographicDao.java
@@ -11,6 +11,7 @@
 package ca.openosp.openo.hospitalReportManager.dao;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.persistence.Query;
@@ -147,6 +148,30 @@ public class HRMDocumentToDemographicDao extends AbstractDaoImpl<HRMDocumentToDe
         }
 
         return attachedHRMDocumentToDemographics;
+    }
+
+    /**
+     * Returns the subset of the given HRM document IDs that are linked to the specified patient.
+     *
+     * <p>Used to validate that HRM document attachments belong to the correct patient before
+     * an Ocean eReferral submission. Returns an empty list immediately when {@code hrmIds} is
+     * {@code null} or empty to avoid JPA provider exceptions on empty {@code IN} clauses.
+     *
+     * @param demographicNo Integer the patient's demographic number
+     * @param hrmIds        List&lt;Integer&gt; the HRM document IDs to validate; may be {@code null} or empty
+     * @return List&lt;Integer&gt; the HRM document IDs from {@code hrmIds} that belong to the patient,
+     *         or an empty list if {@code hrmIds} is {@code null} or empty
+     * @since 2026-03-24
+     */
+    @SuppressWarnings("unchecked")
+    public List<Integer> findHrmIdsForDemographic(Integer demographicNo, List<Integer> hrmIds) {
+        if (hrmIds == null || hrmIds.isEmpty()) return Collections.emptyList();
+        Query query = entityManager.createQuery(
+                "SELECT x.hrmDocumentId FROM HRMDocumentToDemographic x " +
+                "WHERE x.demographicNo = :demographicNo AND x.hrmDocumentId IN :hrmIds");
+        query.setParameter("demographicNo", demographicNo);
+        query.setParameter("hrmIds", hrmIds);
+        return query.getResultList();
     }
 
 }

--- a/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesFlowsheet.xml
+++ b/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesFlowsheet.xml
@@ -157,8 +157,15 @@
         ds_rules="diab-C-no-is-high.drl"/>
     <item
         measurement_type="FTLS"
-        display_name="Test loss of Sensation"
-        guideline="Check for peripheral anesthesia with 10g monofilament or 128 Hz tuning fork"
+        display_name="Neurological exam: 10g monofilament"
+        guideline="Check for peripheral anesthesia with 10g monofilament"
+        graphable="no"
+        value_name="Normal"
+        ds_rules="diab-C-no-is-high.drl"/>
+    <item
+        measurement_type="NRTF"
+        display_name="Neurological exam: 128Hz tuning fork D1"
+        guideline="Check for peripheral anesthesia with 128 Hz tuning fork"
         graphable="no"
         value_name="Normal"
         ds_rules="diab-C-no-is-high.drl"/>
@@ -389,19 +396,28 @@
     </measurement>   
  
            
-    <measurement 
-        type="FTLS"      
-        typeDesc="Foot Exam  Loss of Sensation"      
+    <measurement
+        type="FTLS"
+        typeDesc="Foot Exam  Loss of Sensation"
         typeDisplayName="Foot Exam  Test loss of Sensation"
-        measuringInstrc="Normal">  
+        measuringInstrc="Normal">
         <validationRule
            name="Yes/No"
-           regularExp="YES|yes|Yes|Y|NO|no|No|N"/>   
-    </measurement>   
- 
-          
-    <measurement 
-        type="PANE" 
+           regularExp="YES|yes|Yes|Y|NO|no|No|N"/>
+    </measurement>
+
+    <measurement
+        type="NRTF"
+        typeDesc="Neurological exam: 128Hz tuning fork D1"
+        typeDisplayName="Neurological exam: 128Hz tuning fork D1"
+        measuringInstrc="Normal">
+        <validationRule
+           name="Yes/No"
+           regularExp="YES|yes|Yes|Y|NO|no|No|N"/>
+    </measurement>
+
+    <measurement
+        type="PANE"
         typeDesc="Painful Neuropathy"      
         typeDisplayName="Painful Neuropathy" 
         measuringInstrc="Present">  

--- a/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesQueensFlowsheet.xml
+++ b/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesQueensFlowsheet.xml
@@ -96,7 +96,8 @@
 
 	<header display_name="Feet">
 		<item measurement_type="FTE" display_name="Foot Exam" guideline="Foot Care" graphable="no" value_name="Normal"  />
-		<item measurement_type="FTLS" display_name="Monofilament 10g" guideline="Check for peripheral anesthesia with 10g monofilament or 128 Hz tuning fork" graphable="no" value_name="Normal"  />
+		<item measurement_type="FTLS" display_name="Neurological exam: 10g monofilament" guideline="Check for peripheral anesthesia with 10g monofilament" graphable="no" value_name="Normal"  />
+		<item measurement_type="NRTF" display_name="Neurological exam: 128Hz tuning fork D1" guideline="Check for peripheral anesthesia with 128 Hz tuning fork" graphable="no" value_name="Normal"  />
 	</header>
 	
 	<header display_name="Psychosocial">
@@ -329,8 +330,12 @@
 	<measurement type="FTLS" typeDesc="Foot Exam  Loss of Sensation" typeDisplayName="Foot Exam  Test loss of Sensation" measuringInstrc="Normal">
 	  <validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>
-	
-	
+
+	<measurement type="NRTF" typeDesc="Neurological exam: 128Hz tuning fork D1" typeDisplayName="Neurological exam: 128Hz tuning fork D1" measuringInstrc="Normal">
+	  <validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
+	</measurement>
+
+
 	<measurement type="FGLC" typeDesc="Fasting glucose meter, lab comparison" typeDisplayName="Fasting Glucose meter , lab comparison" measuringInstrc="Within 20 percent">
 	  <validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>

--- a/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/omdDiabetesFlowsheet.xml
+++ b/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/omdDiabetesFlowsheet.xml
@@ -300,13 +300,23 @@
 				</recommendation>
 			</rules>
 		</item>
-		<item measurement_type="FTLS" display_name="Monofilament 10g" guideline="Check for peripheral anesthesia with 10g monofilament or 128 Hz tuning fork" graphable="no" value_name="Normal"  >
+		<item measurement_type="FTLS" display_name="Neurological exam: 10g monofilament" guideline="Check for peripheral anesthesia with 10g monofilament" graphable="no" value_name="Normal"  >
 			<rules>
 				<recommendation strength="warning" >
 					<condition type="monthrange" param="FTLS" value="&gt;12" />
 				</recommendation>
 				<recommendation strength="warning" >
 					<condition type="monthrange" param="FTLS" value="-1" />
+				</recommendation>
+			</rules>
+		</item>
+		<item measurement_type="NRTF" display_name="Neurological exam: 128Hz tuning fork D1" guideline="Check for peripheral anesthesia with 128 Hz tuning fork" graphable="no" value_name="Normal"  >
+			<rules>
+				<recommendation strength="warning" >
+					<condition type="monthrange" param="NRTF" value="&gt;12" />
+				</recommendation>
+				<recommendation strength="warning" >
+					<condition type="monthrange" param="NRTF" value="-1" />
 				</recommendation>
 			</rules>
 		</item>
@@ -696,7 +706,11 @@
 	<measurement type="FTLS" typeDesc="Foot Exam  Loss of Sensation" typeDisplayName="Foot Exam  Test loss of Sensation" measuringInstrc="Normal">
 		<validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>
-	
+
+	<measurement type="NRTF" typeDesc="Neurological exam: 128Hz tuning fork D1" typeDisplayName="Neurological exam: 128Hz tuning fork D1" measuringInstrc="Normal">
+		<validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
+	</measurement>
+
 	<measurement type="FGLC" typeDesc="Fasting glucose meter, lab comparison" typeDisplayName="Fasting Glucose meter , lab comparison" measuringInstrc="Within 20 percent">
 		<validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>

--- a/src/main/webapp/js/custom/ocean/conreq.js
+++ b/src/main/webapp/js/custom/ocean/conreq.js
@@ -34,20 +34,38 @@ jQuery(document).ready(function () {
     });
 });
 
+function validateAttachments(demographicNo, docs) {
+    let valid = false;
+    jQuery.ajax({
+        type: 'POST',
+        async: false,
+        url: document.getElementById("contextPath").value + '/oscarEncounter/eRefer.do',
+        data: "demographicNo=" + demographicNo + "&method=validateDocuments&" + jQuery.param({documents: docs}, true),
+        dataType: 'json',
+        success: function (response) { valid = response.valid; }
+    });
+    if (!valid) {
+        alert("Something went wrong. Please close this window and restart the process from the beginning.");
+    }
+    return valid;
+}
+
 // This code will be executed when a user sends a new e-refer to OceanMD from the consult request form.
 // It involves saving attachments in the 'EreferAttachment' table by sending the selected attachments (documents)
 // and demographic information to the EreferAction.java class.
 function eRefer(event) {
-    let demographicNo = document.getElementById("demographicNo").serialize();
+    let demographicNo = jQuery("#demographicNo").serialize();
     let documents = getDocuments(event);
-    let data = demographicNo + "&" + documents + "&method=attachOceanEReferralConsult";
+    let docs = documents.replace('documents=', '').split('|').filter(Boolean);
+    if (!validateAttachments(jQuery("#demographicNo").val(), docs)) {
+        throw new Error("Document validation failed");
+    }
+
     jQuery.ajax({
         type: 'POST',
         url: document.getElementById("contextPath").value + '/oscarEncounter/eRefer.do',
-        data: data,
-        success: function (response) {
-            console.log(response);
-        }
+        data: demographicNo + "&" + documents + "&method=attachOceanEReferralConsult",
+        success: function (response) { console.log(response); }
     });
 }
 
@@ -77,16 +95,18 @@ function getDocuments(event) {
 // It will update the attachments in the consult request and send those attachments to OceanMD
 // by saving them into the 'EreferAttachment' table.
 function attachOceanAttachments() {
-    let demographicNo = document.getElementById("demographicNo").serialize();
-    let requestId = document.getElementById("requestId").serialize();
+    let demographicNo = jQuery("#demographicNo").serialize();
+    let requestId = jQuery("#requestId").serialize();
     let documents = getDocuments();
-    let data = demographicNo + "&" + requestId + "&" + documents + "&method=editOceanEReferralConsult";
+    let docs = documents.replace('documents=', '').split('|').filter(Boolean);
+    if (!validateAttachments(jQuery("#demographicNo").val(), docs)) {
+        throw new Error("Document validation failed");
+    }
+
     jQuery.ajax({
         type: 'POST',
         url: document.getElementById("contextPath").value + '/oscarEncounter/eRefer.do',
-        data: data,
-        success: function (response) {
-            console.log(response);
-        }
+        data: demographicNo + "&" + requestId + "&" + documents + "&method=editOceanEReferralConsult",
+        success: function (response) { console.log(response); }
     });
 }

--- a/src/main/webapp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/oscarMDS/documentsInQueues.jsp
@@ -1825,13 +1825,14 @@
 //console.log('foundQ='+foundQ);
             //descrease the queue's doc number by 1
             if (foundQ.length > 0) {
-                var n = $('docNo_' + foundQ).innerHTML;
-                //console.log('not found11');
-                n = parseInt(n);
-                //console.log('not found22');
+                const el = document.getElementById('docNo_' + foundQ);
+                if (!el) { return; }
+
+                const n = parseInt(el.textContent, 10);
+                if (isNaN(n)) { return; }
+
                 if (n > 0) {
-                    //console.log('not found33');
-                    $('docNo_' + foundQ).innerHTML = n - 1;
+                    el.textContent = n - 1;
                 }
             }
             //console.log('not found44');

--- a/src/main/webapp/share/javascript/oscarMDSIndex.js
+++ b/src/main/webapp/share/javascript/oscarMDSIndex.js
@@ -1538,6 +1538,15 @@ function updateGlobalDataAndSideNav(doclabid, patientId) {
             na.splice(index, 1);
             addIdToPatient(doclabid, patientId);//add to patient
         }
+
+        // Update queue side nav count and remove from queue data if in queue context
+        if (typeof updateSideNavInQueue === 'function') {
+            updateSideNavInQueue(doclabid);
+        }
+        if (typeof removeDocFromQueue === 'function') {
+            removeDocFromQueue(doclabid);
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
## Summary

This package contains a couple of bugfixes and some additions required for OMD Validation. 

## Individual PRs

### 1. [**PR #2405**](https://github.com/openo-beta/Open-O/pull/2405) - Fix: Ocean eReferral attachment cross-patient validation (2 commits)
- Attachments (labs, documents, HRM records) submitted via Ocean eReferral were not validated to confirm they belonged to the correct patient, creating a risk of cross-patient data exposure
- Validation has been added server-side to reject attachments that do not belong to the demographic being referred; a serialization bug in the referral request has also been fixed, and empty-list guards added to prevent JPA exceptions

**Related Issue:** https://github.com/openo-beta/Open-O/issues/2382

### 2. [**PR #2403**](https://github.com/openo-beta/Open-O/pull/2403) - Fix: MDS queue doc count not updating after Save & Next (2 commits)
- A bug introduced in PR #2335 caused the document count badge in the MDs queue sidebar to stop decrementing after using Save & Next, because a subsequent jQuery reload was overwriting the updated count
- The queue count update logic has been restored and a `const` reassignment error introduced in the same change has been fixed

**Related Issue:** https://github.com/openo-beta/Open-O/issues/2384

### 3. [**PR #2380**](https://github.com/openo-beta/Open-O/pull/2380) - Fix: missing 128Hz tuning fork measurement on diabetes flowsheet (3 commits)
- The 128Hz tuning fork (D1) measurement required for OMD validation was missing from the diabetes flowsheet
- The measurement has been added along with the necessary database migration, and a capitalisation inconsistency in the measurement label was corrected

**Related Issue:** https://github.com/openo-beta/Open-O/issues/2338

### 4. [**PR #2383**](https://github.com/openo-beta/Open-O/pull/2383) - Feat: add OMA uninsured service fees to private billing form (3 commits)
- OMA uninsured service fee codes were missing from the private billing form, blocking OMD validation requirements
- The fees have been added to the billing service table along with the necessary database migration

**Related Issue:** https://github.com/openo-beta/Open-O/issues/2381

### 5. [**PR #2402**](https://github.com/openo-beta/Open-O/pull/2402) - Chore: fix Maven repository resolution order and update .gitignore (2 commits)
- The Maven repository order was incorrectly placing JitPack above the standard repositories, causing slower and less reliable artifact resolution
- Repository order has been corrected and Eclipse IDE files have been added to `.gitignore`
