### PR TITLE
Encoder updates and fixes followup (to PR 225)

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -432,6 +432,14 @@
     "optional" : false,
     "integrity" : "sha512:L+w8UAxL7RQ6SOhOmNWTjcR3SDDpyHbK8M/Di9nq7RiQcnjropJGd1T9EyyfuzCTAJ89yR91/xprznH09dQ7FA=="
   }, {
+    "groupId" : "com.github.stephenc.jcip",
+    "artifactId" : "jcip-annotations",
+    "version" : "1.0-1",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:AvzRajDQ5os+nkiZcxGBxqu3EXuqFcCWypQOAd3gi7hhAcvq5VLEl/ipDZI7X6LytvOFC6+NyU29OZiHkkqQaQ=="
+  }, {
     "groupId" : "com.google.auto.service",
     "artifactId" : "auto-service-annotations",
     "version" : "1.1.1",
@@ -583,6 +591,38 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:Gc/JbnIfkDdHrwCXWo5a1A4ewH9m3CxHA/yfDUJk2HDPrAkEBQd5NoJQltzJfBcU0QsRHIMn3867gUnQo8sgTQ=="
+  }, {
+    "groupId" : "com.nimbusds",
+    "artifactId" : "content-type",
+    "version" : "2.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:Kz19vxAmRbG2wR3pZ6h37duV6NOORBjPDE9xEnIMq3L4r4oCweaikKxzcYa/tX1cbbkHrG51gMFsYm8CvX7q6Q=="
+  }, {
+    "groupId" : "com.nimbusds",
+    "artifactId" : "lang-tag",
+    "version" : "1.7",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:SUJndmyXTOFqmcsiGVPtyR/ejbDJICMHWOzqDqnTAG6V2GrUb3qdYbgQ2FsPptqaPOK1B82+S+MgxJnq6pNmaw=="
+  }, {
+    "groupId" : "com.nimbusds",
+    "artifactId" : "nimbus-jose-jwt",
+    "version" : "9.37.3",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:Sp9mm9D6RtcClu+zJNBGNP0uWyBD5uzhsq7ASy7gSVG3Xi/lj7Cm25tCYBjimvcTTYcP4L9JXFZ5GQjPVw0/mQ=="
+  }, {
+    "groupId" : "com.nimbusds",
+    "artifactId" : "oauth2-oidc-sdk",
+    "version" : "9.43.6",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:mLjzfNF20E0laCmowAC5uhJm9GsqVLM33QTBUOQkG88x+CUSsEJjoNy+cYgt/pD7oUcu/cOxHSTz1UUXYuirmg=="
   }, {
     "groupId" : "com.onelogin",
     "artifactId" : "java-saml-core",
@@ -953,6 +993,22 @@
     "optional" : false,
     "integrity" : "sha512:TSXsVUMPPIBP0lpkm4GwlaH3QqmLmWsjEM14Vn7zBZZDzE04U24FyezojodAnXbFcEctPBfGrM4bvSInnVlyDw=="
   }, {
+    "groupId" : "io.micrometer",
+    "artifactId" : "micrometer-commons",
+    "version" : "1.12.13",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:9XCdRde5kF2CrOGBYHhfYvE1vPlNcEAarv+7bxMeV3EuC0NBPD3ds0fCxJx9U+F2ZBUqdWm33A+mTKUHe1JAvg=="
+  }, {
+    "groupId" : "io.micrometer",
+    "artifactId" : "micrometer-observation",
+    "version" : "1.12.13",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:lHjLZ/lpii8JZdYLITH5yDvJ0UhTNmh/ge0076E016Ukq6FkYZLrvEKZRHrUaiHxpeGiLmbBogcyKbftN3r0rw=="
+  }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-buffer",
     "version" : "4.1.129.Final",
@@ -960,6 +1016,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:TZ++bNn6SnhTDlaAt/7D+agp/899U6zW12iLPtHokZGvdmKC6gNAKXpCd+hTcZuV2JjNE4JEjdF8iQtBSxD6NQ=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-codec-dns",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:JdF4cBB7LgoYefiZzSUi5Iq9Fb7QFUfczCuzr1wn70pecwME5CitoACbXWYtbImXWB0xaClP9X3lGmEugT9I1Q=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-codec-http2",
@@ -970,12 +1034,77 @@
     "integrity" : "sha512:vxWCF/NlHB5j+5GOY6lCHjHeP8gdAOcUkU0BUx0P9vJNaLZNIKnMKo5XbWdEh9l2yFga77vf/cLk8Ah7gSQjoA=="
   }, {
     "groupId" : "io.netty",
+    "artifactId" : "netty-codec-http",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:yQpCTQ/yXuIzWUmUfx1XUozHN8dcmmbVKnE7ZW3lCJoNlQ0sdZ11vGCFi5oUq8brnHyHkJXRXqTiWGNSrSQD3g=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-codec-socks",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:Z8X0n28aorVQb5Lui5RpRPhtClkHDlIuR4ZyzhA9ltSTOyEnoU206AoSsWCc91Jhzl9ZVPuFKYivyOIgqNAK4A=="
+  }, {
+    "groupId" : "io.netty",
     "artifactId" : "netty-codec",
     "version" : "4.1.129.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:2Y3teF1BFRL7Aq08NaTzA1EGjTxAeIM2G/VE0snNNbid5avgA5BDHw9dgHVlwySA3K7Why91axuATNOya3BMiw=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-common",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:tkpkF6ZfinLDMrD46SkuGo4ZB8nfeRR6EtyEGr7AaFUs5LNESRoItNdVpHRBG2vLqmv9e3yRYx9SxMZ9W50pQg=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-handler-proxy",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:xrENm0RjeKChw0al3vmuSwHU/GC/rfKdyz66/DzWRxTHQaWaoMwmWYtkv/Ukido4rDIgiv1tQ2bQacpu8LXLGw=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-handler",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:J+NZOhCl5U6sl5ChD/DR/4uvgeEeNJBWvu3C0xfIWznitQ+74+pQZ5UZY1KWzAD0iMucPN0/dxEpfInMEAPFQw=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-resolver-dns-classes-macos",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:VtWsLfpnXOB10ESQm1oOJ3trUFX+zHCWW0no0IV5mZba+vj8eyGiQn6PVjH+GsLyPD1nH1xYLAMVWpkIQjEpTA=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-resolver-dns-native-macos",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:6rnXbRzNdHYK8pT4s5AgaceaKyrAw7SVrTmklKda4jVbE1tjbVIe535MSBn9d97T0pZuoUEjAy+bL+6YyIn4WQ==",
+    "classifier" : "osx-x86_64"
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-resolver-dns",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:YEmsdoXSMabLgj8HamL7vo50iVEawdc5oZDcx6v6xwfxOWQ93thmVDnkIcLoTOMBkJOxh0EUc61rlsRZrKZqIg=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-resolver",
@@ -986,12 +1115,53 @@
     "integrity" : "sha512:X+Kgn7DSj3hELxfrWpsZ/9nohX9InMUfynI/hOH6JmzzelB8tk1/QhDmD5Q4R4GtdgcyxfpwegYtSqUp0RaXAQ=="
   }, {
     "groupId" : "io.netty",
+    "artifactId" : "netty-transport-classes-epoll",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:egD2JWyaj+onn6oKzyLKiZdKtS5kRTurpaSK3MtEolJ0aU+1CExizfrWdYX6h0r/l1W1IgWU1XKcxHsw8KtFOw=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-transport-native-epoll",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:Hia9G7Rd14/fMK2bx4DZpiHO7ixRuLHsVMzcNewtkaZrFSWFghVHD7LxJWqEnEtltAFyTpowbNIzx05Xc7B28Q==",
+    "classifier" : "linux-x86_64"
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-transport-native-unix-common",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:gHb18BZVyqHQzjK8POQPeEZNTxv9yEAkXTkSPg3xn6H5oL1M0jZBdnT2NTq41JHrdVG7LSGx90/wap6dJ76nwA=="
+  }, {
+    "groupId" : "io.netty",
     "artifactId" : "netty-transport",
     "version" : "4.1.129.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:3ulAVVAU1Ng/XJrXMIUomsIeAzf9x+svAjqmt4v+7iS2uhdUREU1+4JrIoe+AKY8fBI2Ay74MBl6l3lJs2hZpA=="
+  }, {
+    "groupId" : "io.projectreactor.netty",
+    "artifactId" : "reactor-netty-core",
+    "version" : "1.0.40",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:yn1YX1mG6BfLO5cZRlMsAPYqkHS1kVTxIPoDRgOr1fLtLxtvEFyR91Blm5Toi+8PBf0va4R42HKYW5lnm8LM1g=="
+  }, {
+    "groupId" : "io.projectreactor.netty",
+    "artifactId" : "reactor-netty-http",
+    "version" : "1.0.40",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:dab/uo9l/8qsMvrXL53450TmNAzY5Us0asYz+n5FpT566WP3aKaz6YKuazS0U7uugzbZuciMGyXZr3g2ZKs3kw=="
   }, {
     "groupId" : "io.projectreactor",
     "artifactId" : "reactor-core",
@@ -1280,6 +1450,22 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+  }, {
+    "groupId" : "net.minidev",
+    "artifactId" : "accessors-smart",
+    "version" : "2.5.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:O70pdhYicUrGHb4CuDURiFc/gZvav7QCUZaj8VYb/lLMMIr5IIGE9zOcZpiOf4rTI8XNew+oRjMhtrsD5KkYHg=="
+  }, {
+    "groupId" : "net.minidev",
+    "artifactId" : "json-smart",
+    "version" : "2.5.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:CHkxxvJUx+VP91tulJg9BititoNWqYil7SdoGby0+vutLwu8Nj4WyNqgntgYkkHwjv9ujl9fPdx3C1QdlvyOLQ=="
   }, {
     "groupId" : "net.sf.ehcache",
     "artifactId" : "ehcache",
@@ -3346,12 +3532,44 @@
     "integrity" : "sha512:3BwvcFqB8d2IEyX3Q65nkBsrHcdgRTawbllr47DYPXvNqYI5c1Xu1QQIJMunuxXTYkWjiSUWOl+LLqSoJ4/nGg=="
   }, {
     "groupId" : "org.springframework.security",
+    "artifactId" : "spring-security-core",
+    "version" : "6.3.9",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:7zEzcxbxRG81yvIX9hvt2yHC3fI8sg5IpZuyUeqpjWRd0Q1o6lLZlQOHbTZFypB95QIk097Y61sHdH52nGrQtQ=="
+  }, {
+    "groupId" : "org.springframework.security",
     "artifactId" : "spring-security-crypto",
     "version" : "6.3.9",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:miq5ftqPiXgbLMVicLUvnSO53a62SqSXA5TPH9Xl7CrSptRriFpGDMPMCbp1Jx48tphBzJ3Z+AHoNgvC2b57Dw=="
+  }, {
+    "groupId" : "org.springframework.security",
+    "artifactId" : "spring-security-oauth2-client",
+    "version" : "6.3.9",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:rYv00k+F7iHlgpH7OtckXS/cc3L5uNdwsi+LkPSS6B6cgS0yPh7CAOHbXmuE/GqlBbxTZH2n8NHI+iF9NAKltw=="
+  }, {
+    "groupId" : "org.springframework.security",
+    "artifactId" : "spring-security-oauth2-core",
+    "version" : "6.3.9",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:J+D0UCAAlQlY1d9W7HK7zEdgb1kc3h9LI/4SFMvwmfbxAk9+XBITHlu8RHJKHqMeX2F6Wh7toCKrN9ArheRHGQ=="
+  }, {
+    "groupId" : "org.springframework.security",
+    "artifactId" : "spring-security-web",
+    "version" : "6.3.9",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:R3Fu2fvVQHUXo5hlrAx3MVeVfhlM9lQDf5BIN0g/6I++Xyw4XEUaEu16LYnSqm134jDwHJt+zbmst6Wgx+DVRw=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-aop",
@@ -3464,6 +3682,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:vowFRRgmOo6zoaEpT13mi6GAWMYADi0yvogsXp2919yO4v8fKdfLuSy3WZ+noey+VC/aNXTA0Efe1dTHAhBCCg=="
+  }, {
+    "groupId" : "org.springframework",
+    "artifactId" : "spring-webflux",
+    "version" : "5.3.39",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:A1u75oGGgzzzPBwO0Wgu5u2EHZdBABpxUQYXxLgr0yJvG2uCzWz55qB3Qleqm+7aM5qVYums9mo5fbPDERIbdQ=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-webmvc",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -432,6 +432,14 @@
     "optional" : false,
     "integrity" : "sha512:L+w8UAxL7RQ6SOhOmNWTjcR3SDDpyHbK8M/Di9nq7RiQcnjropJGd1T9EyyfuzCTAJ89yR91/xprznH09dQ7FA=="
   }, {
+    "groupId" : "com.github.stephenc.jcip",
+    "artifactId" : "jcip-annotations",
+    "version" : "1.0-1",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:AvzRajDQ5os+nkiZcxGBxqu3EXuqFcCWypQOAd3gi7hhAcvq5VLEl/ipDZI7X6LytvOFC6+NyU29OZiHkkqQaQ=="
+  }, {
     "groupId" : "com.google.auto.service",
     "artifactId" : "auto-service-annotations",
     "version" : "1.1.1",
@@ -583,6 +591,38 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:Gc/JbnIfkDdHrwCXWo5a1A4ewH9m3CxHA/yfDUJk2HDPrAkEBQd5NoJQltzJfBcU0QsRHIMn3867gUnQo8sgTQ=="
+  }, {
+    "groupId" : "com.nimbusds",
+    "artifactId" : "content-type",
+    "version" : "2.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:Kz19vxAmRbG2wR3pZ6h37duV6NOORBjPDE9xEnIMq3L4r4oCweaikKxzcYa/tX1cbbkHrG51gMFsYm8CvX7q6Q=="
+  }, {
+    "groupId" : "com.nimbusds",
+    "artifactId" : "lang-tag",
+    "version" : "1.7",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:SUJndmyXTOFqmcsiGVPtyR/ejbDJICMHWOzqDqnTAG6V2GrUb3qdYbgQ2FsPptqaPOK1B82+S+MgxJnq6pNmaw=="
+  }, {
+    "groupId" : "com.nimbusds",
+    "artifactId" : "nimbus-jose-jwt",
+    "version" : "9.37.3",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:Sp9mm9D6RtcClu+zJNBGNP0uWyBD5uzhsq7ASy7gSVG3Xi/lj7Cm25tCYBjimvcTTYcP4L9JXFZ5GQjPVw0/mQ=="
+  }, {
+    "groupId" : "com.nimbusds",
+    "artifactId" : "oauth2-oidc-sdk",
+    "version" : "9.43.6",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:mLjzfNF20E0laCmowAC5uhJm9GsqVLM33QTBUOQkG88x+CUSsEJjoNy+cYgt/pD7oUcu/cOxHSTz1UUXYuirmg=="
   }, {
     "groupId" : "com.onelogin",
     "artifactId" : "java-saml-core",
@@ -953,6 +993,22 @@
     "optional" : false,
     "integrity" : "sha512:TSXsVUMPPIBP0lpkm4GwlaH3QqmLmWsjEM14Vn7zBZZDzE04U24FyezojodAnXbFcEctPBfGrM4bvSInnVlyDw=="
   }, {
+    "groupId" : "io.micrometer",
+    "artifactId" : "micrometer-commons",
+    "version" : "1.12.13",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:9XCdRde5kF2CrOGBYHhfYvE1vPlNcEAarv+7bxMeV3EuC0NBPD3ds0fCxJx9U+F2ZBUqdWm33A+mTKUHe1JAvg=="
+  }, {
+    "groupId" : "io.micrometer",
+    "artifactId" : "micrometer-observation",
+    "version" : "1.12.13",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:lHjLZ/lpii8JZdYLITH5yDvJ0UhTNmh/ge0076E016Ukq6FkYZLrvEKZRHrUaiHxpeGiLmbBogcyKbftN3r0rw=="
+  }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-buffer",
     "version" : "4.1.129.Final",
@@ -960,6 +1016,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:TZ++bNn6SnhTDlaAt/7D+agp/899U6zW12iLPtHokZGvdmKC6gNAKXpCd+hTcZuV2JjNE4JEjdF8iQtBSxD6NQ=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-codec-dns",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:JdF4cBB7LgoYefiZzSUi5Iq9Fb7QFUfczCuzr1wn70pecwME5CitoACbXWYtbImXWB0xaClP9X3lGmEugT9I1Q=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-codec-http2",
@@ -970,12 +1034,77 @@
     "integrity" : "sha512:vxWCF/NlHB5j+5GOY6lCHjHeP8gdAOcUkU0BUx0P9vJNaLZNIKnMKo5XbWdEh9l2yFga77vf/cLk8Ah7gSQjoA=="
   }, {
     "groupId" : "io.netty",
+    "artifactId" : "netty-codec-http",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:yQpCTQ/yXuIzWUmUfx1XUozHN8dcmmbVKnE7ZW3lCJoNlQ0sdZ11vGCFi5oUq8brnHyHkJXRXqTiWGNSrSQD3g=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-codec-socks",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:Z8X0n28aorVQb5Lui5RpRPhtClkHDlIuR4ZyzhA9ltSTOyEnoU206AoSsWCc91Jhzl9ZVPuFKYivyOIgqNAK4A=="
+  }, {
+    "groupId" : "io.netty",
     "artifactId" : "netty-codec",
     "version" : "4.1.129.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:2Y3teF1BFRL7Aq08NaTzA1EGjTxAeIM2G/VE0snNNbid5avgA5BDHw9dgHVlwySA3K7Why91axuATNOya3BMiw=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-common",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:tkpkF6ZfinLDMrD46SkuGo4ZB8nfeRR6EtyEGr7AaFUs5LNESRoItNdVpHRBG2vLqmv9e3yRYx9SxMZ9W50pQg=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-handler-proxy",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:xrENm0RjeKChw0al3vmuSwHU/GC/rfKdyz66/DzWRxTHQaWaoMwmWYtkv/Ukido4rDIgiv1tQ2bQacpu8LXLGw=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-handler",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:J+NZOhCl5U6sl5ChD/DR/4uvgeEeNJBWvu3C0xfIWznitQ+74+pQZ5UZY1KWzAD0iMucPN0/dxEpfInMEAPFQw=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-resolver-dns-classes-macos",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:VtWsLfpnXOB10ESQm1oOJ3trUFX+zHCWW0no0IV5mZba+vj8eyGiQn6PVjH+GsLyPD1nH1xYLAMVWpkIQjEpTA=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-resolver-dns-native-macos",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:6rnXbRzNdHYK8pT4s5AgaceaKyrAw7SVrTmklKda4jVbE1tjbVIe535MSBn9d97T0pZuoUEjAy+bL+6YyIn4WQ==",
+    "classifier" : "osx-x86_64"
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-resolver-dns",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:YEmsdoXSMabLgj8HamL7vo50iVEawdc5oZDcx6v6xwfxOWQ93thmVDnkIcLoTOMBkJOxh0EUc61rlsRZrKZqIg=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-resolver",
@@ -986,12 +1115,53 @@
     "integrity" : "sha512:X+Kgn7DSj3hELxfrWpsZ/9nohX9InMUfynI/hOH6JmzzelB8tk1/QhDmD5Q4R4GtdgcyxfpwegYtSqUp0RaXAQ=="
   }, {
     "groupId" : "io.netty",
+    "artifactId" : "netty-transport-classes-epoll",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:egD2JWyaj+onn6oKzyLKiZdKtS5kRTurpaSK3MtEolJ0aU+1CExizfrWdYX6h0r/l1W1IgWU1XKcxHsw8KtFOw=="
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-transport-native-epoll",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:Hia9G7Rd14/fMK2bx4DZpiHO7ixRuLHsVMzcNewtkaZrFSWFghVHD7LxJWqEnEtltAFyTpowbNIzx05Xc7B28Q==",
+    "classifier" : "linux-x86_64"
+  }, {
+    "groupId" : "io.netty",
+    "artifactId" : "netty-transport-native-unix-common",
+    "version" : "4.1.129.Final",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:gHb18BZVyqHQzjK8POQPeEZNTxv9yEAkXTkSPg3xn6H5oL1M0jZBdnT2NTq41JHrdVG7LSGx90/wap6dJ76nwA=="
+  }, {
+    "groupId" : "io.netty",
     "artifactId" : "netty-transport",
     "version" : "4.1.129.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:3ulAVVAU1Ng/XJrXMIUomsIeAzf9x+svAjqmt4v+7iS2uhdUREU1+4JrIoe+AKY8fBI2Ay74MBl6l3lJs2hZpA=="
+  }, {
+    "groupId" : "io.projectreactor.netty",
+    "artifactId" : "reactor-netty-core",
+    "version" : "1.0.40",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:yn1YX1mG6BfLO5cZRlMsAPYqkHS1kVTxIPoDRgOr1fLtLxtvEFyR91Blm5Toi+8PBf0va4R42HKYW5lnm8LM1g=="
+  }, {
+    "groupId" : "io.projectreactor.netty",
+    "artifactId" : "reactor-netty-http",
+    "version" : "1.0.40",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:dab/uo9l/8qsMvrXL53450TmNAzY5Us0asYz+n5FpT566WP3aKaz6YKuazS0U7uugzbZuciMGyXZr3g2ZKs3kw=="
   }, {
     "groupId" : "io.projectreactor",
     "artifactId" : "reactor-core",
@@ -1280,6 +1450,22 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+  }, {
+    "groupId" : "net.minidev",
+    "artifactId" : "accessors-smart",
+    "version" : "2.5.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:O70pdhYicUrGHb4CuDURiFc/gZvav7QCUZaj8VYb/lLMMIr5IIGE9zOcZpiOf4rTI8XNew+oRjMhtrsD5KkYHg=="
+  }, {
+    "groupId" : "net.minidev",
+    "artifactId" : "json-smart",
+    "version" : "2.5.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:CHkxxvJUx+VP91tulJg9BititoNWqYil7SdoGby0+vutLwu8Nj4WyNqgntgYkkHwjv9ujl9fPdx3C1QdlvyOLQ=="
   }, {
     "groupId" : "net.sf.ehcache",
     "artifactId" : "ehcache",
@@ -3282,12 +3468,44 @@
     "integrity" : "sha512:3BwvcFqB8d2IEyX3Q65nkBsrHcdgRTawbllr47DYPXvNqYI5c1Xu1QQIJMunuxXTYkWjiSUWOl+LLqSoJ4/nGg=="
   }, {
     "groupId" : "org.springframework.security",
+    "artifactId" : "spring-security-core",
+    "version" : "6.3.9",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:7zEzcxbxRG81yvIX9hvt2yHC3fI8sg5IpZuyUeqpjWRd0Q1o6lLZlQOHbTZFypB95QIk097Y61sHdH52nGrQtQ=="
+  }, {
+    "groupId" : "org.springframework.security",
     "artifactId" : "spring-security-crypto",
     "version" : "6.3.9",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:miq5ftqPiXgbLMVicLUvnSO53a62SqSXA5TPH9Xl7CrSptRriFpGDMPMCbp1Jx48tphBzJ3Z+AHoNgvC2b57Dw=="
+  }, {
+    "groupId" : "org.springframework.security",
+    "artifactId" : "spring-security-oauth2-client",
+    "version" : "6.3.9",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:rYv00k+F7iHlgpH7OtckXS/cc3L5uNdwsi+LkPSS6B6cgS0yPh7CAOHbXmuE/GqlBbxTZH2n8NHI+iF9NAKltw=="
+  }, {
+    "groupId" : "org.springframework.security",
+    "artifactId" : "spring-security-oauth2-core",
+    "version" : "6.3.9",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:J+D0UCAAlQlY1d9W7HK7zEdgb1kc3h9LI/4SFMvwmfbxAk9+XBITHlu8RHJKHqMeX2F6Wh7toCKrN9ArheRHGQ=="
+  }, {
+    "groupId" : "org.springframework.security",
+    "artifactId" : "spring-security-web",
+    "version" : "6.3.9",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:R3Fu2fvVQHUXo5hlrAx3MVeVfhlM9lQDf5BIN0g/6I++Xyw4XEUaEu16LYnSqm134jDwHJt+zbmst6Wgx+DVRw=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-aop",
@@ -3400,6 +3618,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:vowFRRgmOo6zoaEpT13mi6GAWMYADi0yvogsXp2919yO4v8fKdfLuSy3WZ+noey+VC/aNXTA0Efe1dTHAhBCCg=="
+  }, {
+    "groupId" : "org.springframework",
+    "artifactId" : "spring-webflux",
+    "version" : "5.3.39",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:A1u75oGGgzzzPBwO0Wgu5u2EHZdBABpxUQYXxLgr0yJvG2uCzWz55qB3Qleqm+7aM5qVYums9mo5fbPDERIbdQ=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-webmvc",

--- a/src/main/java/ca/openosp/openo/billings/MSP/CheckBillingData.java
+++ b/src/main/java/ca/openosp/openo/billings/MSP/CheckBillingData.java
@@ -31,6 +31,8 @@ package ca.openosp.openo.billings.MSP;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.owasp.encoder.Encode;
+
 public class CheckBillingData {
 
     // check batchHeader VS1
@@ -67,18 +69,38 @@ public class CheckBillingData {
         return ret;
     }
 
+    /**
+     * Wraps a plain-text warning message in an orange warning row of the billing
+     * validation report. The message is HTML-encoded at output, so callers must
+     * pass plain text - HTML fragments (e.g. {@code <br>}, {@code <span>}) will
+     * be escaped and shown as literal text rather than rendered as markup.
+     *
+     * @param m String the plain-text warning message
+     * @return String the rendered {@code <tr>} HTML fragment
+     */
     public String printWarningMsg(String m) {
-        String ret = "<tr bgcolor='orange'><td colspan='11'>" + m
+        String ret = "<tr bgcolor='orange'><td colspan='11'>" + Encode.forHtmlContent(String.valueOf(m))
                 + "</td></tr>";
         return ret;
     }
 
+    /**
+     * Wraps a plain-text error message in a red error row of the billing
+     * validation report, linked to the {@code adjustBill.jsp} popup for the
+     * given billing number. The message is HTML-encoded at output, so callers
+     * must pass plain text - HTML fragments will be escaped and shown as
+     * literal text rather than rendered as markup.
+     *
+     * @param billingNo String the billing master number used in the adjust-bill link
+     * @param m String the plain-text error message
+     * @return String the rendered {@code <tr>} HTML fragment
+     */
     public String printErrorMsg(String billingNo, String m) {
         String ret = "<tr bgcolor='red'><td colspan='11'>"
                 + "<a href='#' onClick=\"openBrWindow('adjustBill.jsp?billingmaster_no="
-                + billingNo
+                + Encode.forUriComponent(String.valueOf(billingNo))
                 + "','','resizable=yes,scrollbars=yes,top=0,left=0,width=900,height=600'); return false;\">"
-                + m + "</a>" + "</td></tr>";
+                + Encode.forHtmlContent(String.valueOf(m)) + "</a>" + "</td></tr>";
         return ret;
     }
 

--- a/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/CheckBillingData.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/CheckBillingData.java
@@ -28,6 +28,7 @@
  */
 package ca.openosp.openo.billings.ca.bc.MSP;
 
+import org.owasp.encoder.Encode;
 import ca.openosp.openo.entities.Billingmaster;
 import ca.openosp.openo.util.SqlUtils;
 
@@ -72,18 +73,38 @@ public class CheckBillingData {
         return ret;
     }
 
+    /**
+     * Wraps a plain-text warning message in an orange warning row of the billing
+     * validation report. The message is HTML-encoded at output, so callers must
+     * pass plain text - HTML fragments (e.g. {@code <br>}, {@code <span>}) will
+     * be escaped and shown as literal text rather than rendered as markup.
+     *
+     * @param m String the plain-text warning message
+     * @return String the rendered {@code <tr>} HTML fragment
+     */
     public String printWarningMsg(String m) {
-        String ret = "<tr bgcolor='orange'><td colspan='11'>" + m
+        String ret = "<tr bgcolor='orange'><td colspan='11'>" + Encode.forHtmlContent(String.valueOf(m))
                 + "</td></tr>";
         return ret;
     }
 
+    /**
+     * Wraps a plain-text error message in a red error row of the billing
+     * validation report, linked to the {@code adjustBill.jsp} popup for the
+     * given billing number. The message is HTML-encoded at output, so callers
+     * must pass plain text - HTML fragments will be escaped and shown as
+     * literal text rather than rendered as markup.
+     *
+     * @param billingNo String the billing master number used in the adjust-bill link
+     * @param m String the plain-text error message
+     * @return String the rendered {@code <tr>} HTML fragment
+     */
     public String printErrorMsg(String billingNo, String m) {
         String ret = "<tr bgcolor='red'><td colspan='11'>"
                 + "<a href='#' onClick=\"openBrWindow('adjustBill.jsp?billingmaster_no="
-                + billingNo
+                + Encode.forUriComponent(String.valueOf(billingNo))
                 + "','','resizable=yes,scrollbars=yes,top=0,left=0,width=900,height=600'); return false;\">"
-                + m + "</a>" + "</td></tr>";
+                + Encode.forHtmlContent(String.valueOf(m)) + "</a>" + "</td></tr>";
         return ret;
     }
 

--- a/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/ExtractBean.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/ExtractBean.java
@@ -27,6 +27,7 @@
 package ca.openosp.openo.billings.ca.bc.MSP;
 
 import org.apache.logging.log4j.Logger;
+import org.owasp.encoder.Encode;
 import ca.openosp.openo.billing.CA.BC.dao.LogTeleplanTxDao;
 import ca.openosp.openo.billing.CA.BC.model.LogTeleplanTx;
 import ca.openosp.openo.billing.CA.BC.model.Wcb;
@@ -259,7 +260,7 @@ public class ExtractBean extends Object implements Serializable {
             pCount = pCount + patientCount;
             rCount = rCount + recordCount;
 
-            htmlFooter = "<tr>    <td colspan='11' class='bodytext'>&nbsp;</td>  </tr>  <tr>    <td colspan='5' class='bodytext'>Billing No: " + providerNo + ": " + pCount + " RECORDS PROCESSED</td>    <td colspan='6' class='bodytext'>TOTAL: " + BigTotal + "</td>  </tr></table></body></html>";
+            htmlFooter = "<tr>    <td colspan='11' class='bodytext'>&nbsp;</td>  </tr>  <tr>    <td colspan='5' class='bodytext'>Billing No: " + Encode.forHtmlContent(String.valueOf(providerNo)) + ": " + Encode.forHtmlContent(String.valueOf(pCount)) + " RECORDS PROCESSED</td>    <td colspan='6' class='bodytext'>TOTAL: " + Encode.forHtmlContent(String.valueOf(BigTotal)) + "</td>  </tr></table></body></html>";
             htmlCode = htmlContentHeader + htmlContent + htmlFooter;
 
             writeHtml(htmlCode);
@@ -528,8 +529,8 @@ public class ExtractBean extends Object implements Serializable {
         htmlContentHeader = "<html><body><style type='text/css'><!-- .bodytext{  font-family: Tahoma, Arial, Helvetica, sans-serif;  font-size: 12px; font-style: normal;  line-height: normal;  font-weight: normal;  font-variant: normal;  text-transform: none;  color: #003366;  text-decoration: none; --></style>";
         htmlContentHeader += "<table width='100%' border='0' cellspacing='0' cellpadding='0'>";
         htmlContentHeader += "<tr>";
-        htmlContentHeader += "<td colspan='4' class='bodytext'>Billing Invoice for Billing No." + providerNo + "</td>";
-        htmlContentHeader += "<td colspan='7' class='bodytext'>Payment date of " + output + "</td>";
+        htmlContentHeader += "<td colspan='4' class='bodytext'>Billing Invoice for Billing No." + Encode.forHtmlContent(String.valueOf(providerNo)) + "</td>";
+        htmlContentHeader += "<td colspan='7' class='bodytext'>Payment date of " + Encode.forHtmlContent(String.valueOf(output)) + "</td>";
         htmlContentHeader += "</tr>";
         htmlContentHeader += "<tr>";
         htmlContentHeader += "<td width='9%' class='bodytext'>INVOICE</td>";
@@ -549,24 +550,25 @@ public class ExtractBean extends Object implements Serializable {
     }
 
     public String htmlLine(String billingMasterNo, String invNo, String demoName, String phn, String serviceDate, String billingCode, String billAmount, String dx1, String dx2, String dx3) {
+        String paddedBillingMasterNo = Misc.forwardZero(billingMasterNo, 7);
         String htmlContent =
                 "<tr>" +
                         "<td class='bodytext'>" +
                         "<a href='#' onClick=\"openBrWindow('adjustBill.jsp?billingmaster_no=" +
-                        Misc.forwardZero(billingMasterNo, 7) +
+                        Encode.forUriComponent(String.valueOf(paddedBillingMasterNo)) +
                         "','','resizable=yes,scrollbars=yes,top=0,left=0,width=900,height=600'); return false;\">" +
-                        invNo +
+                        Encode.forHtmlContent(String.valueOf(invNo)) +
                         "</a>" +
                         "</td>" +
-                        "<td class='bodytext'>" + demoName + "</td>" +
-                        "<td class='bodytext'>" + phn + "</td>" +
-                        "<td class='bodytext'>" + serviceDate + "</td>" +
-                        "<td class='bodytext'>" + billingCode + "</td>" +
-                        "<td align='right' class='bodytext'>" + billAmount + "</td>" +
-                        "<td align='right' class='bodytext'>" + Misc.backwardSpace(dx1, 5) + "</td>" +
-                        "<td align='right' class='bodytext'>" + Misc.backwardSpace(dx2, 5) + "</td>" +
-                        "<td align='right' class='bodytext'>" + Misc.backwardSpace(dx3, 5) + "</td>" +
-                        "<td class='bodytext'>" + Misc.forwardZero(billingMasterNo, 7) + "</td>" +
+                        "<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(demoName)) + "</td>" +
+                        "<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(phn)) + "</td>" +
+                        "<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(serviceDate)) + "</td>" +
+                        "<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(billingCode)) + "</td>" +
+                        "<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(billAmount)) + "</td>" +
+                        "<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(Misc.backwardSpace(dx1, 5))) + "</td>" +
+                        "<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(Misc.backwardSpace(dx2, 5))) + "</td>" +
+                        "<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(Misc.backwardSpace(dx3, 5))) + "</td>" +
+                        "<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(paddedBillingMasterNo)) + "</td>" +
                         "<td class='bodytext'>&nbsp;</td>" +
                         "</tr>";
         return htmlContent;

--- a/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/HtmlTeleplanHelper.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/HtmlTeleplanHelper.java
@@ -26,6 +26,7 @@
 
 package ca.openosp.openo.billings.ca.bc.MSP;
 
+import org.owasp.encoder.Encode;
 import ca.openosp.Misc;
 
 import java.math.BigDecimal;
@@ -66,8 +67,8 @@ public class HtmlTeleplanHelper {
         }
         StringBuilder htmlContentHeader = new StringBuilder();
         htmlContentHeader.append("<tr> \n");
-        htmlContentHeader.append("<td colspan='4' class='bodytext'>Billing Invoice for Billing No." + providerNo + "</td> \n");
-        htmlContentHeader.append("<td colspan='7' class='bodytext'>Payment date of " + dateStr + "</td> \n");
+        htmlContentHeader.append("<td colspan='4' class='bodytext'>Billing Invoice for Billing No." + Encode.forHtmlContent(String.valueOf(providerNo)) + "</td> \n");
+        htmlContentHeader.append("<td colspan='7' class='bodytext'>Payment date of " + Encode.forHtmlContent(String.valueOf(dateStr)) + "</td> \n");
         htmlContentHeader.append("</tr> \n");
 
         htmlContentHeader.append("<tr> \n");
@@ -91,8 +92,8 @@ public class HtmlTeleplanHelper {
         htmlContentHeader.append("<html><body><style type='text/css'><!-- .bodytext{  font-family: Tahoma, Arial, Helvetica, sans-serif;  font-size: 12px; font-style: normal;  line-height: normal;  font-weight: normal;  font-variant: normal;  text-transform: none;  color: #003366;  text-decoration: none; --></style>");
         htmlContentHeader.append("<table width='100%' border='0' cellspacing='0' cellpadding='0'>");
         htmlContentHeader.append("<tr>");
-        htmlContentHeader.append("<td colspan='4' class='bodytext'>Billing Invoice for Billing No." + providerNo + "</td>");
-        htmlContentHeader.append("<td colspan='7' class='bodytext'>Payment date of " + output + "</td>");
+        htmlContentHeader.append("<td colspan='4' class='bodytext'>Billing Invoice for Billing No." + Encode.forHtmlContent(String.valueOf(providerNo)) + "</td>");
+        htmlContentHeader.append("<td colspan='7' class='bodytext'>Payment date of " + Encode.forHtmlContent(String.valueOf(output)) + "</td>");
         htmlContentHeader.append("</tr>");
         htmlContentHeader.append("<tr>");
         htmlContentHeader.append("<td width='9%' class='bodytext'>INVOICE</td>");
@@ -112,24 +113,25 @@ public class HtmlTeleplanHelper {
     }
 
     public static String htmlLine(String billingMasterNo, String invNo, String demoName, String phn, String serviceDate, String billingCode, String billAmount, String dx1, String dx2, String dx3) {
+        String paddedBillingMasterNo = Misc.forwardZero(billingMasterNo, 7);
         StringBuilder htmlContent = new StringBuilder();
         htmlContent.append("<tr> \n");
         htmlContent.append("<td class='bodytext'> \n");
         htmlContent.append("<a href='#' onClick=\"openBrWindow('adjustBill.jsp?billingmaster_no=");
-        htmlContent.append(Misc.forwardZero(billingMasterNo, 7));
+        htmlContent.append(Encode.forUriComponent(String.valueOf(paddedBillingMasterNo)));
         htmlContent.append("','','resizable=yes,scrollbars=yes,top=0,left=0,width=900,height=600'); return false;\">");
-        htmlContent.append(invNo);
+        htmlContent.append(Encode.forHtmlContent(String.valueOf(invNo)));
         htmlContent.append("</a>");
         htmlContent.append("</td>\n");
-        htmlContent.append("<td class='bodytext'>" + demoName + "</td>\n");
-        htmlContent.append("<td class='bodytext'>" + phn + "</td>\n");
-        htmlContent.append("<td class='bodytext'>" + serviceDate + "</td>\n");
-        htmlContent.append("<td class='bodytext'>" + billingCode + "</td>\n");
-        htmlContent.append("<td align='right' class='bodytext'>" + billAmount + "</td>\n");
-        htmlContent.append("<td align='right' class='bodytext'>" + Misc.backwardSpace(dx1, 5) + "</td>\n");
-        htmlContent.append("<td align='right' class='bodytext'>" + Misc.backwardSpace(dx2, 5) + "</td>\n");
-        htmlContent.append("<td align='right' class='bodytext'>" + Misc.backwardSpace(dx3, 5) + "</td>\n");
-        htmlContent.append("<td class='bodytext'>" + Misc.forwardZero(billingMasterNo, 7) + "</td>\n");
+        htmlContent.append("<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(demoName)) + "</td>\n");
+        htmlContent.append("<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(phn)) + "</td>\n");
+        htmlContent.append("<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(serviceDate)) + "</td>\n");
+        htmlContent.append("<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(billingCode)) + "</td>\n");
+        htmlContent.append("<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(billAmount)) + "</td>\n");
+        htmlContent.append("<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(Misc.backwardSpace(dx1, 5))) + "</td>\n");
+        htmlContent.append("<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(Misc.backwardSpace(dx2, 5))) + "</td>\n");
+        htmlContent.append("<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(Misc.backwardSpace(dx3, 5))) + "</td>\n");
+        htmlContent.append("<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(paddedBillingMasterNo)) + "</td>\n");
         htmlContent.append("<td class='bodytext'>&nbsp;</td>\n");
         htmlContent.append("</tr>\n");
         return htmlContent.toString();
@@ -138,11 +140,11 @@ public class HtmlTeleplanHelper {
     public static String htmlFooter(String providerNo, int count, BigDecimal total) {
         StringBuilder htmlFooter = new StringBuilder();
         htmlFooter.append("<tr><td colspan='11' class='bodytext'>&nbsp;</td>  </tr>  <tr>    <td colspan='5' class='bodytext'>Billing No: ");
-        htmlFooter.append(providerNo);
+        htmlFooter.append(Encode.forHtmlContent(String.valueOf(providerNo)));
         htmlFooter.append(": ");
-        htmlFooter.append(count);
+        htmlFooter.append(Encode.forHtmlContent(String.valueOf(count)));
         htmlFooter.append(" RECORDS PROCESSED</td>    <td colspan='6' class='bodytext'>TOTAL: ");
-        htmlFooter.append(total);
+        htmlFooter.append(Encode.forHtmlContent(String.valueOf(total)));
         htmlFooter.append("</td></tr>");
         return htmlFooter.toString();
     }

--- a/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/WcbSb.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/WcbSb.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 
 import ca.openosp.Misc;
 import org.apache.logging.log4j.Logger;
+import org.owasp.encoder.Encode;
 import ca.openosp.openo.billing.CA.BC.model.Wcb;
 import ca.openosp.openo.commn.dao.BillingServiceDao;
 import ca.openosp.openo.utility.MiscUtils;
@@ -212,7 +213,7 @@ public class WcbSb {
             }
         }
 
-        String ret = "<tr bgcolor='red'><td colspan='11'>" + "<a href='#' onClick=\"openBrWindow('billingTeleplanCorrectionWCB.jsp?billing_no=" + Misc.forwardZero(this.billing_no, 7) + "','','resizable=yes,scrollbars=yes,top=0,left=0,width=900,height=600'); return false;\">" + m.toString() + "</a>" + "</td></tr>";
+        String ret = "<tr bgcolor='red'><td colspan='11'>" + "<a href='#' onClick=\"openBrWindow('billingTeleplanCorrectionWCB.jsp?billing_no=" + Encode.forUriComponent(String.valueOf(Misc.forwardZero(this.billing_no, 7))) + "','','resizable=yes,scrollbars=yes,top=0,left=0,width=900,height=600'); return false;\">" + Encode.forHtmlContent(String.valueOf(m.toString())) + "</a>" + "</td></tr>";
         if ("".equals(m.toString())) {
             return "";
         }
@@ -387,8 +388,9 @@ public class WcbSb {
     }
 
     public String getHtmlLine(String billingMasterNo, String invNo, String demoName, String phn, String serviceDate, String billingCode, String billAmount, String dx1, String dx2, String dx3) {
-        String htmlContent = "<tr>" + "<td class='bodytext'>" + "<a href='#' onClick=\"openBrWindow('billingTeleplanCorrectionWCB.jsp?billing_no=" + Misc.forwardZero(billingMasterNo, 7) + "','','resizable=yes,scrollbars=yes,top=0,left=0,width=900,height=600'); return false;\">" + invNo + "</a>" + "</td>" + "<td class='bodytext'>" + demoName + "</td>" + "<td class='bodytext'>" + w_phn + "</td>" + "<td class='bodytext'>" + dateFormat(serviceDate) + "</td>" + "<td class='bodytext'>" + billingCode + "</td>"
-                + "<td align='right' class='bodytext'>" + billAmount + "</td>" + "<td align='right' class='bodytext'>" + Misc.backwardSpace(dx1, 5) + "</td>" + "<td align='right' class='bodytext'>" + Misc.backwardSpace(dx2, 5) + "</td>" + "<td align='right' class='bodytext'>" + Misc.backwardSpace(dx3, 5) + "</td>" + "<td class='bodytext'>" + Misc.forwardZero(billingMasterNo, 7) + "</td>" + "<td class='bodytext'>&nbsp;</td>" + "</tr>";
+        String paddedBillingMasterNo = Misc.forwardZero(billingMasterNo, 7);
+        String htmlContent = "<tr>" + "<td class='bodytext'>" + "<a href='#' onClick=\"openBrWindow('billingTeleplanCorrectionWCB.jsp?billing_no=" + Encode.forUriComponent(String.valueOf(paddedBillingMasterNo)) + "','','resizable=yes,scrollbars=yes,top=0,left=0,width=900,height=600'); return false;\">" + Encode.forHtmlContent(String.valueOf(invNo)) + "</a>" + "</td>" + "<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(demoName)) + "</td>" + "<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(w_phn)) + "</td>" + "<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(dateFormat(serviceDate))) + "</td>" + "<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(billingCode)) + "</td>"
+                + "<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(billAmount)) + "</td>" + "<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(Misc.backwardSpace(dx1, 5))) + "</td>" + "<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(Misc.backwardSpace(dx2, 5))) + "</td>" + "<td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(Misc.backwardSpace(dx3, 5))) + "</td>" + "<td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(paddedBillingMasterNo)) + "</td>" + "<td class='bodytext'>&nbsp;</td>" + "</tr>";
         return htmlContent;
     }
 

--- a/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ExtractBean.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ExtractBean.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 
 import ca.openosp.SxmlMisc;
 import org.apache.logging.log4j.Logger;
+import org.owasp.encoder.Encode;
 import ca.openosp.openo.billing.CA.dao.BillingDetailDao;
 import ca.openosp.openo.billing.CA.model.BillingDetail;
 import ca.openosp.openo.commn.dao.BillingDao;
@@ -209,8 +210,8 @@ public class ExtractBean implements Serializable {
     private String buildHTMLContentHeader() {
         String ret = null;
         ret = "\n<table width='100%' border='0' cellspacing='0' cellpadding='0'>\n"
-                + "<tr><td colspan='4' class='bodytext'>OHIP Invoice for OHIP No." + providerNo
-                + "</td><td colspan='4' class='bodytext'>Payment date of " + output + "\n</td></tr>";
+                + "<tr><td colspan='4' class='bodytext'>OHIP Invoice for OHIP No." + Encode.forHtmlContent(String.valueOf(providerNo))
+                + "</td><td colspan='4' class='bodytext'>Payment date of " + Encode.forHtmlContent(String.valueOf(output)) + "\n</td></tr>";
         ret += "\n<tr><td class='bodytext'>ACCT NO</td>"
                 + "<td class='bodytext'>NAME</td><td class='bodytext'>HEALTH #</td>"
                 + "<td class='bodytext'>BILLDATE</td><td class='bodytext'>CODE</td>"
@@ -222,28 +223,29 @@ public class ExtractBean implements Serializable {
     private String buildHTMLContentRecord(int invCount) {
         String ret = null;
         if (invCount == 0) {
-            ret = "\n<tr><td class='bodytext'>" + invNo + "</td><td class='bodytext'>" + demoName
-                    + "</td><td class='bodytext'>" + hcHin + "</td><td class='bodytext'>" + apptDate
-                    + "</td><td class='bodytext'>" + serviceCode + "</td><td align='right' class='bodytext'>" + fee
-                    + "</td><td align='right' class='bodytext'>" + diagcode
+            ret = "\n<tr><td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(invNo)) + "</td><td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(demoName))
+                    + "</td><td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(hcHin)) + "</td><td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(apptDate))
+                    + "</td><td class='bodytext'>" + Encode.forHtmlContent(String.valueOf(serviceCode)) + "</td><td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(fee))
+                    + "</td><td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(diagcode))
                     + "</td><td class='bodytext'> &nbsp; &nbsp;" + referral + hcFlag + m_Flag + " </td></tr>";
         } else {
             ret = "\n<tr><td class='bodytext'>&nbsp;</td> <td class='bodytext'>&nbsp;</td>"
                     + "<td class='bodytext'>&nbsp;</td> <td class='bodytext'>&nbsp;</td>" + "<td class='bodytext'>"
-                    + serviceCode + "</td><td align='right' class='bodytext'>" + fee
-                    + "</td><td align='right' class='bodytext'>" + diagcode
+                    + Encode.forHtmlContent(String.valueOf(serviceCode)) + "</td><td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(fee))
+                    + "</td><td align='right' class='bodytext'>" + Encode.forHtmlContent(String.valueOf(diagcode))
                     + "</td><td class='bodytext'>&nbsp;</td></tr>";
         }
         return ret;
     }
 
     private String buildHTMLContentTrailer() {
+        String bigTotalStr = String.valueOf(BigTotal);
         htmlContent += "\n<tr><td colspan='8' class='bodytext'>&nbsp;</td></tr><tr><td colspan='4' class='bodytext'>OHIP No: "
-                + providerNo
+                + Encode.forHtmlContent(String.valueOf(providerNo))
                 + ": "
-                + pCount
+                + Encode.forHtmlContent(String.valueOf(pCount))
                 + " RECORDS PROCESSED</td><td colspan='4' class='bodytext'>TOTAL: "
-                + BigTotal.toString().substring(0, BigTotal.toString().length() - 2) + "\n</td></tr>" + "\n</table>";
+                + Encode.forHtmlContent(bigTotalStr.substring(0, bigTotalStr.length() - 2)) + "\n</td></tr>" + "\n</table>";
         //  writeFile(value);
         String checkSummary = errorMsg.equals("") ? "\n<table border='0' width='100%' bgcolor='green'><tr><td>Pass</td></tr></table>"
                 : "\n<table border='0' width='100%' bgcolor='orange'><tr><td>Please correct the errors and run this simulation again!</td></tr></table>";

--- a/src/main/java/ca/openosp/openo/billings/ca/on/data/JdbcBillingCreateBillingFile.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/data/JdbcBillingCreateBillingFile.java
@@ -36,6 +36,7 @@ import java.util.Locale;
 import java.util.Properties;
 
 import org.apache.logging.log4j.Logger;
+import org.owasp.encoder.Encode;
 import ca.openosp.openo.billing.CA.ON.dao.BillingONDiskNameDao;
 import ca.openosp.openo.billing.CA.ON.dao.BillingONFilenameDao;
 import ca.openosp.openo.billing.CA.ON.dao.BillingONHeaderDao;
@@ -222,7 +223,7 @@ public class JdbcBillingCreateBillingFile {
         ret += "    popup.focus();\n";
         ret += "  }\n";
         ret += "}\n//-->\n</script>\n";
-        ret += "\n<table width='100%' border='0' cellspacing='0' cellpadding='2' class='myDarkGreen'>\n" + "<tr><td colspan='4' class='myGreen'>OHIP Invoice for OHIP No." + bhObj.getProvider_reg_num() + "</td><td colspan='4' class='myGreen'>Payment date of " + output + "\n</td></tr>";
+        ret += "\n<table width='100%' border='0' cellspacing='0' cellpadding='2' class='myDarkGreen'>\n" + "<tr><td colspan='4' class='myGreen'>OHIP Invoice for OHIP No." + Encode.forHtmlContent(String.valueOf(bhObj.getProvider_reg_num())) + "</td><td colspan='4' class='myGreen'>Payment date of " + Encode.forHtmlContent(String.valueOf(output)) + "\n</td></tr>";
         ret += "\n<tr><td class='myGreen'>ACCT NO</td>" + "<td width='25%' class='myGreen'>NAME</td><td class='myGreen'>RO</td><td class='myGreen'>DOB</td><td class='myGreen'>Sex</td><td class='myGreen'>HEALTH #</td>" + "<td class='myGreen'>BILLDATE</td><td class='myGreen'>CODE</td>" + "<td align='right' class='myGreen'>BILLED</td>" + "<td align='right' class='myGreen'>DX</td><td align='right' class='myGreen'>Comment</td></tr>";
         return ret;
     }
@@ -239,7 +240,7 @@ public class JdbcBillingCreateBillingFile {
         ret += "    popup.focus();\n";
         ret += "  }\n";
         ret += "}\n//-->\n</script>\n";
-        ret += "\n<table width='100%' border='0' cellspacing='0' cellpadding='2' class='myIvory'>\n" + "<tr><td colspan='4' class='myGreen'>OHIP Invoice for OHIP No." + bhObj.getProvider_reg_num() + "</td><td colspan='5' class='myGreen'>Payment date of " + output + "\n</td></tr>";
+        ret += "\n<table width='100%' border='0' cellspacing='0' cellpadding='2' class='myIvory'>\n" + "<tr><td colspan='4' class='myGreen'>OHIP Invoice for OHIP No." + Encode.forHtmlContent(String.valueOf(bhObj.getProvider_reg_num())) + "</td><td colspan='5' class='myGreen'>Payment date of " + Encode.forHtmlContent(String.valueOf(output)) + "\n</td></tr>";
         ret += "\n<tr><td class='myGreen'>ACCT NO</td>" + "<td width='25%' class='myGreen'>NAME</td><td class='myGreen'>HEALTH #</td>" + "<td class='myGreen'>BILLDATE</td><td class='myGreen'>CODE</td>" + "<td align='right' class='myGreen'>BILLED</td>" + "<td align='right' class='myGreen'>DX</td><td align='right' class='myGreen'>Comment</td>" + "<td align='centre' class='myGreen'>SITE</td></tr>";
         return ret;
     }
@@ -250,27 +251,27 @@ public class JdbcBillingCreateBillingFile {
         String styleClass = patientCount % 2 == 0 ? "myLightBlue" : "myIvory";
         if (invCount == 0) {
             Demographic demo = demographicManager.getDemographic(loggedInInfo, ch1Obj.getDemographic_no());
-            ret += "\n<tr " + (summaryView ? "style='display:none;' class='record" + providerNo + "'" : "") + ">";
+            ret += "\n<tr " + (summaryView ? "style='display:none;' class='record" + Encode.forHtmlAttribute(String.valueOf(providerNo)) + "'" : "") + ">";
             if (simulation) {
-                ret += "<td class='" + styleClass + "'>" + ch1Obj.getProvider_ohip_no() + "</td>"
-                        + "<td class='" + styleClass + "'><a href='javascript:void(0);'  onclick=\"popupPage(1000,800,'../billing/CA/ON/billingONCorrection.jsp?billing_no=" + ch1Obj.getId() + "');return false;\">" + ch1Obj.getId() + "</a></td>"
-                        + "<td class='" + styleClass + "'><a href='javascript:void(0);' onclick=\"popupPage(720,740,'../demographic/demographiccontrol.jsp?demographic_no=" + ch1Obj.getDemographic_no() + "&displaymode=edit&dboperation=search_detail');return false;\">" + ch1Obj.getDemographic_name() + "</a></td>";
+                ret += "<td class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(ch1Obj.getProvider_ohip_no())) + "</td>"
+                        + "<td class='" + styleClass + "'><a href='javascript:void(0);'  onclick=\"popupPage(1000,800,'../billing/CA/ON/billingONCorrection.jsp?billing_no=" + Encode.forUriComponent(String.valueOf(ch1Obj.getId())) + "');return false;\">" + Encode.forHtmlContent(String.valueOf(ch1Obj.getId())) + "</a></td>"
+                        + "<td class='" + styleClass + "'><a href='javascript:void(0);' onclick=\"popupPage(720,740,'../demographic/demographiccontrol.jsp?demographic_no=" + Encode.forUriComponent(String.valueOf(ch1Obj.getDemographic_no())) + "&displaymode=edit&dboperation=search_detail');return false;\">" + Encode.forHtmlContent(String.valueOf(ch1Obj.getDemographic_name())) + "</a></td>";
             } else {
-                ret += "<td class='" + styleClass + "'>" + ch1Obj.getId() + "</td>"
-                        + "<td class='" + styleClass + "'>" + ch1Obj.getDemographic_name() + "</td>";
+                ret += "<td class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(ch1Obj.getId())) + "</td>"
+                        + "<td class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(ch1Obj.getDemographic_name())) + "</td>";
             }
-            ret += "<td class='" + styleClass + "'>" + (demo.getRosterStatus() == null ? "" : demo.getRosterStatus()) + "</td>"
-                    + "<td class='" + styleClass + "'>" + demo.getBirthDayAsString() + "</td>"
-                    + "<td class='" + styleClass + "'>" + demo.getSex() + "</td>"
-                    + "<td class='" + styleClass + "'>" + (ch1Obj.getHin() == null ? "" : ch1Obj.getHin()) + (ch1Obj.getVer() == null ? "" : ch1Obj.getVer()) + "</td>"
-                    + "<td class='" + styleClass + "'>" + ch1Obj.getBilling_date() + "</td>"
-                    + "<td class='" + styleClass + "'>" + itemObj.getService_code() + "</td>"
-                    + "<td align='right' class='" + styleClass + "'>" + itemObj.getFee() + "</td>"
-                    + "<td align='right' class='" + styleClass + "'>" + itemObj.getDx() + "</td>"
+            ret += "<td class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(demo.getRosterStatus() == null ? "" : demo.getRosterStatus())) + "</td>"
+                    + "<td class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(demo.getBirthDayAsString())) + "</td>"
+                    + "<td class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(demo.getSex())) + "</td>"
+                    + "<td class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(ch1Obj.getHin() == null ? "" : ch1Obj.getHin())) + Encode.forHtmlContent(String.valueOf(ch1Obj.getVer() == null ? "" : ch1Obj.getVer())) + "</td>"
+                    + "<td class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(ch1Obj.getBilling_date())) + "</td>"
+                    + "<td class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(itemObj.getService_code())) + "</td>"
+                    + "<td align='right' class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(itemObj.getFee())) + "</td>"
+                    + "<td align='right' class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(itemObj.getDx())) + "</td>"
                     + "<td class='" + styleClass + "'> &nbsp; &nbsp;" + referral + hcFlag + m_Flag + " </td></tr>";
         } else {
-            ret = "\n<tr " + (summaryView ? "style='display:none;' class='record" + providerNo + "'" : "") + ">" + "<td class='" + styleClass + "'>&nbsp;</td>" + "<td class='" + styleClass + "'>&nbsp;</td> <td class='" + styleClass + "'>&nbsp;</td><td class='" + styleClass + "'>&nbsp;</td><td class='" + styleClass + "'>&nbsp;</td><td class='" + styleClass + "'>&nbsp;</td>" + "<td class='" + styleClass + "'>&nbsp;</td> <td class='" + styleClass + "'>&nbsp;</td>" + "<td class='" + styleClass + "'>"
-                    + itemObj.getService_code() + "</td><td align='right' class='" + styleClass + "'>" + itemObj.getFee() + "</td><td align='right' class='" + styleClass + "'>" + itemObj.getDx() + "</td><td class='" + styleClass + "'>&nbsp;</td></tr>";
+            ret = "\n<tr " + (summaryView ? "style='display:none;' class='record" + Encode.forHtmlAttribute(String.valueOf(providerNo)) + "'" : "") + ">" + "<td class='" + styleClass + "'>&nbsp;</td>" + "<td class='" + styleClass + "'>&nbsp;</td> <td class='" + styleClass + "'>&nbsp;</td><td class='" + styleClass + "'>&nbsp;</td><td class='" + styleClass + "'>&nbsp;</td><td class='" + styleClass + "'>&nbsp;</td>" + "<td class='" + styleClass + "'>&nbsp;</td> <td class='" + styleClass + "'>&nbsp;</td>" + "<td class='" + styleClass + "'>"
+                    + Encode.forHtmlContent(String.valueOf(itemObj.getService_code())) + "</td><td align='right' class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(itemObj.getFee())) + "</td><td align='right' class='" + styleClass + "'>" + Encode.forHtmlContent(String.valueOf(itemObj.getDx())) + "</td><td class='" + styleClass + "'>&nbsp;</td></tr>";
         }
         return ret;
     }
@@ -278,17 +279,17 @@ public class JdbcBillingCreateBillingFile {
     private String buildSiteHTMLContentRecord(int invCount) {
         String ret = null;
         if (invCount == 0) {
-            ret = "\n<tr><td class='myIvory'><a href=# onclick=\"popupPage(720,740,'billingONCorrection.jsp?billing_no=" + ch1Obj.getId() + "');return false;\">" + ch1Obj.getId() + "</a></td>" + "<td class='myIvory'><a href=# onclick=\"popupPage(720,740,'../../../demographic/demographiccontrol.jsp?demographic_no=" + ch1Obj.getDemographic_no() + "&displaymode=edit&dboperation=search_detail');return false;\">" + ch1Obj.getDemographic_name() + "</a></td><td class='myIvory'>" + ch1Obj.getHin()
-                    + ch1Obj.getVer() + "</td><td class='myIvory'>" + ch1Obj.getBilling_date() + "</td><td class='myIvory'>" + itemObj.getService_code() + "</td><td align='right' class='myIvory'>" + itemObj.getFee() + "</td><td align='right' class='myIvory'>" + itemObj.getDx() + "</td><td class='myIvory'> &nbsp; &nbsp;" + referral + hcFlag + m_Flag + " </td>" + "<td bgcolor='" + clinicBgColor + "'> " + clinicShortName.get(ch1Obj.getClinic()) + "</td></tr>";
+            ret = "\n<tr><td class='myIvory'><a href=# onclick=\"popupPage(720,740,'billingONCorrection.jsp?billing_no=" + Encode.forUriComponent(String.valueOf(ch1Obj.getId())) + "');return false;\">" + Encode.forHtmlContent(String.valueOf(ch1Obj.getId())) + "</a></td>" + "<td class='myIvory'><a href=# onclick=\"popupPage(720,740,'../../../demographic/demographiccontrol.jsp?demographic_no=" + Encode.forUriComponent(String.valueOf(ch1Obj.getDemographic_no())) + "&displaymode=edit&dboperation=search_detail');return false;\">" + Encode.forHtmlContent(String.valueOf(ch1Obj.getDemographic_name())) + "</a></td><td class='myIvory'>" + Encode.forHtmlContent(String.valueOf(ch1Obj.getHin()))
+                    + Encode.forHtmlContent(String.valueOf(ch1Obj.getVer())) + "</td><td class='myIvory'>" + Encode.forHtmlContent(String.valueOf(ch1Obj.getBilling_date())) + "</td><td class='myIvory'>" + Encode.forHtmlContent(String.valueOf(itemObj.getService_code())) + "</td><td align='right' class='myIvory'>" + Encode.forHtmlContent(String.valueOf(itemObj.getFee())) + "</td><td align='right' class='myIvory'>" + Encode.forHtmlContent(String.valueOf(itemObj.getDx())) + "</td><td class='myIvory'> &nbsp; &nbsp;" + referral + hcFlag + m_Flag + " </td>" + "<td bgcolor='" + Encode.forHtmlAttribute(String.valueOf(clinicBgColor)) + "'> " + Encode.forHtmlContent(String.valueOf(clinicShortName.get(ch1Obj.getClinic()))) + "</td></tr>";
         } else {
-            ret = "\n<tr><td class='myIvory'>&nbsp;</td> <td class='myIvory'>&nbsp;</td>" + "<td class='myIvory'>&nbsp;</td> <td class='myIvory'>&nbsp;</td>" + "<td class='myIvory'>" + itemObj.getService_code() + "</td><td align='right' class='myIvory'>" + itemObj.getFee() + "</td><td align='right' class='myIvory'>" + itemObj.getDx() + "</td><td class='myIvory'>&nbsp;</td>" + "<td bgcolor='" + clinicBgColor + "'> " + clinicShortName.get(ch1Obj.getClinic()) + "</td></tr>";
+            ret = "\n<tr><td class='myIvory'>&nbsp;</td> <td class='myIvory'>&nbsp;</td>" + "<td class='myIvory'>&nbsp;</td> <td class='myIvory'>&nbsp;</td>" + "<td class='myIvory'>" + Encode.forHtmlContent(String.valueOf(itemObj.getService_code())) + "</td><td align='right' class='myIvory'>" + Encode.forHtmlContent(String.valueOf(itemObj.getFee())) + "</td><td align='right' class='myIvory'>" + Encode.forHtmlContent(String.valueOf(itemObj.getDx())) + "</td><td class='myIvory'>&nbsp;</td>" + "<td bgcolor='" + Encode.forHtmlAttribute(String.valueOf(clinicBgColor)) + "'> " + Encode.forHtmlContent(String.valueOf(clinicShortName.get(ch1Obj.getClinic()))) + "</td></tr>";
         }
         return ret;
     }
 
     private String buildHTMLContentTrailer(boolean simulation) {
         if (!simulation) {
-            htmlContent += "\n<tr><td colspan='11' class='myIvory'>&nbsp;</td></tr><tr><td colspan='7' class='myIvory'>OHIP No: " + bhObj.getProvider_reg_num() + ": " + pCount + " RECORDS PROCESSED</td><td colspan='4' class='myIvory'>TOTAL: " + BigTotal.toString() + "\n</td></tr>" + "\n</table>";
+            htmlContent += "\n<tr><td colspan='11' class='myIvory'>&nbsp;</td></tr><tr><td colspan='7' class='myIvory'>OHIP No: " + Encode.forHtmlContent(String.valueOf(bhObj.getProvider_reg_num())) + ": " + Encode.forHtmlContent(String.valueOf(pCount)) + " RECORDS PROCESSED</td><td colspan='4' class='myIvory'>TOTAL: " + Encode.forHtmlContent(String.valueOf(BigTotal)) + "\n</td></tr>" + "\n</table>";
         }
 
         String checkSummary = "";
@@ -326,7 +327,7 @@ public class JdbcBillingCreateBillingFile {
     }
 
     private String buildSiteHTMLContentTrailer() {
-        htmlContent += "\n<tr><td colspan='9' class='myIvory'>&nbsp;</td></tr><tr><td colspan='4' class='myIvory'>OHIP No: " + bhObj.getProvider_reg_num() + ": " + pCount + " RECORDS PROCESSED</td><td colspan='5' class='myIvory'>TOTAL: " + BigTotal.toString() + "\n</td></tr>" + "\n</table>";
+        htmlContent += "\n<tr><td colspan='9' class='myIvory'>&nbsp;</td></tr><tr><td colspan='4' class='myIvory'>OHIP No: " + Encode.forHtmlContent(String.valueOf(bhObj.getProvider_reg_num())) + ": " + Encode.forHtmlContent(String.valueOf(pCount)) + " RECORDS PROCESSED</td><td colspan='5' class='myIvory'>TOTAL: " + Encode.forHtmlContent(String.valueOf(BigTotal)) + "\n</td></tr>" + "\n</table>";
         // writeFile(value);
         String checkSummary = errorMsg.equals("") ? "\n<table border='0' width='100%' bgcolor='green'><tr><td>Pass</td></tr></table>" : "\n<table border='0' width='100%' bgcolor='orange'><tr><td>Please correct the errors and run this simulation again!</td></tr></table>";
         htmlValue += htmlContent + checkSummary;
@@ -572,9 +573,11 @@ public class JdbcBillingCreateBillingFile {
 
             if (summaryView) {
                 String items = htmlContent;
-                htmlContent = "<tr><td class='myIvory'>" + ohipNo + "</td><td class='myIvory'>" + proItem + "</td><td class='myIvory'>" + proTotal.toString() + "</td><td class='myIvory' colspan='6'><button id='recordShowButton" + providerNo + "' onclick='jQuery(\".record" + providerNo + "\").show();jQuery(this).hide();jQuery(\"#recordHideButton" + providerNo + "\").show();return false;'>Show record details.</button><button id='recordHideButton" + providerNo
-                        + "' style='display:none;' onclick='jQuery(\".record" + providerNo + "\").hide();jQuery(this).hide();jQuery(\"#recordShowButton" + providerNo + "\").show();return false;'>Hide record details.</button></td></tr>";
-                htmlContent += "\n<tr style='display:none;' class='record" + providerNo + "'><td class='myGreen'>OHIP NO</td><td class='myGreen'>ACCT NO</td>" + "<td width='25%' class='myGreen'>NAME</td><td class='myGreen'>RO</td><td class='myGreen'>DOB</td><td class='myGreen'>Sex</td><td class='myGreen'>HEALTH #</td>" + "<td class='myGreen'>BILLDATE</td><td class='myGreen'>CODE</td>" + "<td align='right' class='myGreen'>BILLED</td>"
+                String providerNoForAttr = Encode.forHtmlAttribute(String.valueOf(providerNo));
+                String providerNoForJsInAttr = Encode.forHtmlAttribute(Encode.forJavaScript(String.valueOf(providerNo)));
+                htmlContent = "<tr><td class='myIvory'>" + Encode.forHtmlContent(String.valueOf(ohipNo)) + "</td><td class='myIvory'>" + Encode.forHtmlContent(String.valueOf(proItem)) + "</td><td class='myIvory'>" + Encode.forHtmlContent(String.valueOf(proTotal)) + "</td><td class='myIvory' colspan='6'><button id='recordShowButton" + providerNoForAttr + "' onclick='jQuery(\".record" + providerNoForJsInAttr + "\").show();jQuery(this).hide();jQuery(\"#recordHideButton" + providerNoForJsInAttr + "\").show();return false;'>Show record details.</button><button id='recordHideButton" + providerNoForAttr
+                        + "' style='display:none;' onclick='jQuery(\".record" + providerNoForJsInAttr + "\").hide();jQuery(this).hide();jQuery(\"#recordShowButton" + providerNoForJsInAttr + "\").show();return false;'>Hide record details.</button></td></tr>";
+                htmlContent += "\n<tr style='display:none;' class='record" + providerNoForAttr + "'><td class='myGreen'>OHIP NO</td><td class='myGreen'>ACCT NO</td>" + "<td width='25%' class='myGreen'>NAME</td><td class='myGreen'>RO</td><td class='myGreen'>DOB</td><td class='myGreen'>Sex</td><td class='myGreen'>HEALTH #</td>" + "<td class='myGreen'>BILLDATE</td><td class='myGreen'>CODE</td>" + "<td align='right' class='myGreen'>BILLED</td>"
                         + "<td align='right' class='myGreen'>DX</td><td align='right' class='myGreen'>Comment</td></tr>";
                 htmlContent += items;
             }

--- a/src/main/webapp/admin/faxStatusResults.jspf
+++ b/src/main/webapp/admin/faxStatusResults.jspf
@@ -104,10 +104,10 @@ if(!authed) {
 			<td id="faxType_<%=Encode.forHtmlAttribute(String.valueOf(faxJob.getId()))%>" class="small"><%=Encode.forHtml(String.valueOf(type))%></td>
 			<td class="small"><%=Encode.forHtmlContent(providerName)%>(<%=Encode.forHtml(String.valueOf(faxJob.getUser()))%>)</td>
 			<td id="patientName_<%=Encode.forHtmlAttribute(String.valueOf(faxJob.getId()))%>" class="small"><%=Encode.forHtmlContent(demographicName)%></td>
-			<td class="small"><c:out value="<%=Encode.forHtmlAttribute(String.valueOf(faxJob.getRecipient()))%>" /></td>
-			<td id="status<%=count%>" class="small" ><c:out value="<%=Encode.forHtmlAttribute(String.valueOf(faxJob.getStatus()))%>" /></td>
-			<td class="small" title="<%=Encode.forHtmlAttribute(faxJob.getStatusString())%>" style="max-width: 150px; width: 100px; text-overflow: ellipsis; overflow: hidden;">
-			<c:out value="<%=Encode.forHtmlAttribute(String.valueOf(faxJob.getStatusString()))%>" /></td>
+			<td class="small"><%=faxJob.getRecipient() == null ? "" : Encode.forHtml(faxJob.getRecipient())%></td>
+			<td id="status<%=count%>" class="small" ><%=faxJob.getStatus() == null ? "" : Encode.forHtml(String.valueOf(faxJob.getStatus()))%></td>
+			<td class="small" title="<%=faxJob.getStatusString() == null ? "" : Encode.forHtmlAttribute(faxJob.getStatusString())%>" style="max-width: 150px; width: 100px; text-overflow: ellipsis; overflow: hidden;">
+			<%=faxJob.getStatusString() == null ? "" : Encode.forHtml(faxJob.getStatusString())%></td>
 			<td class="small"><%=Encode.forHtml(String.valueOf(DateFormatUtils.format(faxJob.getStamp(), "yyyy-MM-dd HH:mm:ss")))%></td>
 			<td class="small">
 <div class="btn-group">

--- a/src/main/webapp/admin/providerPrivilege.jsp
+++ b/src/main/webapp/admin/providerPrivilege.jsp
@@ -66,7 +66,6 @@
 <%@ page import="org.springframework.dao.DataIntegrityViolationException" %>
 <%@ page import="org.springframework.web.util.HtmlUtils" %>
 <%@ page import="org.apache.commons.text.StringEscapeUtils" %>
-<%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="ca.openosp.openo.log.LogAction" %>
 <%@ page import="ca.openosp.openo.log.LogConst" %>
@@ -86,6 +85,7 @@
 
 <%
     String msg = "";
+    boolean msgIsError = false;
     String sql = null;
     ResultSet rs = null;
 
@@ -158,8 +158,6 @@
             String priority = request.getParameter(prefix);
             if (objectName.equals("Name1")) objectName = request.getParameter("object$Name1").trim();
 
-            String encodedRoleUserGroup = Encode.forHtmlContent(StringUtils.trimToEmpty(roleUserGroup));
-            String encodedObjectName = Encode.forHtmlContent(StringUtils.trimToEmpty(objectName));
             SecObjPrivilege sop = new SecObjPrivilege();
             sop.setId(new SecObjPrivilegePrimaryKey());
             sop.getId().setRoleUserGroup(roleUserGroup);
@@ -173,11 +171,12 @@
             } catch (DataIntegrityViolationException divEx) {
                 secExceptionMsg = divEx.getMostSpecificCause().getLocalizedMessage();
             }
-            if (secExceptionMsg.length() > 0)
+            if (secExceptionMsg.length() > 0) {
                 msg += secExceptionMsg;
-            else {
-                msg += "Role/Obj/Rights " + encodedRoleUserGroup + "/" + encodedObjectName + "/" + privilege + " is added. ";
-                LogAction.addLog(curUser_no, LogConst.ADD, LogConst.CON_PRIVILEGE, roleUserGroup + "|" + encodedObjectName + "|" + privilege, ip);
+                msgIsError = true;
+            } else {
+                msg += "Role/Obj/Rights " + roleUserGroup + "/" + objectName + "/" + privilege + " is added. ";
+                LogAction.addLog(curUser_no, LogConst.ADD, LogConst.CON_PRIVILEGE, roleUserGroup + "|" + objectName + "|" + privilege, ip);
             }
         }
     }
@@ -185,9 +184,7 @@
 // update the role list
     if (request.getParameter("buttonUpdate") != null && request.getParameter("buttonUpdate").length() > 0) {
         String roleUserGroup = request.getParameter("roleUserGroup");
-        String encodedRoleUserGroup = Encode.forHtmlContent(StringUtils.trimToEmpty(roleUserGroup));
         String objectName = request.getParameter("objectName");
-        String encodedObjectName = Encode.forHtmlContent(StringUtils.trimToEmpty(objectName));
 
         String privilege = request.getParameter("privilege");
         String priority = request.getParameter("priority");
@@ -234,7 +231,8 @@
             msg = "Role/Obj/Rights " + roleUserGroup + "/" + objectName + "/" + privilege + " is updated. ";
             LogAction.addLog(curUser_no, LogConst.UPDATE, LogConst.CON_PRIVILEGE, roleUserGroup + "|" + objectName + "|" + privilege, ip);
         } else {
-            msg = "Role/Obj/Rights " + encodedRoleUserGroup + "/" + encodedObjectName + "/" + privilege + " is <span style='color:red'>NOT</span> updated!!! ";
+            msg = "Role/Obj/Rights " + roleUserGroup + "/" + objectName + "/" + privilege + " is NOT updated!!! ";
+            msgIsError = true;
         }
 
     }
@@ -243,9 +241,7 @@
 // delete the role list
     if (request.getParameter("submit") != null && request.getParameter("submit").equals("Delete")) {
         String roleUserGroup = request.getParameter("roleUserGroup");
-        String encodedRoleUserGroup = Encode.forHtmlContent(StringUtils.trimToEmpty(roleUserGroup));
         String objectName = request.getParameter("objectName");
-        String encodedObjectName = Encode.forHtmlContent(StringUtils.trimToEmpty(objectName));
 
         String privilege = request.getParameter("privilege");
         String priority = request.getParameter("priority");
@@ -257,7 +253,7 @@
             priority = String.valueOf(sop.getPriority());
             provider_no = sop.getProviderNo();
             secObjPrivilegeDao.remove(sop.getId());
-            msg = "Role/Obj/Rights " + encodedRoleUserGroup + "/" + encodedObjectName + "/" + privilege + " is deleted. ";
+            msg = "Role/Obj/Rights " + roleUserGroup + "/" + objectName + "/" + privilege + " is deleted. ";
 
             RecycleBin recycleBin = new RecycleBin();
             recycleBin.setProviderNo(curUser_no);
@@ -271,7 +267,8 @@
             recycleBinDao.persist(recycleBin);
             LogAction.addLog(curUser_no, LogConst.DELETE, LogConst.CON_PRIVILEGE, roleUserGroup + "|" + objectName, ip);
         } else {
-            msg = "Role/Obj/Rights " + encodedRoleUserGroup + "/" + encodedObjectName + "/" + privilege + " is <span style='color:red'>NOT</span> deleted!!! ";
+            msg = "Role/Obj/Rights " + roleUserGroup + "/" + objectName + "/" + privilege + " is NOT deleted!!! ";
+            msgIsError = true;
         }
     }
 
@@ -393,8 +390,10 @@
 <form name="myform" action="providerPrivilege.jsp" method="POST">
     <table width="100%">
         <tr>
-            <th><% if (msg.length() > 1) {%>
-                <div class="alert" style="width:100%; text-align:center"><%=msg%>
+            <th><% if (msg.length() > 1) {
+                String alertClass = msgIsError ? "alert-danger" : "alert-info";
+            %>
+                <div class="alert <%=alertClass%>" style="width:100%; text-align:center"><%=Encode.forHtml(msg)%>
                 </div>
                 <% } %></th>
             <th style="width: 600px">Object Name/Role Name: <input type="text" name="keyword"

--- a/src/main/webapp/admin/providerRole.jsp
+++ b/src/main/webapp/admin/providerRole.jsp
@@ -108,6 +108,8 @@
 
     String ip = request.getRemoteAddr();
     String msg = "";
+    boolean msgIsError = false;
+    List<String> missingPrimaryRoleProviders = new ArrayList<String>();
     String caisiProgram = null;
 
 //get caisi programid for oscar
@@ -158,18 +160,17 @@
 
 // update the role
     if (request.getParameter("buttonUpdate") != null && request.getParameter("buttonUpdate").length() > 0) {
-    String number = Encode.forHtmlAttribute(request.getParameter("providerId"));
+        String number = request.getParameter("providerId");
         String roleId = request.getParameter("roleId");
         String roleOld = request.getParameter("roleOld");
         String roleNew = request.getParameter("roleNew");
-        String encodedRoleNew = Encode.forHtmlContent(roleNew);
 
         if (!"-".equals(roleNew)) {
             Secuserrole secUserRole = secUserRoleDao.findById(Integer.parseInt(roleId));
             if (secUserRole != null) {
                 secUserRole.setRoleName(roleNew);
                 secUserRoleDao.updateRoleName(Integer.parseInt(roleId), roleNew);
-                msg = "Role " + encodedRoleNew + " is updated. (" + number + ")";
+                msg = "Role " + roleNew + " is updated. (" + number + ")";
 
                 RecycleBin recycleBin = new RecycleBin();
                 recycleBin.setProviderNo(curUser_no);
@@ -194,7 +195,8 @@
                 }
 
             } else {
-                msg = "Role " + encodedRoleNew + " is <span style='text-color: red;'>NOT</span> updated!!! (" + number + ")";
+                msg = "Role " + roleNew + " is NOT updated!!! (" + number + ")";
+                msgIsError = true;
             }
         }
 
@@ -205,14 +207,13 @@
     if (request.getParameter("submit") != null && request.getParameter("submit").equals(add)) {
         String number = request.getParameter("providerId");
         String roleNew = request.getParameter("roleNew");
-        String encodedRoleNew = Encode.forHtmlContent(roleNew);
         if (!"-".equals(roleNew)) {
             Secuserrole secUserRole = new Secuserrole();
             secUserRole.setProviderNo(number);
             secUserRole.setRoleName(roleNew);
             secUserRole.setActiveyn(1);
             secUserRoleDao.save(secUserRole);
-            msg = "Role " + encodedRoleNew + " is added. (" + number + ")";
+            msg = "Role " + roleNew + " is added. (" + number + ")";
             LogAction.addLog(curUser_no, LogConst.ADD, LogConst.CON_ROLE, number + "|" + roleNew, ip);
 	    if( newCaseManagement && caisiProgram != null) {
                 ProgramProvider programProvider = programProviderDao.getProgramProvider(number, Long.valueOf(caisiProgram));
@@ -225,7 +226,8 @@
                 programProviderDao.saveProgramProvider(programProvider);
             }
         } else {
-            msg = "Role " + encodedRoleNew + " is <span style='text-color: red;'>NOT</span> added!!! (" + number + ")";
+            msg = "Role " + roleNew + " is NOT added!!! (" + number + ")";
+            msgIsError = true;
         }
 
     }
@@ -233,11 +235,10 @@
 // delete the role
     String delete = oscarRec.getString("global.btnDelete");
     if (request.getParameter("submit") != null && request.getParameter("submit").equals(delete)) {
-    String number = Encode.forHtmlAttribute(request.getParameter("providerId"));
+        String number = request.getParameter("providerId");
         String roleId = request.getParameter("roleId");
         String roleOld = request.getParameter("roleOld");
         String roleNew = request.getParameter("roleNew");
-        String encodedRoleOld = Encode.forHtmlContent(roleOld);
 
 	List secUserRoles = secUserRoleDao.findByProviderNo(number);
 
@@ -248,7 +249,7 @@
             if(secUserRole.getId() == Integer.parseInt(roleId)) {
 
             secUserRoleDao.deleteById(secUserRole.getId());
-            msg = "Role " + encodedRoleOld + " is deleted. (" + number + ")";
+            msg = "Role " + roleOld + " is deleted. (" + number + ")";
                 listIterator.remove();
 
             RecycleBin recycleBin = new RecycleBin();
@@ -297,7 +298,8 @@
         }
 
         } else {
-            msg = "Role " + encodedRoleOld + " is <span style='text-color: red;'>NOT</span> deleted!!! (" + number + ")";
+            msg = "Role " + roleOld + " is NOT deleted!!! (" + number + ")";
+            msgIsError = true;
         }
 
     }
@@ -363,7 +365,7 @@
 				if(programProvider == null || programProvider.isEmpty()) {
                     ProviderData provider = providerDao.findByProviderNo(user);
                     if (provider != null) {
-                        msg += String.format("</br><span style='color:red;'>WARNING: Provider %s requires a primary role assignment.</span>", provider.getFirstName() + " " + provider.getLastName());
+                        missingPrimaryRoleProviders.add(provider.getFirstName() + " " + provider.getLastName());
                     }
                 }
             }
@@ -485,9 +487,20 @@
 
 <form name="myform" action="providerRole.jsp" method="POST">
 
-    <% if (msg.length() > 1) {%>
-    <div class="alert alert-info">
-        <%=msg%>
+    <% if (msg.length() > 1) {
+        String alertClass = msgIsError ? "alert-danger" : "alert-info";
+    %>
+    <div class="alert <%=alertClass%>">
+        <%=Encode.forHtml(msg)%>
+    </div>
+    <% } %>
+    <% if (!missingPrimaryRoleProviders.isEmpty()) {%>
+    <div class="alert alert-warning">
+        <ul>
+            <% for (String providerName : missingPrimaryRoleProviders) { %>
+            <li>WARNING: Provider <%=Encode.forHtml(providerName)%> requires a primary role assignment.</li>
+            <% } %>
+        </ul>
     </div>
     <% } %>
     <div class="well">

--- a/src/main/webapp/admin/providersearchresults.jsp
+++ b/src/main/webapp/admin/providersearchresults.jsp
@@ -168,7 +168,7 @@
     <table>
         <tr>
             <td style="text-align:left"><i><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.search.keywords"/></i>
-                : <%=Encode.forHtml(keyword)%>
+                : <%=Encode.forHtmlContent(keyword)%>
             </td>
         </tr>
     </table>

--- a/src/main/webapp/admin/providerupdateprovider.jsp
+++ b/src/main/webapp/admin/providerupdateprovider.jsp
@@ -555,7 +555,7 @@
                                     billCode = (String) keys.nextElement();
                                     codeDesc = billCenter.getAllBillCenter().getProperty(billCode);
                             %>
-                            <option value="<%= billCode %>"
+                            <option value="<%= Encode.forHtmlAttribute(billCode) %>"
                                     <%=currentBillCode.compareTo(billCode) == 0 ? "selected" : ""%>><%=Encode.forHtml(String.valueOf(codeDesc))%>
                             </option>
                             <%

--- a/src/main/webapp/billing/CA/BC/billStatus.jsp
+++ b/src/main/webapp/billing/CA/BC/billStatus.jsp
@@ -579,7 +579,7 @@
                 <%}%>
                 <td><%=Encode.forHtml(String.valueOf(b.providerLastName))%>,<%=Encode.forHtml(String.valueOf(b.providerFirstName))%>
                 </td>
-                <td title="<%=Encode.forHtmlAttribute(String.valueOf(msp.getStatusDesc(b.reason)))%>"><%=Encode.forHtml(String.valueOf(msp.getStatusDesc(b.reason) == null ? "&nbsp" : msp.getStatusDesc(b.reason)))%>
+                <td title="<%=msp.getStatusDesc(b.reason) == null ? "" : Encode.forHtmlAttribute(msp.getStatusDesc(b.reason))%>"><%=Encode.forHtml(String.valueOf(msp.getStatusDesc(b.reason) == null ? "\u00A0" : msp.getStatusDesc(b.reason)))%>
                 </td>
 
 

--- a/src/main/webapp/billing/CA/CLINICAID/billingClinicaidReport.jsp
+++ b/src/main/webapp/billing/CA/CLINICAID/billingClinicaidReport.jsp
@@ -316,7 +316,7 @@
         <% for (int j = 0; j < header_values.size(); j++) {
             prop = (Properties) column_values.get(i);
         %>
-        <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty((String) header_values.get(j), "&nbsp;")))%>&nbsp;</td>
+        <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty((String) header_values.get(j), "\u00A0")))%>&nbsp;</td>
         <% } %>
     </tr>
     <% } %>

--- a/src/main/webapp/billing/CA/ON/billingON.jsp
+++ b/src/main/webapp/billing/CA/ON/billingON.jsp
@@ -161,7 +161,8 @@
 
     // get patient's detail
     String errorFlag = "";
-    String warningMsg = "", errorMsg = "";
+    List<String> warningMsgs = new ArrayList<String>();
+    List<String> errorMsgs = new ArrayList<String>();
     String r_doctor = "", r_doctor_ohip = "";
     String demoFirst = "", demoLast = "", demoHIN = "", demoVer = "", demoDOB = "", demoDOBYY = "", demoDOBMM = "", demoDOBDD = "", demoHCTYPE = "";
     String family_doctor = "";
@@ -203,15 +204,14 @@
     }
 
     if (demoHIN.equals("")) {
-        warningMsg += "<b><div class='alert alert-error'>Warning: The patient does not have a valid HIN. </div></b>";
+        warningMsgs.add("The patient does not have a valid HIN.");
     }
     if (r_doctor_ohip != null && r_doctor_ohip.length() > 0 && r_doctor_ohip.length() != 6) {
-        warningMsg += "<div class='alert alert error'>Warning: the referral doctor's no is wrong. </div>";
+        warningMsgs.add("The referral doctor's no is wrong.");
     }
     if (StringUtils.isBlank(demoDOB) || demoDOB.length() != 8) {
         errorFlag = "1";
-        errorMsg = errorMsg
-                + "<b><div class='alert alert error'>Error: The patient does not have a valid DOB. </div></b>";
+        errorMsgs.add("The patient does not have a valid DOB.");
     }
     //}
 
@@ -547,8 +547,6 @@
     }
 
 
-    // create msg
-    msg += errorMsg + warningMsg;
 %>
 
 
@@ -1323,7 +1321,14 @@ function toggleDiv(selectedBillForm, selectedBillFormName,billType)
                         <td style="text-align: center;"
                             class="<%=Encode.forHtmlAttribute(String.valueOf(warningClass))%>"><%=Encode.forHtml(String.valueOf(billingRecomendations.toString()))%>
                         </td>
-                        <td style="text-align: center;"><%=msg%>
+                        <td style="text-align: center;">
+                            <%=Encode.forHtmlContent(msg)%>
+                            <% for (String errorText : errorMsgs) { %>
+                                <div class="alert alert-error">Error: <%=Encode.forHtmlContent(errorText)%></div>
+                            <% } %>
+                            <% for (String warningText : warningMsgs) { %>
+                                <div class="alert alert-warning">Warning: <%=Encode.forHtmlContent(warningText)%></div>
+                            <% } %>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/billing/CA/ON/billingONCorrection.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONCorrection.jsp
@@ -577,11 +577,11 @@
                 payer = "";
             } else {
                 htmlPaid = "Paid<br><input type='text' id='payment' name='payment' size=5 value='"
-                        + tProp.getProperty("payment", "0.00") + "' /><input type='hidden' id='oldPayment' name='oldPayment' value='"
-                        + tProp.getProperty("payment", "0.00") + "' /><input type='hidden' id='payDate' name='payDate' value='"
+                        + Encode.forHtmlAttribute(String.valueOf(tProp.getProperty("payment", "0.00"))) + "' /><input type='hidden' id='oldPayment' name='oldPayment' value='"
+                        + Encode.forHtmlAttribute(String.valueOf(tProp.getProperty("payment", "0.00"))) + "' /><input type='hidden' id='payDate' name='payDate' value='"
                         + UtilDateUtilities.getToday("yyyy-MM-dd HH:mm:ss") + "'/><br>";
                 htmlPaid += "Refund<br><input type='text' id='refund' name='refund' size=5 value='"
-                        + tProp.getProperty("refund") + "' /><br>";
+                        + Encode.forHtmlAttribute(String.valueOf(tProp.getProperty("refund"))) + "' /><br>";
                 payer = tProp.getProperty("billTo");
                 if (payer == null) {
                     payer = "";
@@ -640,9 +640,9 @@
                 payment = payment.subtract(credit);
 
                 htmlPaid = "<br/>&nbsp;&nbsp;<span style='font-size:large;font-weight:bold'>Paid:</span>&nbsp;&nbsp;&nbsp;<span id='payment' style='font-size:large;font-weight:bold'>"
-                        + ((payment.compareTo(BigDecimal.ZERO) == -1) ? "-" : "") + currency.format(payment) + "</span>";
+                        + ((payment.compareTo(BigDecimal.ZERO) == -1) ? "-" : "") + Encode.forHtmlContent(currency.format(payment)) + "</span>";
                 htmlPaid += "&nbsp;&nbsp;&nbsp;&nbsp;<span style='font-size:large;font-weight:bold'>Balance:</span>&nbsp;&nbsp;&nbsp;<span id='balance' style='font-size:large;font-weight:bold'>"
-                        + ((balance.compareTo(BigDecimal.ZERO) == -1) ? "-" : "") + currency.format(balance) + "</span>";
+                        + ((balance.compareTo(BigDecimal.ZERO) == -1) ? "-" : "") + Encode.forHtmlContent(currency.format(balance)) + "</span>";
                 htmlPaid += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href='javascript:display3rdPartyPayments()'>Payments List</a>";
             }
             payer = tProp.getProperty("billTo");

--- a/src/main/webapp/billing/CA/ON/billingONNewReport.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONNewReport.jsp
@@ -578,7 +578,7 @@ end broken -->
             <% for (int j = 0; j < vecHeader.size(); j++) {
                 prop = (Properties) vecValue.get(i);
             %>
-            <td style="text-align:center;"><%=Encode.forHtml(String.valueOf(prop.getProperty((String) vecHeader.get(j), "&nbsp;")))%>&nbsp;</td>
+            <td style="text-align:center;"><%=Encode.forHtml(String.valueOf(prop.getProperty((String) vecHeader.get(j), "\u00A0")))%>&nbsp;</td>
             <% } %>
         </tr>
         <% } %>

--- a/src/main/webapp/billing/CA/ON/billingONReview.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONReview.jsp
@@ -137,9 +137,9 @@
     }
     ///////--------
 
-    String warningMsg = "";
+    List<String> warningMsgs = new ArrayList<String>();
     String errorFlag = "";
-    String errorMsg = "";
+    List<String> errorMsgs = new ArrayList<String>();
 
     Vector vecCodeItem = prepObj.getServiceCodeReviewVec(vecServiceParam[0], vecServiceParam[1], vecServiceParam[2], billReferalDate);
     Vector vecPercCodeItem = prepObj.getPercCodeReviewVec(vecServiceParam[0], vecServiceParam[1], vecCodeItem, billReferalDate);  //LINE CAUSING ERROR
@@ -244,24 +244,18 @@
 
         if (demo.getHin() == null) {
             errorFlag = "1";
-            errorMsg = errorMsg
-                    + "<br><div class='alert alert-error'>Error: The patient does not have a HIN </div><br>";
+            errorMsgs.add("The patient does not have a HIN.");
         } else if (demo.getHin().equals("")) {
-            warningMsg += "<br><div class='alert alert-error'>Warning: The patient does not have a HIN </div><br>";
+            warningMsgs.add("The patient does not have a HIN.");
         }
         if (r_doctor_ohip != null && r_doctor_ohip.length() > 0 && r_doctor_ohip.length() != 6) {
-            warningMsg += "<br><div class='alert alert-error'>Warning: the referral doctor's no is wrong. </div><br>";
+            warningMsgs.add("The referral doctor's no is wrong.");
         }
         if (demoDOB.length() != 8) {
             errorFlag = "1";
-            errorMsg = errorMsg
-                    + "<br><div class='alert alert-error'>Error: The patient does not have a valid DOB. </div><br>";
+            errorMsgs.add("The patient does not have a valid DOB.");
         }
     }
-
-
-    // create msg
-    String wrongMsg = errorMsg + warningMsg;
 
 %>
 <c:set var="ctx" value="${pageContext.request.contextPath}" scope="request"/>
@@ -593,7 +587,13 @@
                             &nbsp;&nbsp; <%=demoSex.equals("1") ? "Male" : "Female"%> &nbsp;&nbsp;
                             <%=Encode.forHtml(String.valueOf(" DOB: " + demoDOBYY + "/" + demoDOBMM + "/" + demoDOBDD + " &nbsp;&nbsp; HIN: " + demoHIN + "" + demoVer))%>
                         </td>
-                        <td style="text-align:center"><%=Encode.forHtml(String.valueOf(wrongMsg))%>
+                        <td style="text-align:center">
+                            <% for (String errorText : errorMsgs) { %>
+                                <div class="alert alert-error">Error: <%=Encode.forHtmlContent(errorText)%></div>
+                            <% } %>
+                            <% for (String warningText : warningMsgs) { %>
+                                <div class="alert alert-warning">Warning: <%=Encode.forHtmlContent(warningText)%></div>
+                            <% } %>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/billing/CA/ON/billingReview.jsp
+++ b/src/main/webapp/billing/CA/ON/billingReview.jsp
@@ -85,8 +85,9 @@
 </head>
 
 <%
-    String errorMsg = "", errorFlag = "";
-    String warningMsg = "";
+    String errorFlag = "";
+    List<String> errorMsgs = new ArrayList<String>();
+    List<String> warningMsgs = new ArrayList<String>();
     String proNO = request.getParameter("xml_provider");
     String temp2 = null, content = "", location2 = "", desc3 = "", desc2 = "", scode2 = null, scode3 = null, dsfee = "", fee2 = "", fee3 = "", flag = "", flag1 = "", flag2 = "";
     String pValue = "", pCode = "", pDesc = "", pPerc = "", pUnit = "";
@@ -96,7 +97,7 @@
 
     if (proNO.compareTo("000000") == 0) {
         errorFlag = "1";
-        errorMsg = errorMsg + "Error: Please select a valid Provider. <br>";
+        errorMsgs.add("Please select a valid Provider.");
     }
 %>
 
@@ -132,7 +133,7 @@
                         billing_pCode = billing_E078A;
                         if (" ".equals(billing_E078A)) {
                             errorFlag = "1";
-                            errorMsg += "Error: Diagnostic code error for E078A<br>";
+                            errorMsgs.add("Diagnostic code error for E078A");
                         }
                         break;
                     }
@@ -181,7 +182,7 @@
     }
     if (diagcode.compareTo("000") == 0) {
         errorFlag = "1";
-        errorMsg = errorMsg + "Error: Please enter a valid Diagnostic Code. <br>";
+        errorMsgs.add("Please enter a valid Diagnostic Code.");
     }
 
 
@@ -225,16 +226,16 @@
 
         if (d.getHin() == null) {
             errorFlag = "1";
-            errorMsg = errorMsg + "Error: The patient does not have a valid HIN. <br>";
+            errorMsgs.add("The patient does not have a valid HIN.");
         } else if (d.getHin().equals("")) {
-            warningMsg += "Warning: The patient does not have a valid HIN. <br>";
+            warningMsgs.add("The patient does not have a valid HIN.");
         }
         if (r_doctor_ohip != null && r_doctor_ohip.length() > 0 && r_doctor_ohip.length() != 6) {
-            warningMsg += "Warning: the referral doctor's no is wrong. <br>";
+            warningMsgs.add("The referral doctor's no is wrong.");
         }
         if (demoDOB.length() != 8) {
             errorFlag = "1";
-            errorMsg = errorMsg + "Error: The patient does not have a valid DOB. <br>";
+            errorMsgs.add("The patient does not have a valid DOB.");
         }
 
     }
@@ -982,7 +983,7 @@
 
             if (counter == 0) {
                 errorFlag = "1";
-                errorMsg = errorMsg + "Error: No Service/Procedure Code selected. <br>";
+                errorMsgs.add("No Service/Procedure Code selected.");
             }
 
             if (errorFlag.compareTo("1") == 0) {
@@ -990,7 +991,10 @@
 
     </table>
 
-    <p bgcolor="orange"><%=errorMsg%>
+    <p bgcolor="orange">
+        <% for (String errorText : errorMsgs) { %>
+            <span style="color: red;">Error: <%=Encode.forHtmlContent(errorText)%></span><br/>
+        <% } %>
     </p>
     <% session.setAttribute("content", content); %>
     <form><input type=button name=back value='Go Back and Change'
@@ -1101,10 +1105,13 @@
             href="billingOB.jsp?billForm=<%=Encode.forUriComponent(request.getParameter("billForm"))%>&hotclick=<%=Encode.forUriComponent(String.valueOf(""))%>&appointment_no=<%=Encode.forUriComponent(request.getParameter("appointment_no"))%>&demographic_name=<%=Encode.forUriComponent(String.valueOf(demoname))%>&demographic_no=<%=Encode.forUriComponent(request.getParameter("demographic_no"))%>&user_no=<%=Encode.forUriComponent(request.getParameter("user_no"))%>&providerview=<%=Encode.forUriComponent(request.getParameter("apptProvider_no"))%>&apptProvider_no=<%=Encode.forUriComponent(request.getParameter("apptProvider_no"))%>&appointment_date=<%=Encode.forUriComponent(request.getParameter("xml_appointment_date"))%>&status=<%=Encode.forUriComponent(request.getParameter("status"))%>&start_time=<%=Encode.forUriComponent(request.getParameter("start_time"))%>&bNewForm=0">edit</a>
 
             <%
-	if (warningMsg.length() > 0) {
+	if (!warningMsgs.isEmpty()) {
 %>
 
-    <p bgcolor="yellow"><%=warningMsg%>
+    <p bgcolor="yellow">
+        <% for (String warningText : warningMsgs) { %>
+            <span style="color: orange;">Warning: <%=Encode.forHtmlContent(warningText)%></span><br/>
+        <% } %>
     </p>
     <%
             }

--- a/src/main/webapp/billing/CA/ON/billingShortcutPg1.jsp
+++ b/src/main/webapp/billing/CA/ON/billingShortcutPg1.jsp
@@ -120,7 +120,8 @@
     if (request.getParameter("xml_provider") != null) providerview = request.getParameter("xml_provider");
     // get patient's detail
     String errorFlag = "";
-    String warningMsg = "", errorMsg = "";
+    List<String> warningMsgs = new ArrayList<String>();
+    List<String> errorMsgs = new ArrayList<String>();
     String r_doctor = "", r_doctor_ohip = "";
     String demoFirst = "", demoLast = "", demoHIN = "", demoDOB = "", demoDOBYY = "", demoDOBMM = "", demoDOBDD = "", demoHCTYPE = "";
 
@@ -160,14 +161,14 @@
         demoDOB = demoDOBYY + demoDOBMM + demoDOBDD;
 
         if (demo.getHin() == null || demo.getHin().equals("")) {
-            warningMsg += "<br><b><font color='orange'>Warning: The patient does not have a valid HIN. </font></b><br>";
+            warningMsgs.add("The patient does not have a valid HIN.");
         }
         if (r_doctor_ohip != null && r_doctor_ohip.length() > 0 && r_doctor_ohip.length() != 6) {
-            warningMsg += "<br><font color='orange'>Warning: the referral doctor's no is wrong. </font><br>";
+            warningMsgs.add("The referral doctor's no is wrong.");
         }
         if (demoDOB.length() != 8) {
             errorFlag = "1";
-            errorMsg = errorMsg + "<br><b><font color='red'>Error: The patient does not have a valid DOB. </font></b><br>";
+            errorMsgs.add("The patient does not have a valid DOB.");
         }
     }
 
@@ -396,9 +397,6 @@
             propPremium.setProperty(pr.getServiceCode(), "A");
         }
     }
-    // create msg
-    msg += errorMsg + warningMsg;
-
 %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
@@ -771,8 +769,14 @@
                     <tr bgcolor="#33CCCC">
                         <td nowrap bgcolor="#FFCC99" width="10%" align="center"><%=Encode.forHtml(String.valueOf(demoname))%>
                         </td>
-                        <td bgcolor="#99CCCC" align="center"><font color="black"><%=msg%>
-                        </font>
+                        <td bgcolor="#99CCCC" align="center">
+                            <font color="black"><%=Encode.forHtmlContent(msg)%></font>
+                            <% for (String errorText : errorMsgs) { %>
+                                <br/><span style="color: red;">Error: <%=Encode.forHtmlContent(errorText)%></span><br/>
+                            <% } %>
+                            <% for (String warningText : warningMsgs) { %>
+                                <br/><span style="color: orange;">Warning: <%=Encode.forHtmlContent(warningText)%></span><br/>
+                            <% } %>
                         </td>
                     </tr>
                 </table>
@@ -1320,17 +1324,17 @@
                         Properties propD = (Properties) vecHistD.get(i);
                 %>
                 <tr bgcolor="<%=i%2==0?"ivory":"#EEEEFF"%>" align="center">
-                    <td><%=Encode.forHtml(String.valueOf(prop.getProperty("billing_no", "&nbsp;")))%>
+                    <td><%=Encode.forHtml(String.valueOf(prop.getProperty("billing_no", "\u00A0")))%>
                     </td>
-                    <td><%=Encode.forHtml(String.valueOf(prop.getProperty("billing_date", "&nbsp;")))%>
+                    <td><%=Encode.forHtml(String.valueOf(prop.getProperty("billing_date", "\u00A0")))%>
                     </td>
-                    <td><%=Encode.forHtml(String.valueOf(prop.getProperty("visitdate", "&nbsp;")))%>
+                    <td><%=Encode.forHtml(String.valueOf(prop.getProperty("visitdate", "\u00A0")))%>
                     </td>
-                    <td><%=Encode.forHtml(String.valueOf(propD.getProperty("service_code", "&nbsp;")))%>
+                    <td><%=Encode.forHtml(String.valueOf(propD.getProperty("service_code", "\u00A0")))%>
                     </td>
-                    <td><%=Encode.forHtml(String.valueOf(propD.getProperty("diagnostic_code", "&nbsp;")))%>
+                    <td><%=Encode.forHtml(String.valueOf(propD.getProperty("diagnostic_code", "\u00A0")))%>
                     </td>
-                    <td><%=Encode.forHtml(String.valueOf(prop.getProperty("update_date", "&nbsp;")))%>
+                    <td><%=Encode.forHtml(String.valueOf(prop.getProperty("update_date", "\u00A0")))%>
                     </td>
                 </tr>
                 <%

--- a/src/main/webapp/billing/CA/ON/billingShortcutPg2.jsp
+++ b/src/main/webapp/billing/CA/ON/billingShortcutPg2.jsp
@@ -112,7 +112,8 @@
 
     // get patient's detail
     String errorFlag = "";
-    String warningMsg = "", errorMsg = "";
+    List<String> warningMsgs = new ArrayList<String>();
+    List<String> errorMsgs = new ArrayList<String>();
     String r_doctor = "", r_doctor_ohip = "";
     String demoFirst = "", demoLast = "", demoHIN = "", demoDOB = "", demoDOBYY = "", demoDOBMM = "", demoDOBDD = "", demoHCTYPE = "";
 
@@ -154,14 +155,14 @@
         demoDOB = demoDOBYY + demoDOBMM + demoDOBDD;
 
         if (demo.getHin() == null || demo.getHin().equals("")) {
-            warningMsg += "<br><font color='orange'>Warning: The patient does not have a valid HIN. </font><br>";
+            warningMsgs.add("The patient does not have a valid HIN.");
         }
         if (r_doctor_ohip != null && r_doctor_ohip.length() > 0 && r_doctor_ohip.length() != 6) {
-            warningMsg += "<br><font color='orange'>Warning: the referral doctor's no is wrong. </font><br>";
+            warningMsgs.add("The referral doctor's no is wrong.");
         }
         if (demoDOB.length() != 8) {
             errorFlag = "1";
-            errorMsg = errorMsg + "<br><font color='red'>Error: The patient does not have a valid DOB. </font><br>";
+            errorMsgs.add("The patient does not have a valid DOB.");
         }
     }
 
@@ -463,9 +464,6 @@
     }
 
 
-    // create msg
-    String wrongMsg = errorMsg + warningMsg;
-    //msg += errorMsg + warningMsg;
 %>
 
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -511,7 +509,13 @@
                         <td nowrap bgcolor="#FFCC99" width="10%" align="center"><%=Encode.forHtml(String.valueOf(demoname))%>
                             <%= demoSex.equals("1") ? "Male" : "Female" %> <%=Encode.forHtml(String.valueOf(" DOB: " + demoDOBYY + "/" + demoDOBMM + "/" + demoDOBDD + " HIN: " + demoHIN))%>
                         </td>
-                        <td bgcolor="#99CCCC" align="center"><%=Encode.forHtml(String.valueOf(wrongMsg))%>
+                        <td bgcolor="#99CCCC" align="center">
+                            <% for (String errorText : errorMsgs) { %>
+                                <br/><span style="color: red;">Error: <%=Encode.forHtmlContent(errorText)%></span><br/>
+                            <% } %>
+                            <% for (String warningText : warningMsgs) { %>
+                                <br/><span style="color: orange;">Warning: <%=Encode.forHtmlContent(warningText)%></span><br/>
+                            <% } %>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/billing/CA/ON/onGenRASummary.jsp
+++ b/src/main/webapp/billing/CA/ON/onGenRASummary.jsp
@@ -310,33 +310,33 @@
 		color = i == (aL.size()-1) ? "class='myYellow'" : color;
 %>
         <tr <%=color %>>
-            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("account", "&nbsp;")))%>
+            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("account", "\u00A0")))%>
             </td>
-            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("claimNo", "&nbsp;")))%>
+            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("claimNo", "\u00A0")))%>
             </td>
-            <!--  >td><%=Encode.forHtml(String.valueOf(prop.getProperty("demo_docname", "&nbsp;")))%></td -->
-            <td><%=Encode.forHtml(String.valueOf(prop.getProperty("demo_name", "&nbsp;")))%>
+            <!--  >td><%=Encode.forHtml(String.valueOf(prop.getProperty("demo_docname", "\u00A0")))%></td -->
+            <td><%=Encode.forHtml(String.valueOf(prop.getProperty("demo_name", "\u00A0")))%>
             </td>
-            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("demo_doc", "&nbsp;")))%>
+            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("demo_doc", "\u00A0")))%>
             </td>
-            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("demo_hin", "&nbsp;")))%>
+            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("demo_hin", "\u00A0")))%>
             </td>
-            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("servicedate", "&nbsp;")))%>
+            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("servicedate", "\u00A0")))%>
             </td>
-            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("servicecode", "&nbsp;")))%>
+            <td align="center"><%=Encode.forHtml(String.valueOf(prop.getProperty("servicecode", "\u00A0")))%>
             </td>
             <!--<td width="8%"><%=Encode.forHtml(String.valueOf(serviceno))%></td>-->
-            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("amountsubmit", "&nbsp;")))%>
+            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("amountsubmit", "\u00A0")))%>
             </td>
-            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("amountpay", "&nbsp;")))%>
+            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("amountpay", "\u00A0")))%>
             </td>
-            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("clinicPay", "&nbsp;")))%>
+            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("clinicPay", "\u00A0")))%>
             </td>
-            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("hospitalPay", "&nbsp;")))%>
+            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("hospitalPay", "\u00A0")))%>
             </td>
-            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("obPay", "&nbsp;")))%>
+            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("obPay", "\u00A0")))%>
             </td>
-            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("explain", "&nbsp;")))%>
+            <td align=right><%=Encode.forHtml(String.valueOf(prop.getProperty("explain", "\u00A0")))%>
             </td>
             <td width="0" style="display:none"><%=Encode.forHtml(String.valueOf(prop.getProperty("site", "")))%>
             </td>

--- a/src/main/webapp/casemgmt/CaseManagementEntry.jsp
+++ b/src/main/webapp/casemgmt/CaseManagementEntry.jsp
@@ -249,30 +249,30 @@
         <b><fmt:setBundle basename="oscarResources"/><fmt:message key="casemanagementEntry.clientname"/>
             <I>
                 <c:if test="${not empty requestScope.demoName}">
-                    <c:out value="${requestScope.demoName}"/>
+                    <%=request.getAttribute("demoName") == null ? "" : Encode.forHtml(String.valueOf(request.getAttribute("demoName")))%>
                 </c:if>
                 <c:if test="${empty requestScope.demoName}">
-                    <c:out value="${e:forHtmlAttribute(param.demoName)}"/>
+                    <%=request.getParameter("demoName") == null ? "" : Encode.forHtml(request.getParameter("demoName"))%>
                 </c:if>
             </I>
             <br>
             &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; Age:
             <I>
                 <c:if test="${not empty requestScope.demoName}">
-                    <c:out value="${requestScope.demoAge}"/>
+                    <%=request.getAttribute("demoAge") == null ? "" : Encode.forHtml(String.valueOf(request.getAttribute("demoAge")))%>
                 </c:if>
                 <c:if test="${empty requestScope.demoName}">
-                    <c:out value="${e:forHtmlAttribute(param.demoAge)}"/>
+                    <%=request.getParameter("demoAge") == null ? "" : Encode.forHtml(request.getParameter("demoAge"))%>
                 </c:if>
             </I>
             <br>
             &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; DOB:
             <I>
                 <c:if test="${not empty requestScope.demoName}">
-                    <c:out value="${requestScope.demoDOB}"/>
+                    <%=request.getAttribute("demoDOB") == null ? "" : Encode.forHtml(String.valueOf(request.getAttribute("demoDOB")))%>
                 </c:if>
                 <c:if test="${empty requestScope.demoName}">
-                    <c:out value="${e:forHtmlAttribute(param.demoDOB)}"/>
+                    <%=request.getParameter("demoDOB") == null ? "" : Encode.forHtml(request.getParameter("demoDOB"))%>
                 </c:if>
             </I></b>
         <br><br>

--- a/src/main/webapp/casemgmt/ChartNotes.jsp
+++ b/src/main/webapp/casemgmt/ChartNotes.jsp
@@ -478,11 +478,11 @@
                 </security:oscarSec>
 
                 <security:oscarSec roleName="<%=roleName%>" objectName="_newCasemgmt.templates" rights="r">
-                <select onchange="javascript:popupPage(700,700,'Templates',this.value);">
+                <select onchange="openTemplate(this.value);">
                     <option value="-1"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.Header.Templates"/></option>
                     <option value="-1">------------------</option>
                     <security:oscarSec roleName="<%=roleName%>" objectName="_newCasemgmt.templates" rights="w">
-                        <option value="<%=request.getContextPath()%>/admin/providertemplate.jsp">New / Edit Template
+                        <option value="__new__">New / Edit Template
                         </option>
                         <option value="-1">------------------</option>
                     </security:oscarSec>
@@ -493,7 +493,7 @@
                         for (EncounterTemplate encounterTemplate : allTemplates) {
                             String templateName = encounterTemplate.getEncounterTemplateName();
                     %>
-                    <option value="<%=Encode.forHtmlAttribute(request.getContextPath()+"/admin/providertemplate.jsp?dboperation=Edit&name="+Encode.forUriComponent(templateName))%>"><%=Encode.forHtml(templateName)%>
+                    <option value="<%=Encode.forHtmlAttribute(templateName)%>"><%=Encode.forHtmlContent(templateName)%>
                     </option>
                     <%
                         }

--- a/src/main/webapp/casemgmt/ChartNotesAjax.jsp
+++ b/src/main/webapp/casemgmt/ChartNotesAjax.jsp
@@ -525,12 +525,12 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
                 }
 
                 if (rx != null) {
-                    String url = "popupPage(700,800,'" + hash + "', '" + request.getContextPath() + "/oscarRx/StaticScript2.jsp?demographicNo=" + rx.getDemographicNo() + "&regionalIdentifier=" + rx.getRegionalIdentifier() + "&cn=" + response.encodeURL(rx.getCustomName()) + "');";
+                    String url = "popupPage(700,800,'" + hash + "', '" + request.getContextPath() + "/oscarRx/StaticScript2.jsp?demographicNo=" + Encode.forUriComponent(String.valueOf(rx.getDemographicNo())) + "&regionalIdentifier=" + Encode.forUriComponent(String.valueOf(rx.getRegionalIdentifier())) + "&cn=" + Encode.forUriComponent(String.valueOf(rx.getCustomName())) + "');";
             %>
             <div class="view-links"
                  style="<%=Encode.forHtmlAttribute(String.valueOf((note.isDocument()||note.isCpp()||note.isEformData()||note.isEncounterForm()||note.isInvoice())?(bgColour):""))%>">
                 <a class="links" title="<%=Encode.forHtmlAttribute(String.valueOf(rx.getSpecial()))%>" id="view<%=Encode.forHtmlAttribute(String.valueOf(globalNoteId))%>" href="javascript:void(0);"
-                   onclick="<%=Encode.forJavaScript(String.valueOf(url))%>" style="float: right; margin-right: 5px; "> <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view.rxView"/> </a>
+                   onclick="<%=url%>" style="float: right; margin-right: 5px; "> <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view.rxView"/> </a>
             </div>
             <%
                 }
@@ -544,17 +544,18 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
                 int hash = Math.abs(winName.hashCode());
 
                 String encodedDispDocNo = Encode.forUriComponent(dispDocNo);
+                String encodedDemographicNo = Encode.forUriComponent(String.valueOf(demographicNo));
                 url = "popupPage(1000,1200,'" + hash + "', '" + request.getContextPath() + "/documentManager/showDocument.jsp?inWindow=true&segmentID=" + encodedDispDocNo +"');";
                 url = url + "return false;";
 
-							String editUrl = "window.open('/oscar/annotation/annotation.jsp?display=Documents&amp;table_id=" + encodedDispDocNo + "&amp;demo=" + demographicNo + "','anwin','width=400,height=500');";
+							String editUrl = "window.open('/oscar/annotation/annotation.jsp?display=Documents&amp;table_id=" + encodedDispDocNo + "&amp;demo=" + encodedDemographicNo + "','anwin','width=400,height=500');";
 
                 if (note.getRemoteFacilityId() == null) // only allow editing for local notes
                 {
                     if (!note.isReadOnly()) {
             %>
                 <a title="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.edit.msgEdit"/>" id="edit<%=Encode.forHtmlAttribute(String.valueOf(globalNoteId))%>"
-                   href="javascript:void(0);" onclick="<%=Encode.forJavaScript(String.valueOf(editUrl))%> return false;" style="<%=Encode.forHtmlAttribute(String.valueOf(bgColour))%> order: 1; padding: 2px 5px;">
+                   href="javascript:void(0);" onclick="<%=editUrl%> return false;" style="<%=Encode.forHtmlAttribute(String.valueOf(bgColour))%> order: 1; padding: 2px 5px;">
                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.edit.msgEdit"/>
                 </a>
             <%
@@ -564,7 +565,7 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
             <div class="view-links"
                  style="<%=Encode.forHtmlAttribute(String.valueOf((note.isDocument()||note.isCpp()||note.isEformData()||note.isEncounterForm()||note.isInvoice())?(bgColour):""))%>">
                 <a class="links" title="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view.docView"/>" id="view<%=Encode.forHtmlAttribute(String.valueOf(globalNoteId))%>"
-                   href="javascript:void(0)" onclick="<%=Encode.forJavaScript(String.valueOf(url))%>" style="float: right; "> <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view"/> </a>
+                   href="javascript:void(0)" onclick="<%=url%>" style="float: right; "> <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view"/> </a>
             </div>
             <%
             } else { //document note
@@ -581,7 +582,7 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
             <div class="view-links"
                  style="<%=Encode.forHtmlAttribute(String.valueOf((note.isDocument()||note.isCpp()||note.isEformData()||note.isEncounterForm()||note.isInvoice())?(bgColour):""))%>">
                 <a class="links" title="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view.docView"/>" id="view<%=Encode.forHtmlAttribute(String.valueOf(globalNoteId))%>"
-                   href="javascript:void(0);" onclick="<%=Encode.forJavaScript(String.valueOf(url))%>">
+                   href="javascript:void(0);" onclick="<%=url%>">
                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view"/>
                 </a>
             </div>
@@ -594,26 +595,26 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
                     String url = "popupPage(700,800,'" + hash + "','" + request.getContextPath() + "/eform/efmshowform_data.jsp?appointment=' + appointmentNo + '&fdid=";
 
                     CaseManagementNoteLink noteLink = note.getNoteLink();
-                    if (noteLink != null) url += noteLink.getTableId();
-                    else url += note.getNoteId();
+                    if (noteLink != null) url += Encode.forUriComponent(String.valueOf(noteLink.getTableId()));
+                    else url += Encode.forUriComponent(String.valueOf(note.getNoteId()));
 
                     url += "'); return false;";
             %>
             <div class="view-links"
                  style="<%=Encode.forHtmlAttribute(String.valueOf((note.isDocument()||note.isCpp()||note.isEformData()||note.isEncounterForm()||note.isInvoice())?(bgColour):""))%>">
                 <a class="links" title="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view.eformView"/>" id="view<%=Encode.forHtmlAttribute(String.valueOf(globalNoteId))%>"
-                   href="javascript:void(0)" onclick="<%=Encode.forJavaScript(String.valueOf(url))%>"> <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view"/> </a>
+                   href="javascript:void(0)" onclick="<%=url%>"> <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view"/> </a>
             </div>
             <%
             } else if (note.isInvoice()) {
                 String winName = "invoice" + demographicNo;
                 int hash = Math.abs(winName.hashCode());
-                String url = "popupPage(700,800,'" + hash + "','" + request.getContextPath() + ((NoteDisplayNonNote) note).getLinkInfo() + "'); return false;";
+                String url = "popupPage(700,800,'" + hash + "','" + request.getContextPath() + Encode.forJavaScript(((NoteDisplayNonNote) note).getLinkInfo()) + "'); return false;";
             %>
             <div class="view-links"
                  style="<%=Encode.forHtmlAttribute(String.valueOf((note.isDocument()||note.isCpp()||note.isEformData()||note.isEncounterForm()||note.isInvoice())?(bgColour):""))%>">
                 <a class="links" title="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view.eformView"/>" id="view<%=Encode.forHtmlAttribute(String.valueOf(globalNoteId))%>"
-                   href="javascript:void(0)" onclick="<%=Encode.forJavaScript(String.valueOf(url))%>"> <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view"/> </a>
+                   href="javascript:void(0)" onclick="<%=url%>"> <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view"/> </a>
             </div>
             <%
             } else if (note.isEncounterForm()) {
@@ -628,19 +629,19 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
                 String url = "popupPage(700,800,'"
                         + hash + "started" + "','"
                         + request.getContextPath()
-                        + Encode.forHtml("/form/forwardshortcutname.do?formname=" + formEntry.getNote())
-                        + "&demographic_no=" + demographicNo
-                        + "&formId=" + formEntry.getNoteId()
+                        + "/form/forwardshortcutname.do?formname=" + Encode.forUriComponent(String.valueOf(formEntry.getNote()))
+                        + "&demographic_no=" + Encode.forUriComponent(String.valueOf(demographicNo))
+                        + "&formId=" + Encode.forUriComponent(String.valueOf(formEntry.getNoteId()))
                         + "'); return false;";
             %>
             <div class="view-links"
                  style="<%=Encode.forHtmlAttribute(String.valueOf((note.isDocument()||note.isCpp()||note.isEformData()||note.isEncounterForm()||note.isInvoice())?(bgColour):""))%>">
                 <a class="links" title="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view.eformView"/>" id="view<%=Encode.forHtmlAttribute(String.valueOf(globalNoteId))%>"
-                   href="javascript:void(0)" onclick="<%=Encode.forJavaScript(String.valueOf(url))%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view"/></a>
+                   href="javascript:void(0)" onclick="<%=url%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view"/></a>
             </div>
             <%
             } else if (note.isEmailNote()) {
-                String url = "viewEmailByLogId(1100,1000,'" + request.getContextPath() + "/admin/ManageEmails.do?method=resendEmail&logId=" + dispDocNo + "');" + "return false;";
+                String url = "viewEmailByLogId(1100,1000,'" + request.getContextPath() + "/admin/ManageEmails.do?method=resendEmail&logId=" + Encode.forUriComponent(String.valueOf(dispDocNo)) + "');" + "return false;";
 							if (fulltxt) {
 								%>
 									<img title='Minimize Display' id='quitImg<%=Encode.forHtmlAttribute(String.valueOf(globalNoteId))%>' style='float: right;' alt='Minimize Display' onclick='minNonEditableNoteView(<%=Encode.forJavaScript(String.valueOf(globalNoteId))%>)' src='<%=Encode.forHtmlAttribute(String.valueOf(ctx))%>/oscarEncounter/graphics/triangle_up.gif'>
@@ -655,7 +656,7 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
                             %>
             <div class="view-links" style="<%=Encode.forHtmlAttribute(String.valueOf((isMagicNote)?(bgColour):""))%>">
                 <a class="links" title="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view.docView"/>" id="view<%=Encode.forHtmlAttribute(String.valueOf(globalNoteId))%>"
-                   href="javascript:void(0);" onclick="<%=Encode.forJavaScript(String.valueOf(url))%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view"/> </a>
+                   href="javascript:void(0);" onclick="<%=url%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.view"/> </a>
             </div>
             <%
                 }
@@ -810,7 +811,7 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
 									<%if (!note.isEmailNote()) {%>
                     <div style="clear: right; margin-right: 3px; float: right;">
                         <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.encType.title"/>:&nbsp;
-                        <span id="encType<%=Encode.forHtmlAttribute(String.valueOf(globalNoteId))%>"><%=Encode.forHtml(String.valueOf(note.getEncounterType().equals("") ? "" : "&quot;" + note.getEncounterType() + "&quot;"))%></span>
+                        <span id="encType<%=Encode.forHtmlAttribute(String.valueOf(globalNoteId))%>"><%=note.getEncounterType().equals("") ? "" : "\"" + Encode.forHtml(note.getEncounterType()) + "\""%></span>
                     </div>
 
                     <div>

--- a/src/main/webapp/casemgmt/historyview.jsp
+++ b/src/main/webapp/casemgmt/historyview.jsp
@@ -65,26 +65,26 @@
 <br>
 Client name:
 <I> <c:if test="${not empty requestScope.demoName}">
-    <c:out value="${requestScope.demoName}"/>
+    <%=request.getAttribute("demoName") == null ? "" : Encode.forHtml(String.valueOf(request.getAttribute("demoName")))%>
 </c:if>
 <c:if test="${empty requestScope.demoName}">
-    <c:out value="${e:forHtmlAttribute(param.demoName)}"/>
+    <%=request.getParameter("demoName") == null ? "" : Encode.forHtml(request.getParameter("demoName"))%>
 </c:if> </I>
 <br>
 &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; Age:
 <I> <c:if test="${not empty requestScope.demoName}">
-    <c:out value="${requestScope.demoAge}"/>
+    <%=request.getAttribute("demoAge") == null ? "" : Encode.forHtml(String.valueOf(request.getAttribute("demoAge")))%>
 </c:if>
 <c:if test="${empty requestScope.demoName}">
-    <c:out value="${e:forHtmlAttribute(param.demoAge)}"/>
+    <%=request.getParameter("demoAge") == null ? "" : Encode.forHtml(request.getParameter("demoAge"))%>
 </c:if> </I>
 <br>
 &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; DOB:
 <I> <c:if test="${not empty requestScope.demoName}">
-    <c:out value="${requestScope.demoDOB}"/>
+    <%=request.getAttribute("demoDOB") == null ? "" : Encode.forHtml(String.valueOf(request.getAttribute("demoDOB")))%>
 </c:if>
 <c:if test="${empty requestScope.demoName}">
-    <c:out value="${e:forHtmlAttribute(param.demoDOB)}"/>
+    <%=request.getParameter("demoDOB") == null ? "" : Encode.forHtml(request.getParameter("demoDOB"))%>
 </c:if> </I>
 <br>
 <br>

--- a/src/main/webapp/casemgmt/unlockAjax.jsp
+++ b/src/main/webapp/casemgmt/unlockAjax.jsp
@@ -101,7 +101,7 @@
             </div>
             <div style="clear: right; margin-right: 3px; float: right;">Enc
                 Type:&nbsp;<span
-                        id="encType<%=Encode.forHtmlAttribute(String.valueOf(note.getId()))%>"><%=Encode.forHtml(String.valueOf(note.getEncounter_type().equals("") ? "" : "&quot;" + note.getEncounter_type() + "&quot;"))%></span>
+                        id="encType<%=Encode.forHtmlAttribute(String.valueOf(note.getId()))%>"><%=note.getEncounter_type().equals("") ? "" : "\"" + Encode.forHtml(note.getEncounter_type()) + "\""%></span>
             </div>
 
             <%

--- a/src/main/webapp/eform/efmformmanageredit.jsp
+++ b/src/main/webapp/eform/efmformmanageredit.jsp
@@ -24,7 +24,7 @@
 
 --%>
 <%@ page
-        import="ca.openosp.openo.eform.data.*, ca.openosp.openo.eform.*, java.util.*, ca.openosp.openo.util.*, org.apache.commons.text.StringEscapeUtils" %>
+        import="ca.openosp.openo.eform.data.*, ca.openosp.openo.eform.*, java.util.*, ca.openosp.openo.util.*" %>
 <%@ page import="ca.openosp.openo.eform.EFormUtil" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -50,7 +50,7 @@
 
     if (request.getParameter("formHtmlG") != null) {
         //load html from hidden form from eformGenerator.jsp,the html is then injected into edit-eform
-        curform.put("formHtml", StringEscapeUtils.unescapeHtml4(request.getParameter("formHtmlG")));
+        curform.put("formHtml", request.getParameter("formHtmlG"));
     }
     if (curform.get("formDate") == null) curform.put("formDate", "--");
     if (curform.get("formTime") == null) curform.put("formTime", "--");

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -133,6 +133,14 @@
 
     }
 
+    function openTemplate(value) {
+        if (value === "-1") return;
+        var url = (value === "__new__")
+            ? ctx + "/admin/providertemplate.jsp"
+            : ctx + "/admin/providertemplate.jsp?dboperation=Edit&name=" + encodeURIComponent(value);
+        popupPage(700, 700, "Templates", url);
+    }
+
     function urlencode(str) {
         var ns = (navigator.appName == "Netscape") ? 1 : 0;
         if (ns) {

--- a/src/main/webapp/lab/CumulativeLabValues3.jsp
+++ b/src/main/webapp/lab/CumulativeLabValues3.jsp
@@ -325,9 +325,6 @@
                             String testName = (String) nameMap.get(loinc_code);
                             LinkedHashMap IdMap = (LinkedHashMap) measIdMap.get(loinc_code);
 
-                            //preserve spaces in the test names
-                            testName = testName.replaceAll("\\s", "&#160;");
-
                             // display the latest value for the test
                             if (!loinc_code.startsWith("NULL")) {
                                 String latestDate = "";
@@ -344,7 +341,8 @@
                                 }
                     %>
                     <tr>
-                        <td><%=Encode.forHtml(String.valueOf(testName))%>
+                        <%-- preserve leading whitespace - signals panel child tests (e.g. GLUCOSE under URINALYSIS) --%>
+                        <td><%=Encode.forHtml(String.valueOf(testName)).replaceAll("\\s", "&#160;")%>
                         </td>
                         <td class="<%=Encode.forHtmlAttribute(String.valueOf(abn))%>"><%=Encode.forHtml(String.valueOf(StringUtils.maxLenString(latestVal, 9, 8, "...")))%>
                         </td>

--- a/src/main/webapp/oscarRx/RenalDosing.jsp
+++ b/src/main/webapp/oscarRx/RenalDosing.jsp
@@ -236,9 +236,9 @@ Clcr = {(140 - <%=Encode.forHtml(String.valueOf(age))%> ) X <%=Encode.forHtml(St
       -->
         <table class="equation">
             <tr>
-                <th rowspan=2 valign="middle">Clcr <%=Encode.forHtml(String.valueOf(setNA(equate, Clcr)))%> =</th>
+                <th rowspan=2 valign="middle">Clcr <%=setNA(equate, Clcr)%> =</th>
                 <td align="center">
-                    (140 - <%=Encode.forHtml(String.valueOf(setNA(ageb, age)))%>[age] ) X <%=Encode.forHtml(String.valueOf(setNA(weightb, weight)))%>
+                    (140 - <%=setNA(ageb, age)%>[age] ) X <%=setNA(weightb, weight)%>
                     <a href="javascript: function myFunction() {return false; }"
                        onclick="popup(500,1000,'<%= request.getContextPath() %>/oscarEncounter/oscarMeasurements/SetupMeasurements.do?groupName=Renal Dosing&amp;demographic_no=<%=Encode.forUriComponent(demographicNo)%>','dddsfds'); return false;">
                         [kg <%=Encode.forHtml(String.valueOf(UtilDateUtilities.DateToString(wtDate, "yyyy-MMM-dd")))%>]
@@ -250,7 +250,7 @@ Clcr = {(140 - <%=Encode.forHtml(String.valueOf(age))%> ) X <%=Encode.forHtml(St
                 <%}%>
             </tr>
             <tr>
-                <td align="center" style="border-top: 2px black solid;"><%=Encode.forHtml(String.valueOf(setNA(sCrb, sCr)))%> sCr
+                <td align="center" style="border-top: 2px black solid;"><%=setNA(sCrb, sCr)%> sCr
                     <a href="javascript: function myFunction() {return false; }"
                        onclick="popup(500,1000,'<%= request.getContextPath() %>/oscarEncounter/oscarMeasurements/SetupMeasurements.do?groupName=Renal Dosing&amp;demographic_no=<%=Encode.forUriComponent(String.valueOf(demographicNo))%>','dddsfds'); return false;">
                         [umol/L <%=Encode.forHtml(String.valueOf(UtilDateUtilities.DateToString(sCrDate, "yyyy-MMM-dd")))%>]


### PR DESCRIPTION
## Summary

Follow-up to PR [#225](https://github.com/open-osp/Open-O/pull/225) (Encoder updates and fixes). Three streams of work:

1. **Address review feedback on PR [#225](https://github.com/open-osp/Open-O/pull/225)** — the comments where I agreed in full, or where I disagreed at the proposed fix site but addressed the underlying concern upstream.
2. **Bulk-fix-fallout audit findings** — investigating the review comments surfaced a broader pattern: the April Snyk bulk script (`ada4c9a73f` and siblings) wrapped every `<%=value%>` with `Encode.forHtml(String.valueOf(value))` across ~1,233 files. Most were correct, but a small set either double-encoded pre-built markup or wrong-context-encoded JS/URL values. A three-pass audit (pattern grep → deeper grep → diff-driven walk) caught 13 confirmed sites.
3. **Follow-ups from this PR's own review cycle** — null-safety regressions, logic gaps, and tooling-friendliness cleanups surfaced by CodeRabbit / cubic / sourcery.

## Areas fixed per feedback on [PR #225](https://github.com/open-osp/Open-O/pull/225)

> Note: commits based on this PR's branch: https://github.com/openo-beta/Open-O/pull/2438

| # | File | Fix | Commit |
|---|---|---|---|
| 1 | `admin/providerPrivilege.jsp` | Refactored `msg` construction + `msgIsError` flag, restored output encoding | `f49a53a7ef` |
| 2 | `admin/providerRole.jsp` | Split `msg` into action result + `missingPrimaryRoleProviders` list; fixed stored XSS on provider names | `bd87a018e8` |
| 3 | `admin/providersearchresults.jsp` | `forHtml` → `forHtmlContent` on `keyword` output | `25b2599faf` |
| 4 | `admin/providerupdateprovider.jsp` | Wrapped `billCode` dropdown with `forHtmlAttribute` | `178c97a7d9` |
| 6 | `billing/CA/BC/billingSim.jsp` | Per-value encoding moved upstream into BC `ExtractBean` + sibling helpers (`CheckBillingData`, `HtmlTeleplanHelper`, `WcbSb`). JSP-level wrap intentionally NOT applied — breaks the intentional report HTML; see [PR https://github.com/open-osp/Open-O/pull/225 reply](https://github.com/open-osp/Open-O/pull/225#discussion_r3306291609) for screenshots | `4241488a51`, `d35864cefd`, `a7ff97ac7e` |
| 7 | `billing/CA/ON/billingOHIPsimulation.jsp` | Same shape as [https://github.com/open-osp/Open-O/pull/6](https://github.com/open-osp/Open-O/pull/225#discussion_r3306291609) — per-value encoding in `JdbcBillingCreateBillingFile` + ON `OHIP/ExtractBean` | `f8746560ea`, `dde977d15c` |
| 8 | `billing/CA/ON/billingONCorrection.jsp` | Encoded `tProp` values in `htmlPaid` construction | `1fc33f2f6c` |
| 10 | `casemgmt/ChartNotes.jsp` | Refactored `<option value>` from URL to template name with sentinel handling | `a52f7d7b84`, `3c6b44f7e7` |
| 11 | `casemgmt/ChartNotesAjax.jsp` | Encoded URL params inline, dropped wrong-context `forJavaScript` wraps on 8 onclick handlers | `446a8cf396` |
| 12 | `eform/efmformmanageredit.jsp` | Dropped `StringEscapeUtils.unescapeHtml4` round-trip | `4499cfe363` |

Comments [#5](https://github.com/open-osp/Open-O/pull/225#discussion_r3305868510) and [#9](https://github.com/open-osp/Open-O/pull/225#discussion_r3306454117) were intentionally not changed — see the per-comment replies on PR #225 for the reasoning.

## Additional fixes (not from PR feedback)

### Bulk-fix-fallout — pattern audit
Snyk bulk script wrapped values that contained pre-built HTML markup or were destined for non-HTML-body contexts. Fixed sites:

- `lab/CumulativeLabValues3.jsp` — restored panel child-test indentation (`&#160;` was double-encoded → literal text). `eef6d891a9`
- `billing/CA/ON/billingShortcutPg1.jsp`, `billingShortcutPg2.jsp`, `billingONReview.jsp`, `billingON.jsp`, `billingReview.jsp` — refactored inline HTML warning/error markup into typed `List<String>` with output-side encoding + Bootstrap alert classes (where applicable). `a1e6060923`, `0b155e1ce1`, `9d56007eff`, `39e0cc7519`, `e07b8c080c`
- `oscarRx/RenalDosing.jsp` — `setNA(boolean, int|double)` scriptlet helper returns `<span style="color:orange">N/A</span>` when a clinical value (age / weight / sCr / Clcr) is unavailable; bulk script wrapped 3 call sites with `Encode.forHtml(String.valueOf(setNA(...)))`, escaping the markup so users saw literal `<span style="color:orange">N/A</span>` text in the renal-dosing equation table. Unwrapped the call sites; `setNA`'s value-path returns a stringified `int`/`double` (no markup) and its N/A path is intentional static markup, so the sites are safe without re-encoding. `6e98c87285`

### Third-pass audit (diff-driven)
Walking the 5 bulk-fix commits file-by-file surfaced additional sites:

- `casemgmt/ChartNotesAjax.jsp` + `casemgmt/unlockAjax.jsp` — encounter-type quote double-encode (`"&quot;"` literal inside `Encode.forHtml`). `2a35ff7b46`, `5f8bc34912`
- `billing/CA/ON/onGenRASummary.jsp`, `billingONNewReport.jsp`, `billingShortcutPg1.jsp`, `billing/CA/CLINICAID/billingClinicaidReport.jsp`, `billing/CA/BC/billStatus.jsp` — `prop.getProperty("foo", "&nbsp;")` defaults double-encoded → literal `&nbsp;` text in empty cells. Swapped to `" "`. `1f787b8b33`
- `admin/faxStatusResults.jspf` — `<c:out value="<%=Encode.forHtmlAttribute(...)%>" />` double-encode + wrong-context. `521bf1a13e`
- `casemgmt/CaseManagementEntry.jsp` + `casemgmt/historyview.jsp` — patient name banner used `<c:out value="${e:forHtmlAttribute(param.X)}"/>` (O'Brien → O&#39;Brien). `becf5d59e2`

### Review-cycle follow-ups (this PR's own reviews)
- `casemgmt/ChartNotesAjax.jsp` invoice popup — switched `Encode.forHtml(linkInfo)` to `Encode.forJavaScript` (correct context for JS string literal). `ba2adb59f8`
- `admin/providerPrivilege.jsp` + `admin/providerRole.jsp` — extracted alert class ternary to scriptlet variable to eliminate confusing nested-double-quote shape (tripped PMD). `ee7fd0ffda`
- BC + base MSP `CheckBillingData` — added JavaDoc clarifying plain-text contract on `printWarningMsg`/`printErrorMsg`; mirrored encoder hardening to the symmetric base class. `962932757d`, `314f60d0f2`
- `admin/providerPrivilege.jsp` Add-flow — set `msgIsError = true` on the `DataIntegrityViolationException` branch so DB integrity errors render red (`alert-danger`) instead of blue (`alert-info`). `f7a39118bf`
- Null-safe rendering fixes — `String.valueOf(null)` was producing literal "null" text in patient banner, fax queue, and billStatus title. `ee56002f58`, `4e200a0b5a`, `795257c7b2`

### Misc
- BigDecimal-to-String consistency across BC/ON encoder fixes. `c3c574dd3f`
- Encode only the dynamic encounter type (not the static quote decoration). `5f8bc34912`