### PR TITLE
Fix: reconcile dependency lock files and dhirSubmission.jsp compile error after FHIR-libraries merge

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -1493,11 +1493,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.1",
+    "version" : "5.19.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+    "integrity" : "sha512:DmqWCs/W+sd0htp7bRjrnZjgogW994GJVImX+29gk+cT5XDpgp7MbX3sgTJ26vXTr1bTDGJ/67OgsyT6kDXojw=="
   }, {
     "groupId" : "net.minidev",
     "artifactId" : "accessors-smart",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -41,6 +41,14 @@
     "integrity" : "sha512:P7sy4EBGDXhLcZPUsS3xCkperUfAmQV/AJpOV9VLTudj9qt42wVGzUSTSX1GqrCBtyTz+7iF4wmpCi6dXnTuhQ=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
+    "artifactId" : "hapi-fhir-client",
+    "version" : "6.10.5",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:M5yV/2n3/xlm72Q9+h2Bdt214lkZr1ZxZVkhrm0H0NXnVb60yvzZ+tB3XCfNJTzok2fcdqAxPjvs8AbD0lUdxg=="
+  }, {
+    "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "hapi-fhir-structures-dstu2",
     "version" : "6.10.5",
     "scope" : "compile",
@@ -57,12 +65,28 @@
     "integrity" : "sha512:TwbsA/lm8DAkBibmgATRxK3WBM/iGZsuO0SV7QI65QGXEDMWM8v4IvkjPfAybFU8NswYIYLI3DT57SGEWBBPKw=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
+    "artifactId" : "hapi-fhir-structures-r4",
+    "version" : "6.10.5",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:4jMFxdKLeGD3L8HqkuA1ZYNce6l6ZQnGPY76/p66Il3UPgX/gv3Od3cD9QyOg5UYT4pXF7MuUFa8UNXJU3JbhA=="
+  }, {
+    "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.dstu3",
     "version" : "6.4.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:jsXA+nxwtcREDusL853GitoYNywUJULdej+gWT0Wc7zo01zAPhblaiRS3UeBcFJ/5vWV0tD3LQhG7OTPnTIx+A=="
+  }, {
+    "groupId" : "ca.uhn.hapi.fhir",
+    "artifactId" : "org.hl7.fhir.r4",
+    "version" : "6.1.2.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:WfEKhiY8LyJLtM+3g62f/pHfKyk5x270MyXMroVkQZOd7nCEVdrQ+9YNta1kAA59St6p8nqp1Z8MGr0VaBvyXg=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.utilities",
@@ -74,67 +98,67 @@
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-base",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:52LSZKam5t5rMnXtXw8fN3i/ngUQp6vz1Wve+KNgYxHDh4nYcW9uX0lf8UeHvoZoWfGpeBGNXYeV+DP3Bj122A=="
+    "integrity" : "sha512:cV+QZUX1X/mqWSaT/AktQsvPINxz/qKSOzOBSmCwTQg2glvov64e/IT3oM8Q1ArvW54uzRIiJKK5fGRCRXFjgA=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v21",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:NCMpcJGrsvrshD64gZOzLnr029MEphePqjdIAO6PnNWjijsjnihjYw6CvstY/Vi7sAmQKTAjzH0KHIoI3SOtJA=="
+    "integrity" : "sha512:9HQfithExK8yz+vfBjHKYO+XQvj9+lb2naTowVxghVe7X8+lgGpRdd7piZKEbY4Z8ZcoXrBF5FzTr2yXU/Bk7g=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v22",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Cu+P4/qVeaQgNzt2KPSQTgrSTTdGy1FrIC5XCJ9a2CEO8u6XPo7wesNs5IkIZ/1f5ElZlHonqkyJ0MRBypq0fQ=="
+    "integrity" : "sha512:WhyA2Q6/+ne1+s6TKF4AzuUerQGCPruj2llO7UBHyssP44HgUDA+8+BhLRdrDzzTp2ozh1B9XkCwwuCGcRwFqQ=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v231",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:dM/aJw0rVHllTkmT++OeDrl6ZyJWwqoWfBRgv0mmpk1pvD+iAdew8cOOxllbJKJ5lNYQBtt7L4AIdt6U3l/2RQ=="
+    "integrity" : "sha512:3zRsYqgkJ2KVXKSCu3sG3HfIO8Q7gbaUaKj2kVqOVHqCgQaPrvaMYLu3MIH/yn51mPq0GzJX0wXbcTwU6RlnmQ=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v23",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ZB+6VTphE8XInCdGchvAuZaW+9r7et3pt9VUM4aIvd0HMrKUXbzS5Rbk6+8623Z/3TP3TncXz06bzF9gSQmrqg=="
+    "integrity" : "sha512:Gu4mD3FGY/Wl5Qwlc4u5TxaW+FkZGdF0A3KJG08jU8ihL2KuNDEakYTNrkcxUTsu4yiTlBl2Hrdbxlp9nDmIcg=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v24",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:MM19XuIm4Ud+yZPqJ7E/kJG1bUhOk6krph+k4wU3ha8POHO0IkaJGRKc1w+cLHxZxMTHXSSContBKpkZm/UdTg=="
+    "integrity" : "sha512:dGRV+pRbvdPhMyyh2dJ3OKYJ+FMuHjxWWK/N4P9TnBaCbuT1r8YRwVAaLJUbWZieMb+R+CSP4MCY/OPh39lxGQ=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v25",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:wh2/iX5dUp0gGonkaaR+RHIK1WLGi9qUw+yQXm0K07K+ruH85PhN3NMlZHh6IgUiYjOEyrVrkfsAEtzH+/pKXA=="
+    "integrity" : "sha512:LbVBYam6ks3jgMKffvGM9/0oHlchN6l1oizz4Jttm3OKO1ZrpBjE6fhR4bj6ovXMR5m9f3olJfUhN9fn8g20sw=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v26",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:kljShqyjhOiIw33z0nRrNniQSppzRkw8kC8SzYyjHDl1YGSpsmiSgYBc/JPOMMWw98H6j6e165uJlPa4DtHzdg=="
+    "integrity" : "sha512:ocFVzN1W8Ddy1MerUEiQXVUJ04Hklim6KG17ycRO4WoAsKN2XyWN1oO+/YoF6HwNCbzPXlGVERZfSXWAdZjsWg=="
   }, {
     "groupId" : "cds",
     "artifactId" : "cds",
@@ -192,6 +216,14 @@
     "optional" : false,
     "integrity" : "sha512:IvR7uftlGA6jAcsHjPWKqPGa8RCx7zt5DJkyItTs8cPa8j5LHIBOhyld4q0WDlvwjRxNm1Yw3DH9Kj5JDbUipQ=="
   }, {
+    "groupId" : "com.auth0",
+    "artifactId" : "java-jwt",
+    "version" : "4.5.1",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:Y9yMK4dFqpLskE3PLuLn/gVQudCdr4Q7OOJXuxnNEfreAs5VRIdex5Smx/bVs+2TPvfF47Zy9VYlndLP1xJv+Q=="
+  }, {
     "groupId" : "com.beust",
     "artifactId" : "jcommander",
     "version" : "1.82",
@@ -210,11 +242,11 @@
   }, {
     "groupId" : "com.fasterxml.jackson.core",
     "artifactId" : "jackson-core",
-    "version" : "2.21.1",
+    "version" : "2.21.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:9LFToKfJdGIN7D/P5KSGnCYyq5f3PCZiBBr30OsMQq1GK/7ozcq1VChCF1uWGX3x2RCohBBnZU9udjs3DBjM+g=="
+    "integrity" : "sha512:TwA1HlfOSAQoIWaRxSxZp1yoJGdNXCbvkCJQzD0BLyIELILqucpTDGMoAxtZcjkUPp47aMHHpsxtSc74y0IHdA=="
   }, {
     "groupId" : "com.fasterxml.jackson.core",
     "artifactId" : "jackson-databind",
@@ -897,14 +929,6 @@
     "optional" : false,
     "integrity" : "sha512:Q0hnBXlgG8EVHeLydBRjXE6gtLUwYdEWwJujGeLE+OkdDLBxOpZGaL1RiRBaweK2WQiBhQiAv1/yPMZAnycEIA=="
   }, {
-    "groupId" : "commons-cli",
-    "artifactId" : "commons-cli",
-    "version" : "1.0",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:zg39atifzCzWgZAGf+Lv/5F9gd1kELYIBXKV79vFJEtiPH4QAA2RPv9eDIy/FWtWoRN3MT2/rYwzO5v67q62PA=="
-  }, {
     "groupId" : "commons-codec",
     "artifactId" : "commons-codec",
     "version" : "1.18.0",
@@ -992,6 +1016,30 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:TSXsVUMPPIBP0lpkm4GwlaH3QqmLmWsjEM14Vn7zBZZDzE04U24FyezojodAnXbFcEctPBfGrM4bvSInnVlyDw=="
+  }, {
+    "groupId" : "io.jsonwebtoken",
+    "artifactId" : "jjwt-api",
+    "version" : "0.13.0",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:t25kO6tdoBFkhLtjbl8TnVPjxYCqB/qf+e+59VKxnxSgkCER68plCUZH9vLZukWAXjGF0Unw2dE7joTl9XXITg=="
+  }, {
+    "groupId" : "io.jsonwebtoken",
+    "artifactId" : "jjwt-impl",
+    "version" : "0.13.0",
+    "scope" : "runtime",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:cMTkPkH5OpqexH+3SxFbsqffffJeo0EyCHmYAq8rkcnmBgQqi2TPhWhJFN6snxK172X0N3cCZoqVYtvs3WXvTw=="
+  }, {
+    "groupId" : "io.jsonwebtoken",
+    "artifactId" : "jjwt-jackson",
+    "version" : "0.13.0",
+    "scope" : "runtime",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:58uHirhxjtwAz2+qETQsNxna1efhFG0gNXzW1Alu0l7+wfe6C9/IoNjrT9oK01zEfPFDgbKYZTrjWl2DJYhQsQ=="
   }, {
     "groupId" : "io.micrometer",
     "artifactId" : "micrometer-commons",
@@ -1405,11 +1453,11 @@
   }, {
     "groupId" : "joda-time",
     "artifactId" : "joda-time",
-    "version" : "2.10.6",
+    "version" : "2.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Xd5dVNou6uIB8/XAVi8WOa5mSfezqD0nbih3LOLl2GsmvTUz/c7a+EHMd5gtaDWYwY+OxcW2y6TrR3SPC9QROA=="
+    "integrity" : "sha512:uvO0xAZ9+hK5zbG2ZuWrOqDj0xJKANA6PgDQfXwEZhgqLQl5sgQn0/PUlAOIMVp3c0h5MrBAsAYMRIssn6xp5w=="
   }, {
     "groupId" : "junit",
     "artifactId" : "junit",
@@ -1445,11 +1493,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.1",
+    "version" : "5.19.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+    "integrity" : "sha512:DmqWCs/W+sd0htp7bRjrnZjgogW994GJVImX+29gk+cT5XDpgp7MbX3sgTJ26vXTr1bTDGJ/67OgsyT6kDXojw=="
   }, {
     "groupId" : "net.minidev",
     "artifactId" : "accessors-smart",

--- a/src/main/webapp/oscarPrevention/dhirSubmission.jsp
+++ b/src/main/webapp/oscarPrevention/dhirSubmission.jsp
@@ -40,7 +40,7 @@
 <%@page import="org.hl7.fhir.dstu3.model.Patient" %>
 <%@page import="org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent" %>
 <%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
-<%@page import="ca.openosp.openo.integration.fhir.builder.AbstractFhirMessageBuilder" %>
+<%@page import="ca.openosp.openo.integration.fhir.dstu3.builder.AbstractFhirMessageBuilder" %>
 <%@page import="org.hl7.fhir.dstu3.model.Bundle" %>
 <%@page import="java.util.Map" %>
 <%@page import="java.io.InputStream" %>


### PR DESCRIPTION
## Summary

Two small follow-up fixes that reconcile the tree after the FHIR-libraries merge
(PR `#224`):

1. **Regenerate the dependency lock files** so they match the dependency changes
   that `#224` introduced in `pom.xml` (HAPI FHIR r4, JWT libraries, and assorted
   version bumps) but did not re-lock.
2. **Fix a JSP compilation error** in `oscarPrevention/dhirSubmission.jsp` caused
   by `#224` relocating the `AbstractFhirMessageBuilder` class into a new package.

Both are low-risk, mechanical corrections. No feature behavior changes.

## Problem

The FHIR-libraries refactor reorganized FHIR support and updated dependencies, but
two artifacts were left out of sync with that change:

- **Dependency lock files drifted from `pom.xml`.** OpenO pins resolved dependency
  versions in `dependencies-lock.json` and `dependencies-lock-modern.json`. The
  FHIR work added/updated dependencies (e.g. `ca.uhn.hapi.fhir:hapi-fhir-client`,
  `hapi-fhir-structures-r4`, `org.hl7.fhir.r4`, JWT libraries such as
  `com.auth0:java-jwt` and `io.jsonwebtoken:jjwt-*`, plus several version bumps)
  without regenerating the lock files, leaving them inconsistent with the build.

- **`dhirSubmission.jsp` no longer compiles.** It imports
  `AbstractFhirMessageBuilder` from `ca.openosp.openo.integration.fhir.builder`,
  a package that `#224` removed when it split that class into version-specific
  `dstu3` and `r4` variants.

## Solution

1. **Regenerate the lock files** (`make lock`) so
   `dependencies-lock.json` / `dependencies-lock-modern.json` reflect the current
   `pom.xml` dependency set.

2. **Repoint the JSP import** at the `dstu3` variant — the version this import
   resolved to before the file moved (the original pre-split builder was bound to
   `FhirContext.forDstu3()`):

   ```diff
   -<%@page import="ca.openosp.openo.integration.fhir.builder.AbstractFhirMessageBuilder" %>
   +<%@page import="ca.openosp.openo.integration.fhir.dstu3.builder.AbstractFhirMessageBuilder" %>
   ```

   This restores the page to its prior state and unblocks compilation without
   altering FHIR-version semantics. The DHIR feature ships disabled by default
   (`dhir.enabled=false`), so this is a contained, low-risk fix.

   > **Note for future DHIR work:** other parts of the DHIR path (the producer
   > `AddPrevention2Action` and the `integration/dhir/*` backend) appear to be on
   > r4, while this JSP is dstu3. We did not fully trace why this page was left on
   > dstu3, so this change deliberately only restores its previous state rather
   > than migrating it. Worth confirming alignment to r4 — and validating an
   > end-to-end DHIR submission — whenever DHIR is next worked on. The upstream
   > OscarPro version of this page resolves these imports to r4, which may be a
   > useful comparison point:
   > https://bitbucket.org/oscaremr/oscarpro/src/master/src/main/webapp/oscarPrevention/dhirSubmission.jsp

## Verification

- `make lock` regenerates the lock files cleanly with no further diff.
- Confirmed the old package `ca.openosp.openo.integration.fhir.builder` no longer
  exists, and the `dstu3` builder it was split into is the faithful continuation
  (`FhirContext.forDstu3()`).
- Confirmed no other file under `src/` references the old package path.
- Final gate: `make clean && make install` and `make jspc` builds and deploys cleanly with the
  regenerated lock files and the corrected JSP.

## Files changed

- `dependencies-lock.json` — regenerated
- `dependencies-lock-modern.json` — regenerated
- `src/main/webapp/oscarPrevention/dhirSubmission.jsp` — 1 line (import path)